### PR TITLE
fix: sign release APK with debug key when no release keystore is configured

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -237,6 +237,6 @@ jobs:
             ### Build info
             - Version code: `${{ steps.version.outputs.code }}`
             - Commit: `${{ github.sha }}`
-            - Signed: ${{ steps.signing.outputs.has_keystore == 'true' && 'Yes' || 'No (unsigned – development build)' }}
+            - Signed: ${{ steps.signing.outputs.has_keystore == 'true' && 'Yes (release key)' || 'Debug key (sideload only – not for Play Store)' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -48,8 +48,10 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
-            if (ciStoreFile != null) {
-                signingConfig = signingConfigs.getByName("release")
+            signingConfig = if (ciStoreFile != null) {
+                signingConfigs.getByName("release")
+            } else {
+                signingConfigs.getByName("debug")
             }
         }
     }


### PR DESCRIPTION
Without a signing config, assembleRelease produces an unsigned APK that
Android refuses to install ("not a valid package"). Fall back to the debug
signing config so the APK is always signed and sideloadable.

The release notes now clarify when a debug key was used vs a release key.

https://claude.ai/code/session_01Gu4oSr1KuEZQ6Jwf8KVq18