### PR TITLE
feat: auto-generate date-based version names in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,13 +3,9 @@ name: Release – Package & Publish
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'   # e.g. v1.2.3
+      - 'v[0-9]+.[0-9]+.[0-9]+.[0-9]+'   # e.g. v2026.03.21.1 (override)
   workflow_dispatch:
     inputs:
-      version_name:
-        description: 'Version name (e.g. 1.2.3)'
-        required: true
-        default: '1.0.0'
       create_github_release:
         description: 'Create a GitHub Release?'
         required: false
@@ -20,6 +16,8 @@ jobs:
   build-and-publish:
     name: Build, Sign & Publish
     runs-on: ubuntu-latest
+    permissions:
+      contents: write   # required for creating GitHub Releases
 
     steps:
       # ── 1. Source ──────────────────────────────────────────────────────────
@@ -50,18 +48,44 @@ jobs:
         run: chmod +x ./gradlew
 
       # ── 4. Determine version ──────────────────────────────────────────────
-      - name: Resolve version name
+      # Version format: YYYY.MM.DD.N  (N = daily build number, starting at 1)
+      # versionCode:    YYYYMMDD * 100 + N  (stays within Android Int limit through 2099)
+      - name: Auto-generate version name
         id: version
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [[ "${{ github.event_name }}" == "push" ]]; then
-            # Strip leading 'v' from tag name
+            # Tag-based override: strip leading 'v'
             VERSION="${GITHUB_REF_NAME#v}"
           else
-            VERSION="${{ github.event.inputs.version_name }}"
+            # Auto-generate: YYYY.MM.DD.N
+            DATE=$(date -u +%Y.%m.%d)
+            DATE_COMPACT=$(date -u +%Y%m%d)
+
+            # Count existing releases for today to get the next daily increment
+            EXISTING=$(gh release list \
+              --repo "$GITHUB_REPOSITORY" \
+              --limit 100 \
+              --json tagName \
+              --jq "[.[].tagName | select(startswith(\"v${DATE}\"))] | length" \
+              2>/dev/null || echo "0")
+            # Sanitise: ensure it is a plain integer
+            EXISTING=$(echo "$EXISTING" | tr -cd '0-9')
+            DAILY_NUM=$(( ${EXISTING:-0} + 1 ))
+
+            VERSION="${DATE}.${DAILY_NUM}"
           fi
-          echo "name=${VERSION}" >> "$GITHUB_OUTPUT"
-          # versionCode = epoch-based integer, always increasing
-          echo "code=$(date +%s)" >> "$GITHUB_OUTPUT"
+
+          # Parse components for versionCode
+          # VERSION is e.g. 2026.03.21.1
+          DATE_COMPACT=$(echo "$VERSION" | sed 's/\.\([0-9]*\)$//; s/\.//g')
+          DAILY_NUM=$(echo "$VERSION" | grep -oE '[0-9]+$')
+          VERSION_CODE=$(( DATE_COMPACT * 100 + DAILY_NUM ))
+
+          echo "name=${VERSION}"        >> "$GITHUB_OUTPUT"
+          echo "code=${VERSION_CODE}"   >> "$GITHUB_OUTPUT"
+          echo "Generated version: ${VERSION} (code: ${VERSION_CODE})"
 
       # ── 5. Unit tests ─────────────────────────────────────────────────────
       - name: Run unit tests
@@ -76,14 +100,13 @@ jobs:
 
       # ── 6. Decode keystore ────────────────────────────────────────────────
       - name: Decode release keystore
-        # Only attempt signing when the secret is present
-        if: ${{ secrets.RELEASE_KEYSTORE_BASE64 != '' }}
+        if: secrets.RELEASE_KEYSTORE_BASE64 != ''
         run: |
           echo "${{ secrets.RELEASE_KEYSTORE_BASE64 }}" | base64 --decode > "$RUNNER_TEMP/release.keystore"
 
       # ── 7. Build release APK ──────────────────────────────────────────────
-      - name: Build release APK (unsigned fallback when no keystore)
-        if: ${{ secrets.RELEASE_KEYSTORE_BASE64 == '' }}
+      - name: Build release APK (unsigned – no keystore)
+        if: secrets.RELEASE_KEYSTORE_BASE64 == ''
         run: |
           ./gradlew :app:assembleRelease \
             -PversionName="${{ steps.version.outputs.name }}" \
@@ -91,7 +114,7 @@ jobs:
             --no-daemon
 
       - name: Build release APK (signed)
-        if: ${{ secrets.RELEASE_KEYSTORE_BASE64 != '' }}
+        if: secrets.RELEASE_KEYSTORE_BASE64 != ''
         run: |
           ./gradlew :app:assembleRelease \
             -PversionName="${{ steps.version.outputs.name }}" \
@@ -103,8 +126,8 @@ jobs:
             --no-daemon
 
       # ── 8. Build release AAB ──────────────────────────────────────────────
-      - name: Build release AAB (unsigned fallback when no keystore)
-        if: ${{ secrets.RELEASE_KEYSTORE_BASE64 == '' }}
+      - name: Build release AAB (unsigned – no keystore)
+        if: secrets.RELEASE_KEYSTORE_BASE64 == ''
         run: |
           ./gradlew :app:bundleRelease \
             -PversionName="${{ steps.version.outputs.name }}" \
@@ -112,7 +135,7 @@ jobs:
             --no-daemon
 
       - name: Build release AAB (signed)
-        if: ${{ secrets.RELEASE_KEYSTORE_BASE64 != '' }}
+        if: secrets.RELEASE_KEYSTORE_BASE64 != ''
         run: |
           ./gradlew :app:bundleRelease \
             -PversionName="${{ steps.version.outputs.name }}" \
@@ -136,17 +159,17 @@ jobs:
 
       # ── 10. Rename artefacts with version ─────────────────────────────────
       - name: Rename artefacts
+        id: rename
         run: |
           VERSION="${{ steps.version.outputs.name }}"
           APK="${{ steps.artefacts.outputs.apk }}"
           AAB="${{ steps.artefacts.outputs.aab }}"
           DIR=$(dirname "$APK")
-          cp "$APK" "${DIR}/NetSwissKnife-${VERSION}.apk"
           DIR_AAB=$(dirname "$AAB")
+          cp "$APK" "${DIR}/NetSwissKnife-${VERSION}.apk"
           cp "$AAB" "${DIR_AAB}/NetSwissKnife-${VERSION}.aab"
-          echo "apk_named=${DIR}/NetSwissKnife-${VERSION}.apk"   >> "$GITHUB_OUTPUT"
+          echo "apk_named=${DIR}/NetSwissKnife-${VERSION}.apk"    >> "$GITHUB_OUTPUT"
           echo "aab_named=${DIR_AAB}/NetSwissKnife-${VERSION}.aab" >> "$GITHUB_OUTPUT"
-        id: rename
 
       # ── 11. Upload artefacts to workflow run ──────────────────────────────
       - name: Upload APK artefact
@@ -179,7 +202,7 @@ jobs:
             ${{ steps.rename.outputs.apk_named }}
             ${{ steps.rename.outputs.aab_named }}
           body: |
-            ## Net Swiss Knife v${{ steps.version.outputs.name }}
+            ## Net Swiss Knife ${{ steps.version.outputs.name }}
 
             ### Installation
 


### PR DESCRIPTION
Version format: YYYY.MM.DD.N where N is a daily increment determined
by counting existing GitHub releases with today's date prefix.
versionCode uses YYYYMMDD * 100 + N (safe within Android Int limit
through 2099, replaces epoch-seconds which was approaching overflow).

workflow_dispatch no longer requires manual version input — version
is always auto-generated. Tag pushes (v*.*.*.*) still override.

Also adds explicit `contents: write` permission required by
softprops/action-gh-release to create releases without 403 errors.

https://claude.ai/code/session_01PfhqfT5DzJ8aNoEcwTrfxK