### PR TITLE
Update to Gradle 9.3.1, AGP 9.1.0, Kotlin 2.2.10, KSP, and fix tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.kotlin.kapt)
+    alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
 }
 
@@ -19,12 +19,12 @@ val ciKeyPassword:   String? = findProperty("keyPassword")   as String?
 
 android {
     namespace  = "com.example.netswissknife.app"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "com.example.netswissknife"
         minSdk        = 26
-        targetSdk     = 34
+        targetSdk     = 35
         versionCode   = ciVersionCode ?: 1
         versionName   = ciVersionName ?: "1.0.0"
     }
@@ -59,16 +59,8 @@ android {
         targetCompatibility = JavaVersion.VERSION_21
     }
 
-    kotlinOptions {
-        jvmTarget = "21"
-    }
-
     buildFeatures {
         compose = true
-    }
-
-    composeOptions {
-        kotlinCompilerExtensionVersion = libs.versions.composeCompiler.get()
     }
 }
 
@@ -96,7 +88,7 @@ dependencies {
 
     // Hilt
     implementation(libs.hilt.android)
-    kapt(libs.hilt.android.compiler)
+    ksp(libs.hilt.compiler)
     implementation(libs.hilt.navigation.compose)
 
     // Coroutines

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,8 +2,8 @@
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false
-    alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.jvm) apply false
-    alias(libs.plugins.kotlin.kapt) apply false
+    alias(libs.plugins.compose.compiler) apply false
+    alias(libs.plugins.ksp) apply false
     alias(libs.plugins.hilt) apply false
 }

--- a/core-domain/build.gradle.kts
+++ b/core-domain/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
     testImplementation(libs.junit5.api)
     testImplementation(libs.junit5.params)
     testRuntimeOnly(libs.junit5.engine)
+    testRuntimeOnly(libs.junit5.launcher)
     testImplementation(libs.mockk)
     testImplementation(libs.coroutines.test)
 }

--- a/core-network/build.gradle.kts
+++ b/core-network/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     testImplementation(libs.junit5.api)
     testImplementation(libs.junit5.params)
     testRuntimeOnly(libs.junit5.engine)
+    testRuntimeOnly(libs.junit5.launcher)
     testImplementation(libs.mockk)
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,3 +7,10 @@ android.useAndroidX=true
 android.nonTransitiveRClass=true
 
 kotlin.code.style=official
+
+# Override nonProxyHosts so Google Maven is reachable through the proxy
+systemProp.http.nonProxyHosts=localhost|127.0.0.1
+systemProp.https.nonProxyHosts=localhost|127.0.0.1
+
+# AGP 9.x built-in Kotlin: allow KSP to register generated sources
+android.disallowKotlinSourceSets=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,17 +1,17 @@
 [versions]
-agp = "8.3.2"
-coroutines = "1.8.1"
-kotlin = "1.9.23"
-composeCompiler = "1.5.13"
-composeBom = "2024.05.00"
-navigationCompose = "2.7.7"
-hilt = "2.51.1"
-hiltNavigationCompose = "1.2.0"
-junit5 = "5.10.2"
-mockk = "1.13.11"
-coreKtx = "1.13.1"
-activityCompose = "1.9.0"
-lifecycleViewmodelCompose = "2.8.1"
+agp = "9.1.0"
+coroutines = "1.9.0"
+kotlin = "2.2.10"
+ksp = "2.2.10-2.0.2"
+composeBom = "2024.12.01"
+navigationCompose = "2.8.9"
+hilt = "2.59.2"
+hiltNavigationCompose = "1.3.0"
+junit5 = "5.11.4"
+mockk = "1.13.16"
+coreKtx = "1.15.0"
+activityCompose = "1.10.1"
+lifecycleViewmodelCompose = "2.8.7"
 
 [libraries]
 # AndroidX Core
@@ -34,13 +34,14 @@ navigation-compose = { group = "androidx.navigation", name = "navigation-compose
 
 # Hilt
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
-hilt-android-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hilt" }
+hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hilt" }
 hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
 
 # Testing
 junit5-api = { group = "org.junit.jupiter", name = "junit-jupiter-api", version.ref = "junit5" }
 junit5-engine = { group = "org.junit.jupiter", name = "junit-jupiter-engine", version.ref = "junit5" }
 junit5-params = { group = "org.junit.jupiter", name = "junit-jupiter-params", version.ref = "junit5" }
+junit5-launcher = { group = "org.junit.platform", name = "junit-platform-launcher" }
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
 coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
@@ -48,7 +49,7 @@ coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
-kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
- Gradle: 8.6 → 9.3.1 (minimum required by AGP 9.1.0)
- AGP: 8.3.2 → 9.1.0 (was unavailable; AGP 9.x bundles KGP 2.2.10)
- Kotlin: 1.9.23 → 2.2.10 (matches AGP 9.x bundled KGP version)
- KSP: replaces deprecated kapt (hilt-android-compiler → hilt-compiler)
- Compose Compiler: moved to org.jetbrains.kotlin.plugin.compose plugin
- kotlin-android plugin removed from app (AGP 9.x registers it internally)
- compileSdk/targetSdk: 34 → 35
- Hilt: 2.51.1 → 2.59.2 (AGP 9.x compatible, BaseExtension removed)
- hilt-navigation-compose: 1.2.0 → 1.3.0
- JUnit 5: 5.10.2 → 5.11.4; add junit-platform-launcher for Gradle 9
- MockK: 1.13.11 → 1.13.16
- Coroutines: 1.8.1 → 1.9.0
- AndroidX: core-ktx 1.15.0, activity-compose 1.10.1, lifecycle 2.8.7
- Navigation Compose: 2.7.7 → 2.8.9
- Compose BOM: 2024.05.00 → 2024.12.01
- gradle.properties: fix nonProxyHosts so Google Maven resolves through proxy
- gradle.properties: android.disallowKotlinSourceSets=false for KSP+AGP 9.x

All 27 unit tests pass (core-network: 23, core-domain: 4).

https://claude.ai/code/session_01DWsDVx7A2gXmSoUkXuCF8E