### PR TITLE
Add missing launcher icon resources to fix AAPT build error

### DIFF
--- a/app/src/main/res/drawable/ic_launcher_background.xml
+++ b/app/src/main/res/drawable/ic_launcher_background.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="#1565C0" />
+</shape>

--- a/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <!-- Network/wifi icon representing Net Swiss Knife -->
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M54,30C40.7,30 28.7,35.8 20.3,45.1L27.4,52.2C33.9,44.8 43.4,40 54,40C64.6,40 74.1,44.8 80.6,52.2L87.7,45.1C79.3,35.8 67.3,30 54,30Z" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M54,46C47.1,46 40.9,48.9 36.4,53.6L43.5,60.7C46.2,57.8 50,56 54,56C58,56 61.8,57.8 64.5,60.7L71.6,53.6C67.1,48.9 60.9,46 54,46Z" />
+    <!-- Circle at (54,70) r=7 -->
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M54,63 A7,7 0 1 0 54,77 A7,7 0 1 0 54,63 Z" />
+</vector>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>


### PR DESCRIPTION
Creates mipmap/ic_launcher and mipmap/ic_launcher_round as adaptive
icons (anydpi-v26) with a network-themed vector foreground and a
solid blue background, resolving the AAPT resource-not-found errors
in processDebugResources.

https://claude.ai/code/session_01CN5pheE2ZVNNZzDEFtqRNp