### PR TITLE
fix: resolve four DNS screen issues

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -41,6 +41,10 @@ android {
     }
 
     buildTypes {
+        debug {
+            applicationIdSuffix = ".debug"
+            versionNameSuffix = "-debug"
+        }
         release {
             isMinifyEnabled    = true
             isShrinkResources  = true

--- a/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/DnsScreen.kt
+++ b/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/DnsScreen.kt
@@ -30,6 +30,8 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Clear
@@ -80,6 +82,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -278,6 +282,13 @@ private fun DnsInputCard(
                     }
                 },
                 singleLine = true,
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Uri,
+                    imeAction = ImeAction.Search
+                ),
+                keyboardActions = KeyboardActions(
+                    onSearch = { onLookup() }
+                ),
                 modifier = Modifier.fillMaxWidth(),
                 shape = RoundedCornerShape(12.dp)
             )

--- a/core-network/src/main/kotlin/com/example/netswissknife/core/network/dns/DnsRepositoryImpl.kt
+++ b/core-network/src/main/kotlin/com/example/netswissknife/core/network/dns/DnsRepositoryImpl.kt
@@ -72,9 +72,9 @@ class DnsRepositoryImpl : DnsRepository {
                     rawResponse = rawResponse
                 )
             )
-        } catch (e: Exception) {
+        } catch (e: Throwable) {
             NetworkResult.Error(
-                message = "DNS lookup failed: ${e.message ?: "Unknown error"}",
+                message = "DNS lookup failed: ${e.message ?: e.javaClass.simpleName}",
                 cause = e
             )
         }
@@ -101,7 +101,7 @@ class DnsRepositoryImpl : DnsRepository {
             // ExtendedResolver auto-detects system DNS servers from OS configuration.
             // Falls back to localhost / platform defaults if none found.
             ExtendedResolver().also { it.setTimeout(TIMEOUT) }
-        } catch (e: Exception) {
+        } catch (e: Throwable) {
             // Absolute fallback: use Cloudflare when system DNS can't be detected
             simpleResolver(DnsServer.Cloudflare.PRIMARY)
         }


### PR DESCRIPTION
- DnsRepositoryImpl: catch Throwable (not just Exception) so Android
  ExceptionInInitializerError from dnsjava's JNA/JNDI static init no
  longer escapes the coroutine and crashes the app; also use
  e.javaClass.simpleName as fallback when e.message is null so the UI
  shows a meaningful error instead of "Unknown error"
- app/build.gradle.kts: add applicationIdSuffix ".debug" for debug
  builds so debug APK (com.example.netswissknife.debug) can coexist
  with a release APK without signing-key conflicts
- DnsScreen: add KeyboardOptions(KeyboardType.Uri, ImeAction.Search)
  and KeyboardActions(onSearch) to the domain input field so the IME
  renders in single-line/search mode rather than multiline mode, and
  pressing the keyboard action button triggers the lookup directly

https://claude.ai/code/session_01SSmNVgW5oEHAbVGcPZmbK3