### PR TITLE
fix: resolve System DNS port-unreachable crash and replace server picker with combo box

### DIFF
--- a/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/DnsScreen.kt
+++ b/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/DnsScreen.kt
@@ -49,16 +49,18 @@ import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
@@ -317,29 +319,10 @@ private fun DnsInputCard(
                 )
                 DnsServerSelector(
                     selectedServer = selectedServer,
-                    onServerChange = onServerChange
+                    customServerAddress = customServerAddress,
+                    onServerChange = onServerChange,
+                    onCustomAddressChange = onCustomServerAddressChange
                 )
-                if (selectedServer is DnsServer.Custom) {
-                    OutlinedTextField(
-                        value = customServerAddress,
-                        onValueChange = onCustomServerAddressChange,
-                        label = { Text(stringResource(R.string.dns_custom_server_label)) },
-                        placeholder = { Text(stringResource(R.string.dns_custom_server_placeholder)) },
-                        leadingIcon = {
-                            Icon(Icons.Default.Storage, contentDescription = null)
-                        },
-                        trailingIcon = {
-                            if (customServerAddress.isNotEmpty()) {
-                                IconButton(onClick = { onCustomServerAddressChange("") }) {
-                                    Icon(Icons.Default.Clear, contentDescription = stringResource(R.string.clear))
-                                }
-                            }
-                        },
-                        singleLine = true,
-                        modifier = Modifier.fillMaxWidth(),
-                        shape = RoundedCornerShape(12.dp)
-                    )
-                }
             }
 
             // Lookup button
@@ -442,96 +425,110 @@ private fun RecordTypeDescription(recordType: DnsRecordType) {
     }
 }
 
-// ── DNS server selector ───────────────────────────────────────────────────────
+// ── DNS server selector (combo box) ──────────────────────────────────────────
 
+/**
+ * An editable combo box for DNS server selection.
+ * - Preset servers (System, Google, Cloudflare, OpenDNS, Quad9) are offered in the dropdown.
+ * - The user can also type a custom IP address directly into the field; this switches the
+ *   server to [DnsServer.Custom] automatically.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun DnsServerSelector(
     selectedServer: DnsServer,
-    onServerChange: (DnsServer) -> Unit
+    customServerAddress: String,
+    onServerChange: (DnsServer) -> Unit,
+    onCustomAddressChange: (String) -> Unit
 ) {
     var expanded by remember { mutableStateOf(false) }
-    val presets = DnsServer.presets + listOf(DnsServer.Custom(""))
-    val displayLabel = if (selectedServer is DnsServer.Custom) {
-        stringResource(R.string.dns_server_custom)
-    } else {
-        selectedServer.displayName
-    }
 
-    Box {
-        OutlinedCard(
+    // Text shown in the field: preset display name, or the typed custom address.
+    val fieldValue = if (selectedServer is DnsServer.Custom) customServerAddress
+                     else selectedServer.displayName
+
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = it }
+    ) {
+        OutlinedTextField(
+            value = fieldValue,
+            onValueChange = { text ->
+                // Any manual edit → treat as a custom DNS address.
+                onCustomAddressChange(text)
+            },
+            label = { Text(stringResource(R.string.dns_server_label)) },
+            placeholder = { Text(stringResource(R.string.dns_custom_server_placeholder)) },
+            leadingIcon = {
+                Icon(
+                    imageVector = Icons.Default.Dns,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary
+                )
+            },
+            trailingIcon = {
+                ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded)
+            },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
             modifier = Modifier
                 .fillMaxWidth()
-                .clickable { expanded = true },
-            shape = RoundedCornerShape(12.dp)
-        ) {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 14.dp),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Column {
-                    Text(
-                        text = displayLabel,
-                        style = MaterialTheme.typography.bodyMedium,
-                        fontWeight = FontWeight.Medium,
-                        color = MaterialTheme.colorScheme.onSurface
-                    )
-                    if (selectedServer !is DnsServer.Custom) {
-                        Text(
-                            text = selectedServer.description,
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
-                        )
-                    }
-                }
-                Icon(
-                    imageVector = if (expanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-        }
+                .menuAnchor(MenuAnchorType.PrimaryEditable, enabled = true),
+            shape = RoundedCornerShape(12.dp),
+            colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors()
+        )
 
-        DropdownMenu(
+        ExposedDropdownMenu(
             expanded = expanded,
-            onDismissRequest = { expanded = false },
-            modifier = Modifier.fillMaxWidth(0.85f)
+            onDismissRequest = { expanded = false }
         ) {
-            presets.forEach { server ->
-                val isCustomOption = server is DnsServer.Custom
-                val isSelectedOption = when {
-                    isCustomOption -> selectedServer is DnsServer.Custom
+            DnsServer.presets.forEach { server ->
+                val isSelected = when {
+                    server is DnsServer.System && selectedServer is DnsServer.System -> true
                     else -> selectedServer == server
                 }
                 DropdownMenuItem(
                     text = {
                         Column {
                             Text(
-                                text = if (isCustomOption) stringResource(R.string.dns_server_custom) else server.displayName,
+                                text = server.displayName,
                                 style = MaterialTheme.typography.bodyMedium,
-                                fontWeight = if (isSelectedOption) FontWeight.SemiBold else FontWeight.Normal,
-                                color = if (isSelectedOption) MaterialTheme.colorScheme.primary
+                                fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Normal,
+                                color = if (isSelected) MaterialTheme.colorScheme.primary
                                         else MaterialTheme.colorScheme.onSurface
                             )
-                            if (!isCustomOption) {
-                                Text(
-                                    text = server.description,
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                                )
-                            }
+                            Text(
+                                text = server.description,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
                         }
                     },
                     onClick = {
-                        onServerChange(if (isCustomOption) DnsServer.Custom("") else server)
+                        onServerChange(server)
                         expanded = false
-                    }
+                    },
+                    contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
                 )
             }
+            // "Custom…" sentinel at the bottom of the list
+            val isCustomSelected = selectedServer is DnsServer.Custom
+            DropdownMenuItem(
+                text = {
+                    Text(
+                        text = stringResource(R.string.dns_server_custom),
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = if (isCustomSelected) FontWeight.SemiBold else FontWeight.Normal,
+                        color = if (isCustomSelected) MaterialTheme.colorScheme.primary
+                                else MaterialTheme.colorScheme.onSurface
+                    )
+                },
+                onClick = {
+                    onCustomAddressChange("")
+                    expanded = false
+                },
+                contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
+            )
         }
     }
 }

--- a/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/dns/DnsViewModel.kt
+++ b/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/dns/DnsViewModel.kt
@@ -2,6 +2,7 @@ package com.example.netswissknife.app.ui.screens.dns
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.netswissknife.app.util.SystemDnsAddressProvider
 import com.example.netswissknife.core.domain.DnsLookupParams
 import com.example.netswissknife.core.domain.DnsLookupUseCase
 import com.example.netswissknife.core.network.NetworkResult
@@ -25,7 +26,8 @@ sealed interface DnsUiState {
 
 @HiltViewModel
 class DnsViewModel @Inject constructor(
-    private val dnsLookupUseCase: DnsLookupUseCase
+    private val dnsLookupUseCase: DnsLookupUseCase,
+    private val systemDnsAddressProvider: SystemDnsAddressProvider
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<DnsUiState>(DnsUiState.Idle)
@@ -39,7 +41,7 @@ class DnsViewModel @Inject constructor(
     private val _recordType = MutableStateFlow(DnsRecordType.A)
     val recordType: StateFlow<DnsRecordType> = _recordType.asStateFlow()
 
-    private val _selectedServer = MutableStateFlow<DnsServer>(DnsServer.System)
+    private val _selectedServer = MutableStateFlow<DnsServer>(DnsServer.System())
     val selectedServer: StateFlow<DnsServer> = _selectedServer.asStateFlow()
 
     private val _customServerAddress = MutableStateFlow("")
@@ -82,10 +84,10 @@ class DnsViewModel @Inject constructor(
     }
 
     fun performLookup() {
-        val server = if (_selectedServer.value is DnsServer.Custom) {
-            DnsServer.Custom(_customServerAddress.value)
-        } else {
-            _selectedServer.value
+        val server = when (val s = _selectedServer.value) {
+            is DnsServer.Custom -> DnsServer.Custom(_customServerAddress.value)
+            is DnsServer.System -> DnsServer.System(systemDnsAddressProvider.getAddresses())
+            else -> s
         }
 
         val params = DnsLookupParams(

--- a/app/src/main/kotlin/com/example/netswissknife/app/util/SystemDnsAddressProvider.kt
+++ b/app/src/main/kotlin/com/example/netswissknife/app/util/SystemDnsAddressProvider.kt
@@ -1,0 +1,33 @@
+package com.example.netswissknife.app.util
+
+import android.content.Context
+import android.net.ConnectivityManager
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Reads the DNS server addresses from the currently active network using
+ * [ConnectivityManager] / [android.net.LinkProperties].
+ *
+ * Must live in the app layer because it depends on the Android SDK.
+ */
+@Singleton
+class SystemDnsAddressProvider @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    /**
+     * Returns the DNS server IP strings for the active network, or an empty list if
+     * they cannot be determined (e.g. no active network, permissions missing).
+     */
+    fun getAddresses(): List<String> {
+        return try {
+            val cm = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+            val network = cm.activeNetwork ?: return emptyList()
+            val props = cm.getLinkProperties(network) ?: return emptyList()
+            props.dnsServers.mapNotNull { it.hostAddress }
+        } catch (_: Exception) {
+            emptyList()
+        }
+    }
+}

--- a/core-domain/src/main/kotlin/com/example/netswissknife/core/domain/DnsLookupParams.kt
+++ b/core-domain/src/main/kotlin/com/example/netswissknife/core/domain/DnsLookupParams.kt
@@ -13,5 +13,5 @@ import com.example.netswissknife.core.network.dns.DnsServer
 data class DnsLookupParams(
     val domain: String,
     val recordType: DnsRecordType = DnsRecordType.A,
-    val server: DnsServer = DnsServer.System
+    val server: DnsServer = DnsServer.System()
 )

--- a/core-network/src/main/kotlin/com/example/netswissknife/core/network/dns/DnsRepositoryImpl.kt
+++ b/core-network/src/main/kotlin/com/example/netswissknife/core/network/dns/DnsRepositoryImpl.kt
@@ -84,7 +84,7 @@ class DnsRepositoryImpl : DnsRepository {
 
     private fun buildResolver(server: DnsServer): Resolver {
         return when (server) {
-            is DnsServer.System     -> buildSystemResolver()
+            is DnsServer.System     -> buildSystemResolver(server)
             is DnsServer.Google     -> simpleResolver(DnsServer.Google.PRIMARY)
             is DnsServer.Cloudflare -> simpleResolver(DnsServer.Cloudflare.PRIMARY)
             is DnsServer.OpenDns    -> simpleResolver(DnsServer.OpenDns.PRIMARY)
@@ -96,13 +96,17 @@ class DnsRepositoryImpl : DnsRepository {
     private fun simpleResolver(address: String): Resolver =
         SimpleResolver(address).also { it.setTimeout(TIMEOUT) }
 
-    private fun buildSystemResolver(): Resolver {
-        return try {
-            // ExtendedResolver auto-detects system DNS servers from OS configuration.
-            // Falls back to localhost / platform defaults if none found.
-            ExtendedResolver().also { it.setTimeout(TIMEOUT) }
-        } catch (e: Throwable) {
-            // Absolute fallback: use Cloudflare when system DNS can't be detected
+    private fun buildSystemResolver(server: DnsServer.System): Resolver {
+        // serverAddresses are populated by the app layer (ConnectivityManager / LinkProperties).
+        // Never use ExtendedResolver() with no args – on Android that falls back to localhost:53
+        // which has no DNS listener and throws "Port unreachable".
+        return if (server.serverAddresses.isNotEmpty()) {
+            try {
+                ExtendedResolver(server.serverAddresses.toTypedArray()).also { it.setTimeout(TIMEOUT) }
+            } catch (e: Throwable) {
+                simpleResolver(DnsServer.Cloudflare.PRIMARY)
+            }
+        } else {
             simpleResolver(DnsServer.Cloudflare.PRIMARY)
         }
     }

--- a/core-network/src/main/kotlin/com/example/netswissknife/core/network/dns/DnsServer.kt
+++ b/core-network/src/main/kotlin/com/example/netswissknife/core/network/dns/DnsServer.kt
@@ -8,8 +8,12 @@ sealed class DnsServer(
     val displayName: String,
     val description: String
 ) {
-    /** Uses the device's configured DNS resolver (system-detected or InetAddress fallback). */
-    object System : DnsServer(
+    /**
+     * Uses the device's configured DNS resolver.
+     * [serverAddresses] must be populated by the app layer (via ConnectivityManager / LinkProperties)
+     * before performing a lookup. If empty the repository falls back to Cloudflare.
+     */
+    data class System(val serverAddresses: List<String> = emptyList()) : DnsServer(
         displayName = "System DNS",
         description = "Uses the DNS server configured on your device"
     )
@@ -56,6 +60,6 @@ sealed class DnsServer(
     )
 
     companion object {
-        val presets: List<DnsServer> = listOf(System, Google, Cloudflare, OpenDns, Quad9)
+        val presets: List<DnsServer> = listOf(System(), Google, Cloudflare, OpenDns, Quad9)
     }
 }

--- a/core-network/src/test/kotlin/com/example/netswissknife/core/network/dns/DnsServerTest.kt
+++ b/core-network/src/test/kotlin/com/example/netswissknife/core/network/dns/DnsServerTest.kt
@@ -51,7 +51,7 @@ class DnsServerTest {
 
         @Test
         fun `System has human-readable display name`() {
-            assertTrue(DnsServer.System.displayName.isNotBlank())
+            assertTrue(DnsServer.System().displayName.isNotBlank())
         }
 
         @Test


### PR DESCRIPTION
Root cause: ExtendedResolver() with no args falls back to localhost:53 on Android
(no /etc/resolv.conf), causing SocketException "Port unreachable" on every lookup
and an unstable UI state when switching servers.

Changes:
- DnsServer.System: object → data class with serverAddresses: List<String>
  (populated by the app layer before each lookup; empty = no-arg resolver was used)
- DnsRepositoryImpl.buildSystemResolver: never calls ExtendedResolver() without
  explicit addresses; falls back to Cloudflare when addresses are unavailable
- SystemDnsAddressProvider (new, app layer): reads active-network DNS from
  ConnectivityManager / LinkProperties and supplies them to the ViewModel
- DnsViewModel.performLookup: resolves real system DNS addresses via
  SystemDnsAddressProvider before dispatching DnsServer.System lookups
- DnsScreen: replace two-part dropdown + separate custom text field with a single
  ExposedDropdownMenuBox combo box — presets in the dropdown, editable field for
  typing a custom IP directly; switching to Custom is automatic on any manual edit

https://claude.ai/code/session_01TB6zBKCgyfGUg1uR7NG463