### PR TITLE
fix: avoid test timeout for valid slash-16 subnet validation test

### DIFF
--- a/core-domain/src/test/kotlin/com/example/netswissknife/core/domain/LanScanUseCaseTest.kt
+++ b/core-domain/src/test/kotlin/com/example/netswissknife/core/domain/LanScanUseCaseTest.kt
@@ -79,8 +79,10 @@ class LanScanUseCaseTest {
 
         @Test
         fun `valid slash-16 subnet is accepted`() = runTest {
-            val results = makeUseCase().invoke(LanScanParams(subnet = "10.0.0.0/16")).toList()
-            assertTrue(results.none { it is LanScanFlowResult.ValidationError })
+            // Use .first() to avoid collecting all 65 534 host results from a /16 scan.
+            // If validation fails the first emission is ValidationError; otherwise validation passed.
+            val first = makeUseCase().invoke(LanScanParams(subnet = "10.0.0.0/16")).first()
+            assertTrue(first !is LanScanFlowResult.ValidationError)
         }
 
         @Test


### PR DESCRIPTION
The /16 subnet has 65 534 hosts; collecting the full scan via .toList()
exceeded the runTest timeout even with an instant-returning hostChecker.
Changed to .first() so the test cancels the flow after the first emission,
which is sufficient to confirm that no ValidationError was emitted.

https://claude.ai/code/session_017bmXd7k575mwwmhgMoRpDy