### PR TITLE
fix: avoid test timeout in port validation test for 10 000-port range

### DIFF
--- a/core-domain/src/test/kotlin/com/example/netswissknife/core/domain/PortScanUseCaseTest.kt
+++ b/core-domain/src/test/kotlin/com/example/netswissknife/core/domain/PortScanUseCaseTest.kt
@@ -9,6 +9,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -179,10 +180,10 @@ class PortScanUseCaseTest {
 
         @Test
         fun `valid custom range of 10000 is accepted`() = runTest {
-            val results = makeUseCase().invoke(
+            val firstResult = makeUseCase().invoke(
                 PortScanParams(host = "8.8.8.8", preset = PortScanPreset.CUSTOM, startPort = 1, endPort = 10000)
-            ).toList()
-            assertTrue(results.none { it.isError })
+            ).first()
+            assertTrue(!firstResult.isError)
         }
     }
 


### PR DESCRIPTION
Replace toList() with first() so the test only checks that the first
emission is not a ValidationError, rather than waiting for all 10 000
port scan results to complete.  The previous approach exceeded the
runTest timeout, causing a JobCancellationException.

https://claude.ai/code/session_0189qiUCZ5jh1AqQzd2P6HzK