### PR TITLE
fix: resolve secrets context error that prevented release.yml from loading

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,15 +98,32 @@ jobs:
           name: test-results
           path: '**/build/reports/tests/'
 
-      # ── 6. Decode keystore ────────────────────────────────────────────────
-      - name: Decode release keystore
-        if: secrets.RELEASE_KEYSTORE_BASE64 != ''
+      # ── 6. Check signing configuration ────────────────────────────────────
+      # secrets context is not available in `if:` expressions, so we detect
+      # keystore presence here and expose it as a step output instead.
+      - name: Check signing configuration
+        id: signing
+        env:
+          KEYSTORE_B64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
         run: |
-          echo "${{ secrets.RELEASE_KEYSTORE_BASE64 }}" | base64 --decode > "$RUNNER_TEMP/release.keystore"
+          if [ -n "$KEYSTORE_B64" ]; then
+            echo "has_keystore=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_keystore=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No RELEASE_KEYSTORE_BASE64 secret found – building unsigned APK/AAB."
+          fi
 
-      # ── 7. Build release APK ──────────────────────────────────────────────
+      # ── 7. Decode keystore ────────────────────────────────────────────────
+      - name: Decode release keystore
+        if: steps.signing.outputs.has_keystore == 'true'
+        env:
+          KEYSTORE_B64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
+        run: |
+          echo "$KEYSTORE_B64" | base64 --decode > "$RUNNER_TEMP/release.keystore"
+
+      # ── 8. Build release APK ──────────────────────────────────────────────
       - name: Build release APK (unsigned – no keystore)
-        if: secrets.RELEASE_KEYSTORE_BASE64 == ''
+        if: steps.signing.outputs.has_keystore == 'false'
         run: |
           ./gradlew :app:assembleRelease \
             -PversionName="${{ steps.version.outputs.name }}" \
@@ -114,7 +131,7 @@ jobs:
             --no-daemon
 
       - name: Build release APK (signed)
-        if: secrets.RELEASE_KEYSTORE_BASE64 != ''
+        if: steps.signing.outputs.has_keystore == 'true'
         run: |
           ./gradlew :app:assembleRelease \
             -PversionName="${{ steps.version.outputs.name }}" \
@@ -125,9 +142,9 @@ jobs:
             -PkeyPassword="${{ secrets.RELEASE_KEY_PASSWORD }}" \
             --no-daemon
 
-      # ── 8. Build release AAB ──────────────────────────────────────────────
+      # ── 9. Build release AAB ──────────────────────────────────────────────
       - name: Build release AAB (unsigned – no keystore)
-        if: secrets.RELEASE_KEYSTORE_BASE64 == ''
+        if: steps.signing.outputs.has_keystore == 'false'
         run: |
           ./gradlew :app:bundleRelease \
             -PversionName="${{ steps.version.outputs.name }}" \
@@ -135,7 +152,7 @@ jobs:
             --no-daemon
 
       - name: Build release AAB (signed)
-        if: secrets.RELEASE_KEYSTORE_BASE64 != ''
+        if: steps.signing.outputs.has_keystore == 'true'
         run: |
           ./gradlew :app:bundleRelease \
             -PversionName="${{ steps.version.outputs.name }}" \
@@ -220,6 +237,6 @@ jobs:
             ### Build info
             - Version code: `${{ steps.version.outputs.code }}`
             - Commit: `${{ github.sha }}`
-            - Signed: ${{ secrets.RELEASE_KEYSTORE_BASE64 != '' && 'Yes' || 'No (unsigned – development build)' }}
+            - Signed: ${{ steps.signing.outputs.has_keystore == 'true' && 'Yes' || 'No (unsigned – development build)' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,6 +186,13 @@ The release workflow uses GitHub Actions secrets for signing:
 
 Set these in **GitHub → Settings → Secrets and variables → Actions** before running the workflow.
 
+> **Important – GitHub Actions limitation:** The `secrets` context is **not** available
+> inside `if:` expressions. The workflow works around this by running a detection step
+> (`signing`) that reads the secret into an env var and emits a `has_keystore` output;
+> all conditional steps then use `steps.signing.outputs.has_keystore == 'true'`.
+> Do **not** write `if: secrets.XYZ != ''` in this workflow — it will cause a parse
+> error and the entire workflow will fail to load.
+
 ---
 
 ## File Naming Conventions


### PR DESCRIPTION
GitHub Actions does not allow the `secrets` context in `if:` expressions.
This caused "Unrecognized named-value: 'secrets'" parse errors at lines
103, 109, 117, 130, and 138, making the entire workflow fail to load.

Fix:
- Add a `Check signing configuration` step that reads RELEASE_KEYSTORE_BASE64
  via an env var and outputs `has_keystore=true/false`
- Replace all `if: secrets.RELEASE_KEYSTORE_BASE64 !=/== ''` conditions with
  `if: steps.signing.outputs.has_keystore == 'true/false'`
- Replace the secrets reference in the release body with the same step output
- Document the limitation in CLAUDE.md so future edits don't reintroduce it

No secrets or repository settings are required to trigger the workflow;
the signing secrets are optional – without them an unsigned APK/AAB is built.

https://claude.ai/code/session_01W5KgUGe4MxyZZ8eWsNQx9a