### PR TITLE
fix: suppress R8 missing-class warnings for dnsjava desktop dependencies

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,1 +1,17 @@
 # Add project specific ProGuard rules here.
+
+# dnsjava: Windows-specific JNA classes not present on Android
+-dontwarn com.sun.jna.**
+-dontwarn com.sun.jna.platform.win32.**
+-dontwarn com.sun.jna.ptr.**
+-dontwarn com.sun.jna.win32.**
+
+# dnsjava: JNDI classes not present on Android
+-dontwarn javax.naming.**
+-dontwarn javax.naming.directory.**
+
+# dnsjava: Lombok compile-time annotations not present at runtime
+-dontwarn lombok.**
+
+# dnsjava: SLF4J static binder not used on Android (logback/slf4j-android handles this)
+-dontwarn org.slf4j.impl.StaticLoggerBinder


### PR DESCRIPTION
dnsjava includes Windows-specific JNA classes (IPHlpAPI, WindowsResolver),
JNDI context classes, Lombok annotations, and SLF4J static binder — none of
which exist on Android. R8 fails the release build when it encounters these
missing class references.

Add -dontwarn rules for:
- com.sun.jna.** (JNA Windows adapter resolution)
- javax.naming.** (JNDI resolver config provider)
- lombok.** (compile-time annotations)
- org.slf4j.impl.StaticLoggerBinder (desktop SLF4J binding)

https://claude.ai/code/session_016q2j7cXiGRsPLvVMCRAwep