### PR TITLE
Fix @Composable invocation outside composable context in PortsScreen

### DIFF
--- a/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/PortsScreen.kt
+++ b/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/PortsScreen.kt
@@ -119,6 +119,7 @@ fun PortsScreen(viewModel: PortScanViewModel = hiltViewModel()) {
 
     val keyboardController = LocalSoftwareKeyboardController.current
     val clipboard = LocalClipboardManager.current
+    var showAll by remember { mutableStateOf(false) }
 
     AnimatedVisibility(
         visible = screenVisible,
@@ -212,7 +213,6 @@ fun PortsScreen(viewModel: PortScanViewModel = hiltViewModel()) {
                 // ── All Results Section ─────────────────────────────────────────
                 val allNonOpen = summary.results.filter { it.status != PortStatus.OPEN }
                 if (allNonOpen.isNotEmpty()) {
-                    var showAll by remember { mutableStateOf(false) }
                     item {
                         Row(
                             modifier = Modifier.fillMaxWidth(),


### PR DESCRIPTION
Move showAll state from LazyListScope (non-composable) to PortsScreen
composable level where remember{} calls are valid.

https://claude.ai/code/session_01FMFiiYcjTvwiTaHezngU7a