### PR TITLE
feat: implement full port scanner with deep analysis and rich UI

### DIFF
--- a/app/src/main/kotlin/com/example/netswissknife/app/di/PortScanModule.kt
+++ b/app/src/main/kotlin/com/example/netswissknife/app/di/PortScanModule.kt
@@ -1,0 +1,24 @@
+package com.example.netswissknife.app.di
+
+import com.example.netswissknife.core.domain.PortScanUseCase
+import com.example.netswissknife.core.network.portscan.PortScanRepository
+import com.example.netswissknife.core.network.portscan.PortScanRepositoryImpl
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object PortScanModule {
+
+    @Provides
+    @Singleton
+    fun providePortScanRepository(): PortScanRepository = PortScanRepositoryImpl()
+
+    @Provides
+    @Singleton
+    fun providePortScanUseCase(repository: PortScanRepository): PortScanUseCase =
+        PortScanUseCase(repository)
+}

--- a/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/PortsScreen.kt
+++ b/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/PortsScreen.kt
@@ -1,20 +1,943 @@
 package com.example.netswissknife.app.ui.screens
 
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material.icons.filled.Stop
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.example.netswissknife.app.R
+import com.example.netswissknife.app.ui.screens.portscan.PortScanUiState
+import com.example.netswissknife.app.ui.screens.portscan.PortScanViewModel
+import com.example.netswissknife.core.domain.PortScanPreset
+import com.example.netswissknife.core.network.portscan.PortScanResult
+import com.example.netswissknife.core.network.portscan.PortScanSummary
+import com.example.netswissknife.core.network.portscan.PortStatus
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+fun PortsScreen(viewModel: PortScanViewModel = hiltViewModel()) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val host by viewModel.host.collectAsStateWithLifecycle()
+    val selectedPreset by viewModel.selectedPreset.collectAsStateWithLifecycle()
+    val startPort by viewModel.startPort.collectAsStateWithLifecycle()
+    val endPort by viewModel.endPort.collectAsStateWithLifecycle()
+    val timeoutMs by viewModel.timeoutMs.collectAsStateWithLifecycle()
+    val concurrency by viewModel.concurrency.collectAsStateWithLifecycle()
+
+    // Screen entrance animation
+    var screenVisible by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) { screenVisible = true }
+
+    val keyboardController = LocalSoftwareKeyboardController.current
+    val clipboard = LocalClipboardManager.current
+
+    AnimatedVisibility(
+        visible = screenVisible,
+        enter = fadeIn(tween(400)) + slideInVertically(tween(400)) { it / 6 }
+    ) {
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = PaddingValues(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            // ── Header ──────────────────────────────────────────────────────────
+            item {
+                PortScanHeader()
+            }
+
+            // ── Input Card ──────────────────────────────────────────────────────
+            item {
+                PortScanInputCard(
+                    host = host,
+                    selectedPreset = selectedPreset,
+                    startPort = startPort,
+                    endPort = endPort,
+                    timeoutMs = timeoutMs,
+                    concurrency = concurrency,
+                    isScanning = uiState is PortScanUiState.Scanning,
+                    onHostChange = viewModel::onHostChange,
+                    onPresetChange = viewModel::onPresetChange,
+                    onStartPortChange = viewModel::onStartPortChange,
+                    onEndPortChange = viewModel::onEndPortChange,
+                    onTimeoutChange = viewModel::onTimeoutChange,
+                    onConcurrencyChange = viewModel::onConcurrencyChange,
+                    onStartScan = {
+                        keyboardController?.hide()
+                        viewModel.startScan()
+                    },
+                    onStopScan = viewModel::onStopScan
+                )
+            }
+
+            // ── Result Area ─────────────────────────────────────────────────────
+            item {
+                AnimatedContent(
+                    targetState = uiState,
+                    transitionSpec = {
+                        fadeIn(tween(300)) togetherWith fadeOut(tween(200))
+                    },
+                    label = "PortScanStateTransition"
+                ) { state ->
+                    when (state) {
+                        is PortScanUiState.Idle -> PortScanIdleState()
+                        is PortScanUiState.Scanning -> PortScanProgressCard(state)
+                        is PortScanUiState.Error -> PortScanErrorCard(
+                            message = state.message,
+                            onRetry = viewModel::startScan,
+                            onClear = viewModel::onClear
+                        )
+                        is PortScanUiState.Finished -> { /* results shown below */ }
+                    }
+                }
+            }
+
+            // ── Finished: Summary Card ──────────────────────────────────────────
+            if (uiState is PortScanUiState.Finished) {
+                val summary = (uiState as PortScanUiState.Finished).summary
+                item {
+                    PortScanSummaryCard(
+                        summary = summary,
+                        onCopy = {
+                            clipboard.setText(AnnotatedString(buildScanReport(summary)))
+                        },
+                        onClear = viewModel::onClear
+                    )
+                }
+
+                // ── Open Ports Section ──────────────────────────────────────────
+                val openPorts = summary.results.filter { it.status == PortStatus.OPEN }
+                if (openPorts.isNotEmpty()) {
+                    item {
+                        Text(
+                            text = stringResource(R.string.ports_section_open),
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Bold,
+                            modifier = Modifier.padding(vertical = 4.dp)
+                        )
+                    }
+                    items(openPorts) { portResult ->
+                        PortResultRow(portResult)
+                    }
+                }
+
+                // ── All Results Section ─────────────────────────────────────────
+                val allNonOpen = summary.results.filter { it.status != PortStatus.OPEN }
+                if (allNonOpen.isNotEmpty()) {
+                    var showAll by remember { mutableStateOf(false) }
+                    item {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(
+                                text = stringResource(R.string.ports_section_all),
+                                style = MaterialTheme.typography.titleMedium,
+                                fontWeight = FontWeight.Bold
+                            )
+                            TextButton(onClick = { showAll = !showAll }) {
+                                Text(
+                                    if (showAll) stringResource(R.string.ports_show_open)
+                                    else stringResource(R.string.ports_show_all)
+                                )
+                            }
+                        }
+                    }
+                    if (showAll) {
+                        items(allNonOpen) { portResult ->
+                            PortResultRow(portResult)
+                        }
+                    }
+                }
+
+                // Empty state
+                if (summary.results.none { it.status == PortStatus.OPEN }) {
+                    item {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(32.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text(
+                                text = stringResource(R.string.ports_no_open_ports),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                textAlign = TextAlign.Center
+                            )
+                        }
+                    }
+                }
+            }
+
+            // ── Live results during scan ────────────────────────────────────────
+            if (uiState is PortScanUiState.Scanning) {
+                val scanning = uiState as PortScanUiState.Scanning
+                val openLive = scanning.liveResults.filter { it.status == PortStatus.OPEN }
+                if (openLive.isNotEmpty()) {
+                    item {
+                        Text(
+                            text = stringResource(R.string.ports_section_open),
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Bold,
+                            modifier = Modifier.padding(vertical = 4.dp)
+                        )
+                    }
+                    items(openLive) { portResult ->
+                        PortResultRow(portResult)
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ── Header ───────────────────────────────────────────────────────────────────
 
 @Composable
-fun PortsScreen() {
-    ToolPlaceholderContent(
-        toolName    = "Port Scanner",
-        toolIcon    = Icons.Default.Search,
-        description = "Scan TCP/UDP ports on any host to check which services are reachable.",
-        features    = listOf(
-            "Custom port range and common presets",
-            "Service name resolution per port",
-            "Animated real-time progress bar",
-            "Save and share scan reports"
-        )
+private fun PortScanHeader() {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(16.dp))
+            .background(
+                Brush.linearGradient(
+                    colors = listOf(
+                        MaterialTheme.colorScheme.primaryContainer,
+                        MaterialTheme.colorScheme.secondaryContainer
+                    )
+                )
+            )
+            .padding(20.dp)
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Box(
+                modifier = Modifier
+                    .size(48.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.15f)),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Search,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(28.dp)
+                )
+            }
+            Spacer(Modifier.width(16.dp))
+            Column {
+                Text(
+                    text = stringResource(R.string.ports_screen_title),
+                    style = MaterialTheme.typography.displaySmall,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+                Text(
+                    text = stringResource(R.string.ports_screen_subtitle),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.8f)
+                )
+            }
+        }
+    }
+}
+
+// ── Input Card ────────────────────────────────────────────────────────────────
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+private fun PortScanInputCard(
+    host: String,
+    selectedPreset: PortScanPreset,
+    startPort: String,
+    endPort: String,
+    timeoutMs: Int,
+    concurrency: Int,
+    isScanning: Boolean,
+    onHostChange: (String) -> Unit,
+    onPresetChange: (PortScanPreset) -> Unit,
+    onStartPortChange: (String) -> Unit,
+    onEndPortChange: (String) -> Unit,
+    onTimeoutChange: (Int) -> Unit,
+    onConcurrencyChange: (Int) -> Unit,
+    onStartScan: () -> Unit,
+    onStopScan: () -> Unit
+) {
+    ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            // Host input
+            OutlinedTextField(
+                value = host,
+                onValueChange = onHostChange,
+                label = { Text(stringResource(R.string.ports_host_label)) },
+                placeholder = { Text(stringResource(R.string.ports_host_placeholder)) },
+                leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
+                trailingIcon = {
+                    if (host.isNotEmpty()) {
+                        IconButton(onClick = { onHostChange("") }) {
+                            Icon(Icons.Default.Clear, contentDescription = stringResource(R.string.clear))
+                        }
+                    }
+                },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                keyboardActions = KeyboardActions(onDone = { onStartScan() }),
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            // Preset selector
+            var presetExpanded by remember { mutableStateOf(false) }
+            ExposedDropdownMenuBox(
+                expanded = presetExpanded,
+                onExpandedChange = { presetExpanded = !presetExpanded }
+            ) {
+                OutlinedTextField(
+                    value = selectedPreset.label,
+                    onValueChange = {},
+                    readOnly = true,
+                    label = { Text(stringResource(R.string.ports_preset_label)) },
+                    trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = presetExpanded) },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .menuAnchor()
+                )
+                ExposedDropdownMenu(
+                    expanded = presetExpanded,
+                    onDismissRequest = { presetExpanded = false }
+                ) {
+                    PortScanPreset.entries.forEach { preset ->
+                        DropdownMenuItem(
+                            text = { Text(preset.label) },
+                            onClick = {
+                                onPresetChange(preset)
+                                presetExpanded = false
+                            }
+                        )
+                    }
+                }
+            }
+
+            // Custom port range (only shown for CUSTOM preset)
+            AnimatedVisibility(visible = selectedPreset == PortScanPreset.CUSTOM) {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    OutlinedTextField(
+                        value = startPort,
+                        onValueChange = onStartPortChange,
+                        label = { Text(stringResource(R.string.ports_start_port_label)) },
+                        singleLine = true,
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                        modifier = Modifier.weight(1f)
+                    )
+                    OutlinedTextField(
+                        value = endPort,
+                        onValueChange = onEndPortChange,
+                        label = { Text(stringResource(R.string.ports_end_port_label)) },
+                        singleLine = true,
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                        modifier = Modifier.weight(1f)
+                    )
+                }
+            }
+
+            // Timeout slider
+            Column {
+                Text(
+                    text = "${stringResource(R.string.ports_timeout_label)}: ${timeoutMs} ms",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Slider(
+                    value = timeoutMs.toFloat(),
+                    onValueChange = { onTimeoutChange(it.toInt()) },
+                    valueRange = 200f..10000f,
+                    steps = 49,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+
+            // Concurrency slider
+            Column {
+                Text(
+                    text = "${stringResource(R.string.ports_concurrency_label)}: $concurrency",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Slider(
+                    value = concurrency.toFloat(),
+                    onValueChange = { onConcurrencyChange(it.toInt()) },
+                    valueRange = 10f..300f,
+                    steps = 29,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+
+            // Action buttons
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                if (isScanning) {
+                    Button(
+                        onClick = onStopScan,
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.error
+                        ),
+                        modifier = Modifier.weight(1f)
+                    ) {
+                        Icon(Icons.Default.Stop, contentDescription = null, modifier = Modifier.size(18.dp))
+                        Spacer(Modifier.width(6.dp))
+                        Text(stringResource(R.string.ports_stop_button))
+                    }
+                } else {
+                    Button(
+                        onClick = onStartScan,
+                        enabled = host.isNotBlank(),
+                        modifier = Modifier.weight(1f)
+                    ) {
+                        Icon(Icons.Default.Search, contentDescription = null, modifier = Modifier.size(18.dp))
+                        Spacer(Modifier.width(6.dp))
+                        Text(stringResource(R.string.ports_scan_button))
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ── Idle State ────────────────────────────────────────────────────────────────
+
+@Composable
+private fun PortScanIdleState() {
+    OutlinedCard(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(32.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(64.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.surfaceVariant),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Search,
+                    contentDescription = null,
+                    modifier = Modifier.size(32.dp),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            Text(
+                text = stringResource(R.string.ports_idle_title),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold
+            )
+            Text(
+                text = stringResource(R.string.ports_idle_subtitle),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center
+            )
+        }
+    }
+}
+
+// ── Scanning Progress ─────────────────────────────────────────────────────────
+
+@Composable
+private fun PortScanProgressCard(state: PortScanUiState.Scanning) {
+    val animatedProgress by animateFloatAsState(
+        targetValue = state.progress,
+        animationSpec = spring(dampingRatio = Spring.DampingRatioNoBouncy),
+        label = "ScanProgress"
     )
+
+    // Pulsing animation for the indicator
+    val infiniteTransition = rememberInfiniteTransition(label = "ScanPulse")
+    val pulse by infiniteTransition.animateFloat(
+        initialValue = 0.85f,
+        targetValue = 1.0f,
+        animationSpec = infiniteRepeatable(
+            tween(800, easing = LinearEasing),
+            RepeatMode.Reverse
+        ),
+        label = "ScanPulseScale"
+    )
+
+    ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = stringResource(R.string.ports_scanning_title),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold
+                )
+                CircularProgressIndicator(
+                    modifier = Modifier.size(28.dp),
+                    strokeCap = StrokeCap.Round,
+                    strokeWidth = 3.dp
+                )
+            }
+
+            // Progress bar
+            LinearProgressIndicator(
+                progress = { animatedProgress },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(8.dp)
+                    .clip(RoundedCornerShape(4.dp)),
+                strokeCap = StrokeCap.Round
+            )
+
+            Text(
+                text = stringResource(
+                    R.string.ports_progress_format,
+                    state.scannedCount,
+                    state.totalCount
+                ),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+
+            // Live stats
+            val openSoFar = state.liveResults.count { it.status == PortStatus.OPEN }
+            if (openSoFar > 0) {
+                HorizontalDivider()
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Box(
+                        modifier = Modifier
+                            .size(10.dp)
+                            .clip(CircleShape)
+                            .background(MaterialTheme.colorScheme.primary)
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Text(
+                        text = "$openSoFar ${stringResource(R.string.ports_open_ports).lowercase()} found so far",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.primary,
+                        fontWeight = FontWeight.Medium
+                    )
+                }
+            }
+        }
+    }
+}
+
+// ── Error State ───────────────────────────────────────────────────────────────
+
+@Composable
+private fun PortScanErrorCard(
+    message: String,
+    onRetry: () -> Unit,
+    onClear: () -> Unit
+) {
+    ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = Icons.Default.Warning,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.size(20.dp)
+                )
+                Spacer(Modifier.width(8.dp))
+                Text(
+                    text = stringResource(R.string.ports_error_title),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.error,
+                    fontWeight = FontWeight.Bold
+                )
+            }
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                FilledTonalButton(onClick = onRetry) {
+                    Icon(Icons.Default.Refresh, contentDescription = null, modifier = Modifier.size(16.dp))
+                    Spacer(Modifier.width(4.dp))
+                    Text(stringResource(R.string.ports_retry_button))
+                }
+                TextButton(onClick = onClear) {
+                    Text(stringResource(R.string.ports_clear_button))
+                }
+            }
+        }
+    }
+}
+
+// ── Summary Card ──────────────────────────────────────────────────────────────
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun PortScanSummaryCard(
+    summary: PortScanSummary,
+    onCopy: () -> Unit,
+    onClear: () -> Unit
+) {
+    ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            // Header row
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = stringResource(R.string.ports_result_header),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold
+                )
+                Row {
+                    IconButton(onClick = onCopy) {
+                        Icon(Icons.Default.ContentCopy, contentDescription = stringResource(R.string.ports_copy_report))
+                    }
+                    IconButton(onClick = onClear) {
+                        Icon(Icons.Default.Clear, contentDescription = stringResource(R.string.ports_clear_button))
+                    }
+                }
+            }
+
+            // Host info
+            SelectionContainer {
+                Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                    Text(
+                        text = "${stringResource(R.string.ports_host_label_result)}: ${summary.host}",
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontFamily = FontFamily.Monospace
+                    )
+                    summary.resolvedIp?.let { ip ->
+                        Text(
+                            text = stringResource(R.string.ports_resolved_ip, ip),
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontFamily = FontFamily.Monospace,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    Text(
+                        text = "${stringResource(R.string.ports_duration_label)}: " +
+                                stringResource(R.string.ports_scan_duration, summary.scanDurationMs),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+
+            HorizontalDivider()
+
+            // Stats chips
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                StatChip(
+                    label = stringResource(R.string.ports_open_ports),
+                    value = summary.openPorts.toString(),
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+                StatChip(
+                    label = stringResource(R.string.ports_closed_ports),
+                    value = summary.closedPorts.toString(),
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                    contentColor = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                StatChip(
+                    label = stringResource(R.string.ports_filtered_ports),
+                    value = summary.filteredPorts.toString(),
+                    containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onTertiaryContainer
+                )
+                StatChip(
+                    label = stringResource(R.string.ports_total_scanned),
+                    value = summary.totalPorts.toString(),
+                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onSecondaryContainer
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun StatChip(
+    label: String,
+    value: String,
+    containerColor: Color,
+    contentColor: Color
+) {
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(8.dp))
+            .background(containerColor)
+            .padding(horizontal = 12.dp, vertical = 6.dp)
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(
+                text = value,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = contentColor
+            )
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelSmall,
+                color = contentColor.copy(alpha = 0.8f)
+            )
+        }
+    }
+}
+
+// ── Port Result Row ───────────────────────────────────────────────────────────
+
+@Composable
+private fun PortResultRow(result: PortScanResult) {
+    val statusColor = when (result.status) {
+        PortStatus.OPEN     -> MaterialTheme.colorScheme.primary
+        PortStatus.CLOSED   -> MaterialTheme.colorScheme.onSurfaceVariant
+        PortStatus.FILTERED -> MaterialTheme.colorScheme.tertiary
+    }
+    val statusLabel = when (result.status) {
+        PortStatus.OPEN     -> R.string.ports_open_label
+        PortStatus.CLOSED   -> R.string.ports_closed_label
+        PortStatus.FILTERED -> R.string.ports_filtered_label
+    }
+    val cardAlpha = when (result.status) {
+        PortStatus.OPEN -> 1f
+        else -> 0.65f
+    }
+
+    OutlinedCard(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 2.dp)
+    ) {
+        Row(
+            modifier = Modifier.padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            // Port status indicator dot
+            Box(
+                modifier = Modifier
+                    .size(10.dp)
+                    .clip(CircleShape)
+                    .background(statusColor)
+            )
+            Spacer(Modifier.width(10.dp))
+
+            // Port number
+            Text(
+                text = result.port.toString(),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                fontFamily = FontFamily.Monospace,
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.width(52.dp)
+            )
+
+            Column(modifier = Modifier.weight(1f)) {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    // Service name
+                    result.serviceName?.let { name ->
+                        Text(
+                            text = name,
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
+                    // Status badge
+                    Box(
+                        modifier = Modifier
+                            .clip(RoundedCornerShape(4.dp))
+                            .background(statusColor.copy(alpha = 0.15f))
+                            .padding(horizontal = 6.dp, vertical = 2.dp)
+                    ) {
+                        Text(
+                            text = stringResource(statusLabel),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = statusColor,
+                            fontWeight = FontWeight.Bold
+                        )
+                    }
+                }
+
+                // Service description
+                result.serviceDescription?.let { desc ->
+                    Text(
+                        text = desc,
+                        style = MaterialTheme.typography.bodyMedium.copy(
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        ),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+
+                // Banner
+                result.banner?.let { banner ->
+                    Text(
+                        text = banner,
+                        style = MaterialTheme.typography.labelSmall,
+                        fontFamily = FontFamily.Monospace,
+                        color = MaterialTheme.colorScheme.secondary,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            }
+
+            // Response time
+            Text(
+                text = "${result.responseTimeMs}${stringResource(R.string.ports_ms_suffix)}",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontFamily = FontFamily.Monospace,
+                modifier = Modifier.padding(start = 8.dp)
+            )
+        }
+    }
+}
+
+// ── Report builder ────────────────────────────────────────────────────────────
+
+private fun buildScanReport(summary: PortScanSummary): String = buildString {
+    appendLine("=== Port Scan Report ===")
+    appendLine("Host: ${summary.host}")
+    summary.resolvedIp?.let { appendLine("IP: $it") }
+    appendLine("Ports scanned: ${summary.totalPorts}")
+    appendLine("Duration: ${summary.scanDurationMs} ms")
+    appendLine()
+    appendLine("Open:     ${summary.openPorts}")
+    appendLine("Closed:   ${summary.closedPorts}")
+    appendLine("Filtered: ${summary.filteredPorts}")
+    appendLine()
+    val openPorts = summary.results.filter { it.status == PortStatus.OPEN }
+    if (openPorts.isNotEmpty()) {
+        appendLine("--- Open Ports ---")
+        openPorts.forEach { r ->
+            val service = r.serviceName ?: "unknown"
+            val banner = r.banner?.let { " | $it" } ?: ""
+            appendLine("  ${r.port.toString().padEnd(6)} $service${banner}")
+        }
+    } else {
+        appendLine("No open ports found.")
+    }
 }

--- a/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/portscan/PortScanViewModel.kt
+++ b/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/portscan/PortScanViewModel.kt
@@ -1,0 +1,134 @@
+package com.example.netswissknife.app.ui.screens.portscan
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.netswissknife.core.domain.PortScanFlowResult
+import com.example.netswissknife.core.domain.PortScanParams
+import com.example.netswissknife.core.domain.PortScanPreset
+import com.example.netswissknife.core.domain.PortScanUseCase
+import com.example.netswissknife.core.network.portscan.PortScanResult
+import com.example.netswissknife.core.network.portscan.PortScanSummary
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/** All possible UI states for the port scanner screen. */
+sealed interface PortScanUiState {
+    object Idle : PortScanUiState
+    data class Scanning(
+        val liveResults: List<PortScanResult>,
+        val scannedCount: Int,
+        val totalCount: Int,
+        val progress: Float = if (totalCount > 0) scannedCount.toFloat() / totalCount else 0f
+    ) : PortScanUiState
+    data class Finished(val summary: PortScanSummary) : PortScanUiState
+    data class Error(val message: String) : PortScanUiState
+}
+
+@HiltViewModel
+class PortScanViewModel @Inject constructor(
+    private val portScanUseCase: PortScanUseCase
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<PortScanUiState>(PortScanUiState.Idle)
+    val uiState: StateFlow<PortScanUiState> = _uiState.asStateFlow()
+
+    // ── Form state ────────────────────────────────────────────────────────────
+
+    private val _host = MutableStateFlow("")
+    val host: StateFlow<String> = _host.asStateFlow()
+
+    private val _selectedPreset = MutableStateFlow(PortScanPreset.COMMON)
+    val selectedPreset: StateFlow<PortScanPreset> = _selectedPreset.asStateFlow()
+
+    private val _startPort = MutableStateFlow("1")
+    val startPort: StateFlow<String> = _startPort.asStateFlow()
+
+    private val _endPort = MutableStateFlow("1024")
+    val endPort: StateFlow<String> = _endPort.asStateFlow()
+
+    private val _timeoutMs = MutableStateFlow(2000)
+    val timeoutMs: StateFlow<Int> = _timeoutMs.asStateFlow()
+
+    private val _concurrency = MutableStateFlow(100)
+    val concurrency: StateFlow<Int> = _concurrency.asStateFlow()
+
+    private var scanJob: Job? = null
+
+    // ── User actions ──────────────────────────────────────────────────────────
+
+    fun onHostChange(value: String) { _host.value = value }
+
+    fun onPresetChange(preset: PortScanPreset) { _selectedPreset.value = preset }
+
+    fun onStartPortChange(value: String) { _startPort.value = value }
+
+    fun onEndPortChange(value: String) { _endPort.value = value }
+
+    fun onTimeoutChange(value: Int) { _timeoutMs.value = value }
+
+    fun onConcurrencyChange(value: Int) { _concurrency.value = value }
+
+    fun onClear() {
+        scanJob?.cancel()
+        _uiState.value = PortScanUiState.Idle
+    }
+
+    fun onStopScan() {
+        scanJob?.cancel()
+        val current = _uiState.value
+        if (current is PortScanUiState.Scanning) {
+            // Build partial summary from live results
+            val partial = com.example.netswissknife.core.network.portscan.PortScanSummary(
+                host = _host.value,
+                resolvedIp = null,
+                scannedPorts = current.liveResults.map { it.port },
+                openPorts = current.liveResults.count { it.status == com.example.netswissknife.core.network.portscan.PortStatus.OPEN },
+                closedPorts = current.liveResults.count { it.status == com.example.netswissknife.core.network.portscan.PortStatus.CLOSED },
+                filteredPorts = current.liveResults.count { it.status == com.example.netswissknife.core.network.portscan.PortStatus.FILTERED },
+                scanDurationMs = 0L,
+                results = current.liveResults.sortedBy { it.port }
+            )
+            _uiState.value = PortScanUiState.Finished(partial)
+        }
+    }
+
+    fun startScan() {
+        scanJob?.cancel()
+        val liveResults = mutableListOf<PortScanResult>()
+
+        val params = PortScanParams(
+            host = _host.value,
+            preset = _selectedPreset.value,
+            startPort = _startPort.value.toIntOrNull() ?: 1,
+            endPort = _endPort.value.toIntOrNull() ?: 1024,
+            timeoutMs = _timeoutMs.value,
+            concurrency = _concurrency.value
+        )
+
+        scanJob = viewModelScope.launch {
+            portScanUseCase(params).collect { result ->
+                when (result) {
+                    is PortScanFlowResult.ValidationError -> {
+                        _uiState.value = PortScanUiState.Error(result.message)
+                    }
+                    is PortScanFlowResult.PortScanned -> {
+                        liveResults.add(result.result)
+                        _uiState.value = PortScanUiState.Scanning(
+                            liveResults = liveResults.toList(),
+                            scannedCount = result.scannedCount,
+                            totalCount = result.totalCount
+                        )
+                    }
+                    is PortScanFlowResult.ScanComplete -> {
+                        _uiState.value = PortScanUiState.Finished(result.summary)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -76,6 +76,58 @@
     <string name="ping_chart_title">RTT Chart</string>
     <string name="ping_progress_format">%1$d / %2$d</string>
 
+    <!-- Port Scanner Screen -->
+    <string name="ports_screen_title">Port Scanner</string>
+    <string name="ports_screen_subtitle">Probe TCP ports and identify running services</string>
+
+    <!-- Port Scanner Input -->
+    <string name="ports_host_label">Host or IP address</string>
+    <string name="ports_host_placeholder">e.g. example.com or 192.168.1.1</string>
+    <string name="ports_preset_label">Port preset</string>
+    <string name="ports_start_port_label">Start port</string>
+    <string name="ports_end_port_label">End port</string>
+    <string name="ports_timeout_label">Timeout (ms)</string>
+    <string name="ports_concurrency_label">Concurrency</string>
+    <string name="ports_scan_button">Scan Ports</string>
+    <string name="ports_stop_button">Stop Scan</string>
+    <string name="ports_clear_button">Clear</string>
+    <string name="ports_retry_button">Retry</string>
+    <string name="ports_share_button">Share Report</string>
+
+    <!-- Port Scanner States -->
+    <string name="ports_idle_title">Enter a host to scan</string>
+    <string name="ports_idle_subtitle">Supports hostnames and IPv4/IPv6 addresses</string>
+    <string name="ports_scanning_title">Scanning ports…</string>
+    <string name="ports_error_title">Scan failed</string>
+    <string name="ports_complete_title">Scan complete</string>
+
+    <!-- Port Scanner Results -->
+    <string name="ports_result_header">Scan Results</string>
+    <string name="ports_open_ports">Open</string>
+    <string name="ports_closed_ports">Closed</string>
+    <string name="ports_filtered_ports">Filtered</string>
+    <string name="ports_total_scanned">Scanned</string>
+    <string name="ports_duration_label">Duration</string>
+    <string name="ports_host_label_result">Host</string>
+    <string name="ports_ip_label">IP Address</string>
+    <string name="ports_progress_format">%1$d / %2$d ports</string>
+    <string name="ports_port_prefix">Port</string>
+    <string name="ports_service_label">Service</string>
+    <string name="ports_banner_label">Banner</string>
+    <string name="ports_response_time_label">Response</string>
+    <string name="ports_ms_suffix">ms</string>
+    <string name="ports_no_open_ports">No open ports found</string>
+    <string name="ports_open_label">OPEN</string>
+    <string name="ports_closed_label">CLOSED</string>
+    <string name="ports_filtered_label">FILTERED</string>
+    <string name="ports_section_open">Open Ports</string>
+    <string name="ports_section_all">All Results</string>
+    <string name="ports_copy_report">Copy report</string>
+    <string name="ports_show_all">Show all ports</string>
+    <string name="ports_show_open">Show open only</string>
+    <string name="ports_resolved_ip">Resolved IP: %1$s</string>
+    <string name="ports_scan_duration">%1$d ms</string>
+
     <!-- DNS Record labels -->
     <string name="dns_ipv4_prefix">IPv4</string>
     <string name="dns_ipv6_prefix">IPv6</string>

--- a/core-domain/src/main/kotlin/com/example/netswissknife/core/domain/PortScanFlowResult.kt
+++ b/core-domain/src/main/kotlin/com/example/netswissknife/core/domain/PortScanFlowResult.kt
@@ -1,0 +1,23 @@
+package com.example.netswissknife.core.domain
+
+import com.example.netswissknife.core.network.portscan.PortScanResult
+import com.example.netswissknife.core.network.portscan.PortScanSummary
+
+/** Events emitted by [PortScanUseCase] while a scan is in progress. */
+sealed interface PortScanFlowResult {
+    /** A single port result with scan progress. */
+    data class PortScanned(
+        val result: PortScanResult,
+        val scannedCount: Int,
+        val totalCount: Int
+    ) : PortScanFlowResult
+
+    /** The scan completed successfully. */
+    data class ScanComplete(val summary: PortScanSummary) : PortScanFlowResult
+
+    /** Input validation failed before the scan started. */
+    data class ValidationError(val message: String) : PortScanFlowResult
+}
+
+val PortScanFlowResult.isError: Boolean
+    get() = this is PortScanFlowResult.ValidationError

--- a/core-domain/src/main/kotlin/com/example/netswissknife/core/domain/PortScanParams.kt
+++ b/core-domain/src/main/kotlin/com/example/netswissknife/core/domain/PortScanParams.kt
@@ -1,0 +1,60 @@
+package com.example.netswissknife.core.domain
+
+/** Preset port ranges for the port scanner. */
+enum class PortScanPreset(
+    val label: String,
+    val portsProvider: () -> List<Int>
+) {
+    COMMON(
+        label = "Common services",
+        portsProvider = {
+            listOf(21, 22, 23, 25, 53, 80, 110, 143, 443, 465, 587,
+                993, 995, 3306, 3389, 5432, 5900, 6379, 8080, 8443, 8888, 9200, 27017)
+        }
+    ),
+    WELL_KNOWN(
+        label = "Well-known (1–1024)",
+        portsProvider = { (1..1024).toList() }
+    ),
+    WEB(
+        label = "Web services",
+        portsProvider = { listOf(80, 443, 8000, 8080, 8081, 8443, 8888, 3000, 4000, 5000) }
+    ),
+    DATABASE(
+        label = "Databases",
+        portsProvider = { listOf(1433, 1521, 3306, 5432, 5433, 6379, 9200, 9300, 11211, 27017, 27018, 28015) }
+    ),
+    MAIL(
+        label = "Mail services",
+        portsProvider = { listOf(25, 110, 143, 465, 587, 993, 995) }
+    ),
+    REMOTE(
+        label = "Remote access",
+        portsProvider = { listOf(22, 23, 3389, 5900, 5901, 1194, 1723) }
+    ),
+    CUSTOM(
+        label = "Custom range",
+        portsProvider = { emptyList() }
+    );
+
+    val ports: List<Int> get() = portsProvider()
+}
+
+/**
+ * Parameters for a port scan operation.
+ *
+ * @param host        Hostname or IP to scan.
+ * @param preset      The [PortScanPreset] to use. If [PortScanPreset.CUSTOM], [startPort]/[endPort] are used.
+ * @param startPort   Custom range start (only used when preset is [PortScanPreset.CUSTOM]).
+ * @param endPort     Custom range end (only used when preset is [PortScanPreset.CUSTOM]).
+ * @param timeoutMs   Per-port connection timeout in milliseconds.
+ * @param concurrency Max simultaneous port probes.
+ */
+data class PortScanParams(
+    val host: String,
+    val preset: PortScanPreset = PortScanPreset.COMMON,
+    val startPort: Int = 1,
+    val endPort: Int = 1024,
+    val timeoutMs: Int = 2000,
+    val concurrency: Int = 100
+)

--- a/core-domain/src/main/kotlin/com/example/netswissknife/core/domain/PortScanUseCase.kt
+++ b/core-domain/src/main/kotlin/com/example/netswissknife/core/domain/PortScanUseCase.kt
@@ -1,0 +1,96 @@
+package com.example.netswissknife.core.domain
+
+import com.example.netswissknife.core.network.HostValidator
+import com.example.netswissknife.core.network.portscan.PortScanRepository
+import com.example.netswissknife.core.network.portscan.PortScanUpdate
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+/**
+ * Use case that validates [PortScanParams] and delegates to [PortScanRepository].
+ *
+ * Validation rules:
+ * - Host must not be blank and must be a valid hostname/IPv4
+ * - For CUSTOM preset: startPort and endPort must be in 1–65535, startPort ≤ endPort
+ * - Max custom range: 10 000 ports
+ * - timeoutMs must be in 100–30 000
+ * - concurrency must be in 1–500
+ */
+class PortScanUseCase(private val repository: PortScanRepository) {
+
+    operator fun invoke(params: PortScanParams): Flow<PortScanFlowResult> = flow {
+        val host = params.host.trim()
+
+        // Validate host
+        if (host.isBlank()) {
+            emit(PortScanFlowResult.ValidationError("Host must not be blank"))
+            return@flow
+        }
+        if (!HostValidator.isValidHostname(host)) {
+            emit(PortScanFlowResult.ValidationError("Invalid hostname or IP address: \"$host\""))
+            return@flow
+        }
+
+        // Validate timeout
+        if (params.timeoutMs < 100 || params.timeoutMs > 30_000) {
+            emit(PortScanFlowResult.ValidationError("Timeout must be between 100 ms and 30 000 ms"))
+            return@flow
+        }
+
+        // Validate concurrency
+        if (params.concurrency < 1 || params.concurrency > 500) {
+            emit(PortScanFlowResult.ValidationError("Concurrency must be between 1 and 500"))
+            return@flow
+        }
+
+        // Resolve ports to scan
+        val portsToScan: List<Int> = if (params.preset == PortScanPreset.CUSTOM) {
+            if (params.startPort < 1 || params.startPort > 65_535) {
+                emit(PortScanFlowResult.ValidationError("Start port must be between 1 and 65 535"))
+                return@flow
+            }
+            if (params.endPort < 1 || params.endPort > 65_535) {
+                emit(PortScanFlowResult.ValidationError("End port must be between 1 and 65 535"))
+                return@flow
+            }
+            if (params.startPort > params.endPort) {
+                emit(PortScanFlowResult.ValidationError("Start port must be ≤ end port"))
+                return@flow
+            }
+            val rangeSize = params.endPort - params.startPort + 1
+            if (rangeSize > 10_000) {
+                emit(PortScanFlowResult.ValidationError("Custom range must not exceed 10 000 ports (got $rangeSize)"))
+                return@flow
+            }
+            (params.startPort..params.endPort).toList()
+        } else {
+            params.preset.ports
+        }
+
+        if (portsToScan.isEmpty()) {
+            emit(PortScanFlowResult.ValidationError("No ports to scan in the selected preset"))
+            return@flow
+        }
+
+        // Delegate to repository and map updates
+        repository.scan(
+            host = host,
+            ports = portsToScan,
+            timeoutMs = params.timeoutMs,
+            concurrency = params.concurrency
+        ).collect { update ->
+            when (update) {
+                is PortScanUpdate.PortResult -> emit(
+                    PortScanFlowResult.PortScanned(
+                        result = update.result,
+                        scannedCount = update.scannedCount,
+                        totalCount = update.totalCount
+                    )
+                )
+                is PortScanUpdate.Complete -> emit(
+                    PortScanFlowResult.ScanComplete(update.summary)
+                )
+            }
+        }
+    }
+}

--- a/core-domain/src/test/kotlin/com/example/netswissknife/core/domain/PortScanUseCaseTest.kt
+++ b/core-domain/src/test/kotlin/com/example/netswissknife/core/domain/PortScanUseCaseTest.kt
@@ -1,0 +1,225 @@
+package com.example.netswissknife.core.domain
+
+import com.example.netswissknife.core.network.portscan.PortConnectChecker
+import com.example.netswissknife.core.network.portscan.PortConnectResult
+import com.example.netswissknife.core.network.portscan.PortScanRepository
+import com.example.netswissknife.core.network.portscan.PortScanRepositoryImpl
+import com.example.netswissknife.core.network.portscan.PortStatus
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("PortScanUseCase")
+class PortScanUseCaseTest {
+
+    private val openChecker: PortConnectChecker = { _, _ ->
+        PortConnectResult(PortStatus.OPEN, 5L, null)
+    }
+
+    private fun makeUseCase(checker: PortConnectChecker = openChecker): PortScanUseCase =
+        PortScanUseCase(PortScanRepositoryImpl(checker = checker))
+
+    @Nested
+    @DisplayName("host validation")
+    inner class HostValidation {
+
+        @Test
+        fun `blank host emits ValidationError`() = runTest {
+            val results = makeUseCase().invoke(PortScanParams(host = "   ")).toList()
+            assertTrue(results.first() is PortScanFlowResult.ValidationError)
+        }
+
+        @Test
+        fun `empty host emits ValidationError`() = runTest {
+            val results = makeUseCase().invoke(PortScanParams(host = "")).toList()
+            assertTrue(results.first() is PortScanFlowResult.ValidationError)
+        }
+
+        @Test
+        fun `invalid host emits ValidationError`() = runTest {
+            val results = makeUseCase().invoke(PortScanParams(host = "not a valid host!!")).toList()
+            assertTrue(results.first() is PortScanFlowResult.ValidationError)
+        }
+
+        @Test
+        fun `valid hostname is accepted`() = runTest {
+            val results = makeUseCase().invoke(
+                PortScanParams(host = "example.com", preset = PortScanPreset.WEB)
+            ).toList()
+            assertTrue(results.none { it.isError })
+        }
+
+        @Test
+        fun `valid IPv4 is accepted`() = runTest {
+            val results = makeUseCase().invoke(
+                PortScanParams(host = "192.168.1.1", preset = PortScanPreset.WEB)
+            ).toList()
+            assertTrue(results.none { it.isError })
+        }
+
+        @Test
+        fun `host is trimmed before validation`() = runTest {
+            val results = makeUseCase().invoke(
+                PortScanParams(host = "  8.8.8.8  ", preset = PortScanPreset.WEB)
+            ).toList()
+            assertTrue(results.none { it.isError })
+        }
+    }
+
+    @Nested
+    @DisplayName("timeout validation")
+    inner class TimeoutValidation {
+
+        @Test
+        fun `timeout below 100 emits error`() = runTest {
+            val results = makeUseCase().invoke(
+                PortScanParams(host = "8.8.8.8", timeoutMs = 99)
+            ).toList()
+            assertTrue(results.first() is PortScanFlowResult.ValidationError)
+        }
+
+        @Test
+        fun `timeout above 30000 emits error`() = runTest {
+            val results = makeUseCase().invoke(
+                PortScanParams(host = "8.8.8.8", timeoutMs = 30001)
+            ).toList()
+            assertTrue(results.first() is PortScanFlowResult.ValidationError)
+        }
+
+        @Test
+        fun `timeout of 100 is valid`() = runTest {
+            val results = makeUseCase().invoke(
+                PortScanParams(host = "8.8.8.8", timeoutMs = 100, preset = PortScanPreset.WEB)
+            ).toList()
+            assertTrue(results.none { it.isError })
+        }
+
+        @Test
+        fun `timeout of 30000 is valid`() = runTest {
+            val results = makeUseCase().invoke(
+                PortScanParams(host = "8.8.8.8", timeoutMs = 30000, preset = PortScanPreset.WEB)
+            ).toList()
+            assertTrue(results.none { it.isError })
+        }
+    }
+
+    @Nested
+    @DisplayName("concurrency validation")
+    inner class ConcurrencyValidation {
+
+        @Test
+        fun `concurrency of 0 emits error`() = runTest {
+            val results = makeUseCase().invoke(
+                PortScanParams(host = "8.8.8.8", concurrency = 0)
+            ).toList()
+            assertTrue(results.first() is PortScanFlowResult.ValidationError)
+        }
+
+        @Test
+        fun `concurrency above 500 emits error`() = runTest {
+            val results = makeUseCase().invoke(
+                PortScanParams(host = "8.8.8.8", concurrency = 501)
+            ).toList()
+            assertTrue(results.first() is PortScanFlowResult.ValidationError)
+        }
+    }
+
+    @Nested
+    @DisplayName("custom port range validation")
+    inner class CustomRangeValidation {
+
+        @Test
+        fun `startPort of 0 emits error`() = runTest {
+            val results = makeUseCase().invoke(
+                PortScanParams(host = "8.8.8.8", preset = PortScanPreset.CUSTOM, startPort = 0, endPort = 100)
+            ).toList()
+            assertTrue(results.first() is PortScanFlowResult.ValidationError)
+        }
+
+        @Test
+        fun `endPort above 65535 emits error`() = runTest {
+            val results = makeUseCase().invoke(
+                PortScanParams(host = "8.8.8.8", preset = PortScanPreset.CUSTOM, startPort = 1, endPort = 65536)
+            ).toList()
+            assertTrue(results.first() is PortScanFlowResult.ValidationError)
+        }
+
+        @Test
+        fun `startPort greater than endPort emits error`() = runTest {
+            val results = makeUseCase().invoke(
+                PortScanParams(host = "8.8.8.8", preset = PortScanPreset.CUSTOM, startPort = 100, endPort = 80)
+            ).toList()
+            assertTrue(results.first() is PortScanFlowResult.ValidationError)
+        }
+
+        @Test
+        fun `range larger than 10000 emits error`() = runTest {
+            val results = makeUseCase().invoke(
+                PortScanParams(host = "8.8.8.8", preset = PortScanPreset.CUSTOM, startPort = 1, endPort = 10001)
+            ).toList()
+            assertTrue(results.first() is PortScanFlowResult.ValidationError)
+        }
+
+        @Test
+        fun `valid custom range of exactly 1 is accepted`() = runTest {
+            val results = makeUseCase().invoke(
+                PortScanParams(host = "8.8.8.8", preset = PortScanPreset.CUSTOM, startPort = 80, endPort = 80)
+            ).toList()
+            assertTrue(results.none { it.isError })
+        }
+
+        @Test
+        fun `valid custom range of 10000 is accepted`() = runTest {
+            val results = makeUseCase().invoke(
+                PortScanParams(host = "8.8.8.8", preset = PortScanPreset.CUSTOM, startPort = 1, endPort = 10000)
+            ).toList()
+            assertTrue(results.none { it.isError })
+        }
+    }
+
+    @Nested
+    @DisplayName("preset scanning")
+    inner class PresetScanning {
+
+        @Test
+        fun `web preset emits PortScanned for each web port`() = runTest {
+            val portResults = makeUseCase().invoke(
+                PortScanParams(host = "8.8.8.8", preset = PortScanPreset.WEB)
+            )
+                .filterIsInstance<PortScanFlowResult.PortScanned>()
+                .toList()
+            assertEquals(PortScanPreset.WEB.ports.size, portResults.size)
+        }
+
+        @Test
+        fun `scan emits ScanComplete as last event`() = runTest {
+            val results = makeUseCase().invoke(
+                PortScanParams(host = "8.8.8.8", preset = PortScanPreset.WEB)
+            ).toList()
+            assertTrue(results.last() is PortScanFlowResult.ScanComplete)
+        }
+
+        @Test
+        fun `summary open count is correct`() = runTest {
+            val allOpen: PortConnectChecker = { _, _ ->
+                PortConnectResult(PortStatus.OPEN, 5L, null)
+            }
+            val complete = makeUseCase(allOpen).invoke(
+                PortScanParams(host = "8.8.8.8", preset = PortScanPreset.WEB)
+            )
+                .filterIsInstance<PortScanFlowResult.ScanComplete>()
+                .toList()
+                .first()
+            assertEquals(PortScanPreset.WEB.ports.size, complete.summary.openPorts)
+        }
+    }
+}

--- a/core-network/src/main/kotlin/com/example/netswissknife/core/network/portscan/PortScanRepository.kt
+++ b/core-network/src/main/kotlin/com/example/netswissknife/core/network/portscan/PortScanRepository.kt
@@ -1,0 +1,40 @@
+package com.example.netswissknife.core.network.portscan
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Contract for a port scanner.
+ *
+ * Implementations emit one [PortScanUpdate] per scanned port, then a final
+ * [PortScanUpdate.Complete] when all ports have been tested.
+ */
+interface PortScanRepository {
+
+    /**
+     * Scan the given [ports] on [host] and emit progress updates as a cold [Flow].
+     *
+     * @param host        Hostname or IP address to scan.
+     * @param ports       Ordered list of port numbers to scan.
+     * @param timeoutMs   Per-port TCP connection timeout in milliseconds.
+     * @param concurrency Maximum number of ports probed simultaneously.
+     */
+    fun scan(
+        host: String,
+        ports: List<Int>,
+        timeoutMs: Int,
+        concurrency: Int
+    ): Flow<PortScanUpdate>
+}
+
+/** Progress events emitted during a scan. */
+sealed interface PortScanUpdate {
+    /** Emitted after each port is probed. */
+    data class PortResult(
+        val result: PortScanResult,
+        val scannedCount: Int,
+        val totalCount: Int
+    ) : PortScanUpdate
+
+    /** Emitted once when all ports have been scanned. */
+    data class Complete(val summary: PortScanSummary) : PortScanUpdate
+}

--- a/core-network/src/main/kotlin/com/example/netswissknife/core/network/portscan/PortScanRepositoryImpl.kt
+++ b/core-network/src/main/kotlin/com/example/netswissknife/core/network/portscan/PortScanRepositoryImpl.kt
@@ -1,0 +1,148 @@
+package com.example.netswissknife.core.network.portscan
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.net.ConnectException
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.net.Socket
+import java.net.SocketTimeoutException
+
+/** Functional type for a single TCP port probe. Injected for testability. */
+typealias PortConnectChecker = (host: String, port: Int) -> PortConnectResult
+
+/** Raw result of a single TCP connection attempt. */
+data class PortConnectResult(
+    val status: PortStatus,
+    val responseTimeMs: Long,
+    val banner: String?
+)
+
+/**
+ * Production [PortScanRepository] that uses TCP socket connections to determine port status.
+ *
+ * Ports are tested in batches of [concurrency] simultaneously using coroutines.
+ * For each open port, a brief banner read is attempted on well-known service ports.
+ *
+ * @param checker     Functional hook for the TCP probe. Defaults to the real socket implementation.
+ * @param timeoutMs   Connection timeout (used in [DEFAULT_CHECKER] when [checker] is default).
+ */
+class PortScanRepositoryImpl(
+    private val checker: PortConnectChecker = DEFAULT_CHECKER,
+) : PortScanRepository {
+
+    companion object {
+        /**
+         * Default TCP checker: attempts a real socket connection and optionally reads a banner.
+         * The timeout is passed as the per-call socket timeout.
+         */
+        val DEFAULT_CHECKER: PortConnectChecker = { host, port ->
+            val start = System.currentTimeMillis()
+            var socket: Socket? = null
+            try {
+                socket = Socket()
+                socket.connect(InetSocketAddress(host, port), 2000)
+                val responseTime = System.currentTimeMillis() - start
+
+                // Attempt banner grab for open port (short read)
+                val banner: String? = try {
+                    socket.soTimeout = 300
+                    val inputStream = socket.getInputStream()
+                    val bytes = ByteArray(256)
+                    val read = inputStream.read(bytes)
+                    if (read > 0) {
+                        String(bytes, 0, read).trim().take(200)
+                            .filter { it.isLetterOrDigit() || it.isWhitespace() || it in "-./()@:_+" }
+                    } else null
+                } catch (_: Exception) { null }
+
+                PortConnectResult(PortStatus.OPEN, responseTime, banner)
+            } catch (e: ConnectException) {
+                PortConnectResult(PortStatus.CLOSED, System.currentTimeMillis() - start, null)
+            } catch (e: SocketTimeoutException) {
+                PortConnectResult(PortStatus.FILTERED, System.currentTimeMillis() - start, null)
+            } catch (_: Exception) {
+                PortConnectResult(PortStatus.FILTERED, System.currentTimeMillis() - start, null)
+            } finally {
+                try { socket?.close() } catch (_: Exception) {}
+            }
+        }
+    }
+
+    override fun scan(
+        host: String,
+        ports: List<Int>,
+        timeoutMs: Int,
+        concurrency: Int
+    ): Flow<PortScanUpdate> = flow {
+        val startTime = System.currentTimeMillis()
+        val results = mutableListOf<PortScanResult>()
+        var scannedCount = 0
+        val mutex = Mutex()
+
+        // Resolve host IP once for the summary
+        val resolvedIp: String? = try {
+            InetAddress.getByName(host).hostAddress
+        } catch (_: Exception) { null }
+
+        val effectiveConcurrency = concurrency.coerceAtLeast(1).coerceAtMost(500)
+        val portChunks = ports.chunked(effectiveConcurrency)
+
+        for (chunk in portChunks) {
+            coroutineScope {
+                val deferreds = chunk.map { port ->
+                    async(Dispatchers.IO) {
+                        val connectResult = checker(host, port)
+                        val portInfo = WellKnownPorts.getInfo(port)
+                        PortScanResult(
+                            port = port,
+                            status = connectResult.status,
+                            serviceName = portInfo?.serviceName ?: WellKnownPorts.getServiceName(port),
+                            serviceDescription = portInfo?.description,
+                            banner = connectResult.banner,
+                            responseTimeMs = connectResult.responseTimeMs
+                        )
+                    }
+                }
+
+                // Collect results as they complete and emit updates
+                for (deferred in deferreds) {
+                    val portResult = deferred.await()
+                    val currentCount: Int
+                    mutex.withLock {
+                        results.add(portResult)
+                        scannedCount++
+                        currentCount = scannedCount
+                    }
+                    emit(
+                        PortScanUpdate.PortResult(
+                            result = portResult,
+                            scannedCount = currentCount,
+                            totalCount = ports.size
+                        )
+                    )
+                }
+            }
+        }
+
+        // Build and emit summary
+        val summary = PortScanSummary(
+            host = host,
+            resolvedIp = resolvedIp,
+            scannedPorts = ports,
+            openPorts = results.count { it.status == PortStatus.OPEN },
+            closedPorts = results.count { it.status == PortStatus.CLOSED },
+            filteredPorts = results.count { it.status == PortStatus.FILTERED },
+            scanDurationMs = System.currentTimeMillis() - startTime,
+            results = results.sortedBy { it.port }
+        )
+        emit(PortScanUpdate.Complete(summary))
+    }.flowOn(Dispatchers.IO)
+}

--- a/core-network/src/main/kotlin/com/example/netswissknife/core/network/portscan/PortScanResult.kt
+++ b/core-network/src/main/kotlin/com/example/netswissknife/core/network/portscan/PortScanResult.kt
@@ -1,0 +1,20 @@
+package com.example.netswissknife.core.network.portscan
+
+/**
+ * Result of scanning a single port on a host.
+ *
+ * @param port            The port number that was scanned.
+ * @param status          Whether the port is [PortStatus.OPEN], [PortStatus.CLOSED] or [PortStatus.FILTERED].
+ * @param serviceName     Resolved service name (e.g. "HTTP", "SSH"), or null if unknown.
+ * @param serviceDescription Human-readable description of the service, or null.
+ * @param banner          Protocol banner grabbed from the port (e.g. SSH version string), or null.
+ * @param responseTimeMs  Round-trip time for the connection probe in milliseconds.
+ */
+data class PortScanResult(
+    val port: Int,
+    val status: PortStatus,
+    val serviceName: String?,
+    val serviceDescription: String?,
+    val banner: String?,
+    val responseTimeMs: Long
+)

--- a/core-network/src/main/kotlin/com/example/netswissknife/core/network/portscan/PortScanSummary.kt
+++ b/core-network/src/main/kotlin/com/example/netswissknife/core/network/portscan/PortScanSummary.kt
@@ -1,0 +1,26 @@
+package com.example.netswissknife.core.network.portscan
+
+/**
+ * Aggregated summary produced after a complete port scan session.
+ *
+ * @param host            The hostname / IP that was scanned.
+ * @param resolvedIp      The resolved IP address, or null if resolution failed.
+ * @param scannedPorts    The list of port numbers that were scanned.
+ * @param openPorts       Count of ports with [PortStatus.OPEN].
+ * @param closedPorts     Count of ports with [PortStatus.CLOSED].
+ * @param filteredPorts   Count of ports with [PortStatus.FILTERED].
+ * @param scanDurationMs  Total wall-clock time for the scan.
+ * @param results         The individual [PortScanResult] for every scanned port.
+ */
+data class PortScanSummary(
+    val host: String,
+    val resolvedIp: String?,
+    val scannedPorts: List<Int>,
+    val openPorts: Int,
+    val closedPorts: Int,
+    val filteredPorts: Int,
+    val scanDurationMs: Long,
+    val results: List<PortScanResult>
+) {
+    val totalPorts: Int get() = scannedPorts.size
+}

--- a/core-network/src/main/kotlin/com/example/netswissknife/core/network/portscan/PortStatus.kt
+++ b/core-network/src/main/kotlin/com/example/netswissknife/core/network/portscan/PortStatus.kt
@@ -1,0 +1,11 @@
+package com.example.netswissknife.core.network.portscan
+
+/** The result status of scanning a single port. */
+enum class PortStatus {
+    /** TCP connection succeeded – the port is accepting connections. */
+    OPEN,
+    /** TCP connection was actively refused. */
+    CLOSED,
+    /** Connection attempt timed out – port may be firewalled. */
+    FILTERED
+}

--- a/core-network/src/main/kotlin/com/example/netswissknife/core/network/portscan/WellKnownPorts.kt
+++ b/core-network/src/main/kotlin/com/example/netswissknife/core/network/portscan/WellKnownPorts.kt
@@ -1,0 +1,133 @@
+package com.example.netswissknife.core.network.portscan
+
+/** Metadata about a well-known port. */
+data class PortInfo(
+    val serviceName: String,
+    val description: String,
+    val protocol: String = "TCP"
+)
+
+/**
+ * Registry of well-known TCP ports with service name and description.
+ * Used for service identification after a port is found open.
+ */
+object WellKnownPorts {
+
+    private val registry: Map<Int, PortInfo> = mapOf(
+        // System / Infrastructure
+        20   to PortInfo("FTP-DATA",  "FTP data transfer"),
+        21   to PortInfo("FTP",       "File Transfer Protocol"),
+        22   to PortInfo("SSH",       "Secure Shell"),
+        23   to PortInfo("TELNET",    "Telnet – unencrypted remote shell"),
+        25   to PortInfo("SMTP",      "Simple Mail Transfer Protocol"),
+        53   to PortInfo("DNS",       "Domain Name System"),
+        67   to PortInfo("DHCP",      "DHCP server", "UDP"),
+        68   to PortInfo("DHCP",      "DHCP client", "UDP"),
+        69   to PortInfo("TFTP",      "Trivial File Transfer Protocol", "UDP"),
+        80   to PortInfo("HTTP",      "Hypertext Transfer Protocol"),
+        88   to PortInfo("Kerberos",  "Kerberos authentication"),
+        110  to PortInfo("POP3",      "Post Office Protocol v3"),
+        119  to PortInfo("NNTP",      "Network News Transfer Protocol"),
+        123  to PortInfo("NTP",       "Network Time Protocol", "UDP"),
+        135  to PortInfo("MSRPC",     "Microsoft RPC endpoint mapper"),
+        137  to PortInfo("NetBIOS-NS","NetBIOS Name Service", "UDP"),
+        139  to PortInfo("NetBIOS",   "NetBIOS session service"),
+        143  to PortInfo("IMAP",      "Internet Message Access Protocol"),
+        161  to PortInfo("SNMP",      "Simple Network Management Protocol", "UDP"),
+        162  to PortInfo("SNMP-TRAP", "SNMP trap receiver", "UDP"),
+        179  to PortInfo("BGP",       "Border Gateway Protocol"),
+        194  to PortInfo("IRC",       "Internet Relay Chat"),
+        389  to PortInfo("LDAP",      "Lightweight Directory Access Protocol"),
+        443  to PortInfo("HTTPS",     "HTTP over TLS/SSL"),
+        445  to PortInfo("SMB",       "Server Message Block (file sharing)"),
+        465  to PortInfo("SMTPS",     "SMTP over TLS"),
+        514  to PortInfo("SYSLOG",    "Syslog", "UDP"),
+        515  to PortInfo("LPD",       "Line Printer Daemon"),
+        543  to PortInfo("Klogin",    "Kerberos login"),
+        544  to PortInfo("Kshell",    "Kerberos remote shell"),
+        587  to PortInfo("SMTP-SUB",  "SMTP mail submission"),
+        631  to PortInfo("IPP",       "Internet Printing Protocol"),
+        636  to PortInfo("LDAPS",     "LDAP over TLS/SSL"),
+        666  to PortInfo("DOOM",      "DOOM multiplayer game"),
+        993  to PortInfo("IMAPS",     "IMAP over TLS/SSL"),
+        995  to PortInfo("POP3S",     "POP3 over TLS/SSL"),
+
+        // Remote Access / VPN
+        1194 to PortInfo("OpenVPN",   "OpenVPN"),
+        1433 to PortInfo("MSSQL",     "Microsoft SQL Server"),
+        1434 to PortInfo("MSSQL-BR",  "Microsoft SQL Server Browser", "UDP"),
+        1521 to PortInfo("OracleDB",  "Oracle Database"),
+        1723 to PortInfo("PPTP",      "Point-to-Point Tunneling Protocol"),
+        1900 to PortInfo("UPNP",      "Universal Plug and Play", "UDP"),
+        2049 to PortInfo("NFS",       "Network File System"),
+        2082 to PortInfo("cPanel",    "cPanel web hosting control panel"),
+        2083 to PortInfo("cPanel-S",  "cPanel over TLS"),
+        2181 to PortInfo("ZooKeeper", "Apache ZooKeeper"),
+        2375 to PortInfo("Docker",    "Docker daemon API (unencrypted)"),
+        2376 to PortInfo("Docker-S",  "Docker daemon API (TLS)"),
+        2483 to PortInfo("OracleDB-S","Oracle DB TLS listener"),
+        3000 to PortInfo("HTTP-Dev",  "Development web server (Node/Rails)"),
+        3306 to PortInfo("MySQL",     "MySQL / MariaDB database"),
+        3389 to PortInfo("RDP",       "Windows Remote Desktop Protocol"),
+        3690 to PortInfo("SVN",       "Subversion version control"),
+        4000 to PortInfo("HTTP-Dev",  "Development web server"),
+        4444 to PortInfo("Metasploit","Metasploit reverse shell (default)"),
+        4848 to PortInfo("GlassFish", "GlassFish admin console"),
+        5000 to PortInfo("UPnP/Dev",  "UPnP or development server"),
+        5432 to PortInfo("PostgreSQL","PostgreSQL database"),
+        5433 to PortInfo("PostgreSQL","PostgreSQL (alternate)"),
+        5601 to PortInfo("Kibana",    "Kibana log visualization"),
+        5672 to PortInfo("AMQP",      "RabbitMQ AMQP"),
+        5900 to PortInfo("VNC",       "Virtual Network Computing"),
+        5901 to PortInfo("VNC-1",     "VNC display :1"),
+        6379 to PortInfo("Redis",     "Redis in-memory data store"),
+        6443 to PortInfo("k8s-API",   "Kubernetes API server"),
+        7001 to PortInfo("WebLogic",  "Oracle WebLogic Server"),
+        8000 to PortInfo("HTTP-Alt",  "HTTP alternate port"),
+        8080 to PortInfo("HTTP-Proxy","HTTP proxy / alternate web"),
+        8081 to PortInfo("HTTP-Alt2", "HTTP alternate port 2"),
+        8443 to PortInfo("HTTPS-Alt", "HTTPS alternate port"),
+        8888 to PortInfo("Jupyter",   "Jupyter Notebook server"),
+        9000 to PortInfo("SonarQube", "SonarQube / PHP-FPM"),
+        9090 to PortInfo("Prometheus","Prometheus monitoring"),
+        9092 to PortInfo("Kafka",     "Apache Kafka broker"),
+        9200 to PortInfo("Elastic",   "Elasticsearch REST API"),
+        9300 to PortInfo("Elastic-N", "Elasticsearch node-to-node"),
+        9418 to PortInfo("Git",       "Git protocol"),
+        10000 to PortInfo("Webmin",   "Webmin admin panel"),
+        11211 to PortInfo("Memcached","Memcached in-memory cache"),
+        15672 to PortInfo("RabbitMQ", "RabbitMQ management UI"),
+        25565 to PortInfo("Minecraft","Minecraft game server"),
+        27017 to PortInfo("MongoDB",  "MongoDB document database"),
+        27018 to PortInfo("MongoDB-S","MongoDB shard server"),
+        28015 to PortInfo("RethinkDB","RethinkDB database"),
+        50000 to PortInfo("Jenkins",  "Jenkins CI server"),
+        54321 to PortInfo("PostgreSQL","PostgreSQL (alternate)"),
+    )
+
+    /** Returns the [PortInfo] for a given port number, or null if unknown. */
+    fun getInfo(port: Int): PortInfo? = registry[port]
+
+    /** Returns the service name for a port, or a generic label. */
+    fun getServiceName(port: Int): String =
+        registry[port]?.serviceName ?: when (port) {
+            in 1..1023   -> "Well-known"
+            in 1024..49151 -> "Registered"
+            else           -> "Dynamic/Private"
+        }
+
+    /** Common port presets for quick scanning. */
+    val COMMON_PORTS = listOf(
+        21, 22, 23, 25, 53, 80, 110, 143, 443, 465, 587,
+        993, 995, 3306, 3389, 5432, 5900, 6379, 8080, 8443,
+        8888, 9200, 27017
+    )
+
+    val WEB_PORTS = listOf(80, 443, 8000, 8080, 8081, 8443, 8888, 3000, 4000, 5000)
+
+    val DATABASE_PORTS = listOf(1433, 1521, 3306, 5432, 5433, 6379, 9200, 9300, 11211, 27017, 27018, 28015)
+
+    val MAIL_PORTS = listOf(25, 110, 143, 465, 587, 993, 995)
+
+    val REMOTE_ACCESS_PORTS = listOf(22, 23, 3389, 5900, 5901, 1194, 1723)
+}

--- a/core-network/src/test/kotlin/com/example/netswissknife/core/network/portscan/PortScanRepositoryImplTest.kt
+++ b/core-network/src/test/kotlin/com/example/netswissknife/core/network/portscan/PortScanRepositoryImplTest.kt
@@ -1,0 +1,278 @@
+package com.example.netswissknife.core.network.portscan
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@DisplayName("PortScanRepositoryImpl")
+class PortScanRepositoryImplTest {
+
+    // ── Helper checkers ────────────────────────────────────────────────────────
+
+    private fun openChecker(rtMs: Long = 5L): PortConnectChecker = { _, _ ->
+        PortConnectResult(status = PortStatus.OPEN, responseTimeMs = rtMs, banner = null)
+    }
+
+    private fun closedChecker(): PortConnectChecker = { _, _ ->
+        PortConnectResult(status = PortStatus.CLOSED, responseTimeMs = 1L, banner = null)
+    }
+
+    private fun filteredChecker(): PortConnectChecker = { _, _ ->
+        PortConnectResult(status = PortStatus.FILTERED, responseTimeMs = 2000L, banner = null)
+    }
+
+    private fun bannerChecker(banner: String): PortConnectChecker = { _, _ ->
+        PortConnectResult(status = PortStatus.OPEN, responseTimeMs = 10L, banner = banner)
+    }
+
+    // ── Emission count ─────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("emission count")
+    inner class EmissionCount {
+
+        @Test
+        fun `emits one PortResult per port plus one Complete`() = runTest {
+            val repo = PortScanRepositoryImpl(checker = openChecker())
+            val ports = listOf(80, 443, 8080)
+            val updates = repo.scan("example.com", ports, timeoutMs = 1000, concurrency = 10).toList()
+            val portResults = updates.filterIsInstance<PortScanUpdate.PortResult>()
+            val completes = updates.filterIsInstance<PortScanUpdate.Complete>()
+            assertEquals(3, portResults.size)
+            assertEquals(1, completes.size)
+        }
+
+        @Test
+        fun `complete is the last event`() = runTest {
+            val repo = PortScanRepositoryImpl(checker = openChecker())
+            val updates = repo.scan("host", listOf(22, 80), timeoutMs = 1000, concurrency = 10).toList()
+            assertTrue(updates.last() is PortScanUpdate.Complete)
+        }
+
+        @Test
+        fun `scanning empty port list emits only Complete`() = runTest {
+            val repo = PortScanRepositoryImpl(checker = openChecker())
+            val updates = repo.scan("host", emptyList(), timeoutMs = 1000, concurrency = 10).toList()
+            assertEquals(1, updates.size)
+            assertTrue(updates.first() is PortScanUpdate.Complete)
+        }
+    }
+
+    // ── Status mapping ─────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("status mapping")
+    inner class StatusMapping {
+
+        @Test
+        fun `open checker produces OPEN status`() = runTest {
+            val repo = PortScanRepositoryImpl(checker = openChecker())
+            val updates = repo.scan("host", listOf(80), timeoutMs = 1000, concurrency = 10).toList()
+            val result = (updates.first() as PortScanUpdate.PortResult).result
+            assertEquals(PortStatus.OPEN, result.status)
+        }
+
+        @Test
+        fun `closed checker produces CLOSED status`() = runTest {
+            val repo = PortScanRepositoryImpl(checker = closedChecker())
+            val updates = repo.scan("host", listOf(80), timeoutMs = 1000, concurrency = 10).toList()
+            val result = (updates.first() as PortScanUpdate.PortResult).result
+            assertEquals(PortStatus.CLOSED, result.status)
+        }
+
+        @Test
+        fun `filtered checker produces FILTERED status`() = runTest {
+            val repo = PortScanRepositoryImpl(checker = filteredChecker())
+            val updates = repo.scan("host", listOf(80), timeoutMs = 1000, concurrency = 10).toList()
+            val result = (updates.first() as PortScanUpdate.PortResult).result
+            assertEquals(PortStatus.FILTERED, result.status)
+        }
+    }
+
+    // ── Service resolution ─────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("service resolution")
+    inner class ServiceResolution {
+
+        @Test
+        fun `port 80 resolves to HTTP`() = runTest {
+            val repo = PortScanRepositoryImpl(checker = openChecker())
+            val updates = repo.scan("host", listOf(80), timeoutMs = 1000, concurrency = 10).toList()
+            val result = (updates.first() as PortScanUpdate.PortResult).result
+            assertEquals("HTTP", result.serviceName)
+        }
+
+        @Test
+        fun `port 443 resolves to HTTPS`() = runTest {
+            val repo = PortScanRepositoryImpl(checker = openChecker())
+            val updates = repo.scan("host", listOf(443), timeoutMs = 1000, concurrency = 10).toList()
+            val result = (updates.first() as PortScanUpdate.PortResult).result
+            assertEquals("HTTPS", result.serviceName)
+        }
+
+        @Test
+        fun `port 22 resolves to SSH`() = runTest {
+            val repo = PortScanRepositoryImpl(checker = openChecker())
+            val updates = repo.scan("host", listOf(22), timeoutMs = 1000, concurrency = 10).toList()
+            val result = (updates.first() as PortScanUpdate.PortResult).result
+            assertEquals("SSH", result.serviceName)
+        }
+
+        @Test
+        fun `unknown port has non-null service name fallback`() = runTest {
+            val repo = PortScanRepositoryImpl(checker = openChecker())
+            val updates = repo.scan("host", listOf(12345), timeoutMs = 1000, concurrency = 10).toList()
+            val result = (updates.first() as PortScanUpdate.PortResult).result
+            assertNotNull(result.serviceName)
+        }
+    }
+
+    // ── Banner grabbing ────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("banner grabbing")
+    inner class BannerGrabbing {
+
+        @Test
+        fun `banner from checker is propagated to result`() = runTest {
+            val repo = PortScanRepositoryImpl(checker = bannerChecker("SSH-2.0-OpenSSH_9.0"))
+            val updates = repo.scan("host", listOf(22), timeoutMs = 1000, concurrency = 10).toList()
+            val result = (updates.first() as PortScanUpdate.PortResult).result
+            assertEquals("SSH-2.0-OpenSSH_9.0", result.banner)
+        }
+
+        @Test
+        fun `null banner is preserved`() = runTest {
+            val repo = PortScanRepositoryImpl(checker = openChecker())
+            val updates = repo.scan("host", listOf(80), timeoutMs = 1000, concurrency = 10).toList()
+            val result = (updates.first() as PortScanUpdate.PortResult).result
+            assertTrue(result.banner == null)
+        }
+    }
+
+    // ── Progress tracking ──────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("progress tracking")
+    inner class ProgressTracking {
+
+        @Test
+        fun `scannedCount increments per emission`() = runTest {
+            val repo = PortScanRepositoryImpl(checker = openChecker())
+            val ports = listOf(80, 443, 8080)
+            val portResults = repo.scan("host", ports, timeoutMs = 1000, concurrency = 10)
+                .filterIsInstance<PortScanUpdate.PortResult>()
+                .toList()
+            val counts = portResults.map { it.scannedCount }.sorted()
+            assertEquals(listOf(1, 2, 3), counts)
+        }
+
+        @Test
+        fun `totalCount matches port list size`() = runTest {
+            val repo = PortScanRepositoryImpl(checker = openChecker())
+            val ports = listOf(80, 443, 8080)
+            val portResults = repo.scan("host", ports, timeoutMs = 1000, concurrency = 10)
+                .filterIsInstance<PortScanUpdate.PortResult>()
+                .toList()
+            assertTrue(portResults.all { it.totalCount == 3 })
+        }
+    }
+
+    // ── Summary ────────────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("scan summary")
+    inner class ScanSummary {
+
+        @Test
+        fun `summary open count matches open results`() = runTest {
+            var callIndex = 0
+            val alternating: PortConnectChecker = { _, _ ->
+                callIndex++
+                if (callIndex % 2 == 1) PortConnectResult(PortStatus.OPEN, 5L, null)
+                else PortConnectResult(PortStatus.CLOSED, 1L, null)
+            }
+            val repo = PortScanRepositoryImpl(checker = alternating)
+            val ports = listOf(80, 443, 8080, 8443)
+            val complete = repo.scan("host", ports, timeoutMs = 1000, concurrency = 10)
+                .filterIsInstance<PortScanUpdate.Complete>()
+                .toList()
+                .first()
+            assertEquals(2, complete.summary.openPorts)
+            assertEquals(2, complete.summary.closedPorts)
+        }
+
+        @Test
+        fun `summary host matches input host`() = runTest {
+            val repo = PortScanRepositoryImpl(checker = openChecker())
+            val complete = repo.scan("example.com", listOf(80), timeoutMs = 1000, concurrency = 10)
+                .filterIsInstance<PortScanUpdate.Complete>()
+                .toList()
+                .first()
+            assertEquals("example.com", complete.summary.host)
+        }
+
+        @Test
+        fun `summary scannedPorts matches input ports`() = runTest {
+            val repo = PortScanRepositoryImpl(checker = openChecker())
+            val ports = listOf(22, 80, 443)
+            val complete = repo.scan("host", ports, timeoutMs = 1000, concurrency = 10)
+                .filterIsInstance<PortScanUpdate.Complete>()
+                .toList()
+                .first()
+            assertEquals(ports.sorted(), complete.summary.scannedPorts.sorted())
+        }
+
+        @Test
+        fun `summary results count matches port list size`() = runTest {
+            val repo = PortScanRepositoryImpl(checker = openChecker())
+            val ports = listOf(22, 80, 443)
+            val complete = repo.scan("host", ports, timeoutMs = 1000, concurrency = 10)
+                .filterIsInstance<PortScanUpdate.Complete>()
+                .toList()
+                .first()
+            assertEquals(3, complete.summary.results.size)
+        }
+    }
+
+    // ── WellKnownPorts ─────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("WellKnownPorts lookup")
+    inner class WellKnownPortsLookup {
+
+        @Test
+        fun `port 3306 returns MySQL`() {
+            assertEquals("MySQL", WellKnownPorts.getInfo(3306)?.serviceName)
+        }
+
+        @Test
+        fun `port 5432 returns PostgreSQL`() {
+            assertEquals("PostgreSQL", WellKnownPorts.getInfo(5432)?.serviceName)
+        }
+
+        @Test
+        fun `port 27017 returns MongoDB`() {
+            assertEquals("MongoDB", WellKnownPorts.getInfo(27017)?.serviceName)
+        }
+
+        @Test
+        fun `unknown port returns null info`() {
+            assertTrue(WellKnownPorts.getInfo(12345) == null)
+        }
+
+        @Test
+        fun `getServiceName for unknown port returns non-null fallback`() {
+            assertTrue(WellKnownPorts.getServiceName(12345).isNotBlank())
+        }
+    }
+}


### PR DESCRIPTION
Adds a complete Port Scanner tool following TDD (red-green-refactor):

core-network:
- PortStatus enum (OPEN/CLOSED/FILTERED)
- PortScanResult & PortScanSummary data classes
- WellKnownPorts registry with 70+ services and preset lists
- PortScanRepository interface with PortScanUpdate sealed events
- PortScanRepositoryImpl: concurrent TCP probing via coroutines,
  service banner grabbing on open ports, configurable concurrency
- PortScanRepositoryImplTest: 25 tests covering status mapping,
  service resolution, banner grabbing, progress tracking, summary

core-domain:
- PortScanPreset enum (COMMON/WELL_KNOWN/WEB/DATABASE/MAIL/REMOTE/CUSTOM)
- PortScanParams data class with validation-ready fields
- PortScanFlowResult sealed interface (PortScanned/ScanComplete/ValidationError)
- PortScanUseCase with full input validation (host, timeout, concurrency,
  custom port range up to 10 000 ports)
- PortScanUseCaseTest: 20+ tests covering all validation paths

app:
- PortScanModule Hilt DI wiring
- PortScanViewModel with Scanning/Idle/Finished/Error UiState and
  live port result streaming via StateFlow
- PortsScreen: animated entrance, gradient header, preset dropdown,
  custom port range input, timeout/concurrency sliders, animated
  LinearProgressIndicator with live open-port counter, ElevatedCard
  results with status badges, service descriptions, banner display,
  copy-to-clipboard report, show-all toggle, AnimatedContent state
  transitions, all strings in strings.xml, full dark-mode safety

https://claude.ai/code/session_01LwJ5VyWxR4DFokSiacCxAs