### PR TITLE
Redesign homepage and bottom navigation for scalability

### DIFF
--- a/app/src/main/kotlin/com/example/netswissknife/app/MainActivity.kt
+++ b/app/src/main/kotlin/com/example/netswissknife/app/MainActivity.kt
@@ -5,18 +5,29 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.MoreHoriz
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.example.netswissknife.app.ui.navigation.AppNavHost
+import com.example.netswissknife.app.ui.navigation.AppNavigationViewModel
+import com.example.netswissknife.app.ui.navigation.MoreToolsSheet
 import com.example.netswissknife.app.ui.navigation.NavRoutes
 import com.example.netswissknife.app.ui.theme.NetSwissKnifeTheme
 import dagger.hilt.android.AndroidEntryPoint
@@ -37,38 +48,93 @@ class MainActivity : ComponentActivity() {
 
 @Composable
 fun NetSwissKnifeApp(navController: NavHostController) {
+    val navViewModel: AppNavigationViewModel = hiltViewModel()
+    val pinnedRoutes by navViewModel.pinnedRoutes.collectAsState()
+    var showMoreSheet by remember { mutableStateOf(false) }
+
     Scaffold(
-        bottomBar = { AppBottomNavigationBar(navController) }
+        bottomBar = {
+            AppBottomNavigationBar(
+                navController  = navController,
+                pinnedRoutes   = pinnedRoutes,
+                onMoreClick    = { showMoreSheet = true }
+            )
+        }
     ) { innerPadding ->
         AppNavHost(
             navController = navController,
             modifier      = Modifier.padding(innerPadding)
         )
     }
+
+    if (showMoreSheet) {
+        MoreToolsSheet(
+            pinnedRoutes = pinnedRoutes,
+            onNavigate   = { route ->
+                showMoreSheet = false
+                navController.navigate(route) {
+                    popUpTo(navController.graph.startDestinationId) { saveState = true }
+                    launchSingleTop = true
+                    restoreState    = true
+                }
+            },
+            onTogglePin  = navViewModel::togglePin,
+            maxPinned    = AppNavigationViewModel.MAX_PINNED,
+            onDismiss    = { showMoreSheet = false }
+        )
+    }
 }
 
 @Composable
-private fun AppBottomNavigationBar(navController: NavHostController) {
+private fun AppBottomNavigationBar(
+    navController: NavHostController,
+    pinnedRoutes: List<String>,
+    onMoreClick: () -> Unit
+) {
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = navBackStackEntry?.destination?.route
 
+    val pinnedTools = pinnedRoutes.mapNotNull { route ->
+        NavRoutes.allTools.find { it.route == route }
+    }
+
     NavigationBar {
-        NavRoutes.bottomNavItems.forEach { item ->
-            val selected = currentRoute == item.route
+        // Home is always first
+        NavigationBarItem(
+            selected = currentRoute == NavRoutes.Home.route,
+            onClick  = {
+                navController.navigate(NavRoutes.Home.route) {
+                    popUpTo(navController.graph.startDestinationId) { saveState = true }
+                    launchSingleTop = true
+                    restoreState    = true
+                }
+            },
+            icon  = { Icon(Icons.Default.Home, contentDescription = null) },
+            label = { Text(stringResource(R.string.nav_home)) }
+        )
+
+        // Pinned tools (dynamic, up to MAX_PINNED)
+        pinnedTools.forEach { tool ->
             NavigationBarItem(
-                selected = selected,
+                selected = currentRoute == tool.route,
                 onClick  = {
-                    navController.navigate(item.route) {
+                    navController.navigate(tool.route) {
                         popUpTo(navController.graph.startDestinationId) { saveState = true }
                         launchSingleTop = true
                         restoreState    = true
                     }
                 },
-                icon = {
-                    Icon(imageVector = item.icon, contentDescription = item.label)
-                },
-                label = { Text(item.label) }
+                icon  = { Icon(tool.icon, contentDescription = null) },
+                label = { Text(tool.shortLabel) }
             )
         }
+
+        // "More" is always last
+        NavigationBarItem(
+            selected = false,
+            onClick  = onMoreClick,
+            icon     = { Icon(Icons.Default.MoreHoriz, contentDescription = null) },
+            label    = { Text(stringResource(R.string.nav_more)) }
+        )
     }
 }

--- a/app/src/main/kotlin/com/example/netswissknife/app/ui/navigation/AppNavigation.kt
+++ b/app/src/main/kotlin/com/example/netswissknife/app/ui/navigation/AppNavigation.kt
@@ -74,7 +74,15 @@ fun AppNavHost(navController: NavHostController, modifier: Modifier = Modifier) 
             exitTransition   = { homeExitTransition() },
             popEnterTransition  = { homeEnterTransition() },
             popExitTransition   = { homeExitTransition() }
-        ) { HomeScreen() }
+        ) {
+            HomeScreen(onNavigate = { route ->
+                navController.navigate(route) {
+                    popUpTo(navController.graph.startDestinationId) { saveState = true }
+                    launchSingleTop = true
+                    restoreState    = true
+                }
+            })
+        }
 
         composable(NavRoutes.Ping.route)       { PingScreen() }
         composable(NavRoutes.Traceroute.route) { TracerouteScreen() }

--- a/app/src/main/kotlin/com/example/netswissknife/app/ui/navigation/AppNavigationViewModel.kt
+++ b/app/src/main/kotlin/com/example/netswissknife/app/ui/navigation/AppNavigationViewModel.kt
@@ -1,0 +1,29 @@
+package com.example.netswissknife.app.ui.navigation
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+@HiltViewModel
+class AppNavigationViewModel @Inject constructor() : ViewModel() {
+
+    private val _pinnedRoutes = MutableStateFlow(NavRoutes.defaultPinnedRoutes)
+    val pinnedRoutes: StateFlow<List<String>> = _pinnedRoutes.asStateFlow()
+
+    fun togglePin(route: String) {
+        val current = _pinnedRoutes.value.toMutableList()
+        if (current.contains(route)) {
+            current.remove(route)
+        } else if (current.size < MAX_PINNED) {
+            current.add(route)
+        }
+        _pinnedRoutes.value = current
+    }
+
+    companion object {
+        const val MAX_PINNED = 3
+    }
+}

--- a/app/src/main/kotlin/com/example/netswissknife/app/ui/navigation/MoreToolsSheet.kt
+++ b/app/src/main/kotlin/com/example/netswissknife/app/ui/navigation/MoreToolsSheet.kt
@@ -1,0 +1,189 @@
+package com.example.netswissknife.app.ui.navigation
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PushPin
+import androidx.compose.material.icons.outlined.PushPin
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.example.netswissknife.app.R
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MoreToolsSheet(
+    pinnedRoutes: List<String>,
+    onNavigate: (String) -> Unit,
+    onTogglePin: (String) -> Unit,
+    maxPinned: Int,
+    onDismiss: () -> Unit
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 20.dp)
+        ) {
+            Text(
+                text = stringResource(R.string.more_sheet_title),
+                style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
+                color = MaterialTheme.colorScheme.onSurface
+            )
+
+            Spacer(Modifier.height(4.dp))
+
+            Text(
+                text = stringResource(R.string.more_sheet_subtitle, maxPinned),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+
+            Spacer(Modifier.height(16.dp))
+
+            NavRoutes.allTools.forEachIndexed { index, tool ->
+                val isPinned = pinnedRoutes.contains(tool.route)
+                val canPin = isPinned || pinnedRoutes.size < maxPinned
+
+                ToolSheetRow(
+                    tool = tool,
+                    isPinned = isPinned,
+                    canPin = canPin,
+                    onNavigate = { onNavigate(tool.route) },
+                    onTogglePin = { onTogglePin(tool.route) }
+                )
+
+                if (index < NavRoutes.allTools.lastIndex) {
+                    HorizontalDivider(
+                        modifier = Modifier.padding(start = 64.dp),
+                        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
+                    )
+                }
+            }
+
+            Spacer(Modifier.height(24.dp))
+        }
+    }
+}
+
+@Composable
+private fun ToolSheetRow(
+    tool: ToolInfo,
+    isPinned: Boolean,
+    canPin: Boolean,
+    onNavigate: () -> Unit,
+    onTogglePin: () -> Unit
+) {
+    val pinTint by animateColorAsState(
+        targetValue = when {
+            isPinned -> MaterialTheme.colorScheme.primary
+            canPin   -> MaterialTheme.colorScheme.onSurfaceVariant
+            else     -> MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.38f)
+        },
+        animationSpec = tween(200),
+        label = "pin-tint-${tool.route}"
+    )
+    val iconBg by animateColorAsState(
+        targetValue = if (isPinned)
+            MaterialTheme.colorScheme.primaryContainer
+        else
+            MaterialTheme.colorScheme.secondaryContainer,
+        animationSpec = tween(200),
+        label = "icon-bg-${tool.route}"
+    )
+    val iconTint by animateColorAsState(
+        targetValue = if (isPinned)
+            MaterialTheme.colorScheme.onPrimaryContainer
+        else
+            MaterialTheme.colorScheme.onSecondaryContainer,
+        animationSpec = tween(200),
+        label = "icon-tint-${tool.route}"
+    )
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onNavigate)
+            .padding(vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(
+            modifier = Modifier
+                .size(44.dp)
+                .clip(RoundedCornerShape(12.dp))
+                .background(iconBg),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = tool.icon,
+                contentDescription = null,
+                tint = iconTint,
+                modifier = Modifier.size(22.dp)
+            )
+        }
+
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .padding(horizontal = 14.dp)
+        ) {
+            Text(
+                text = tool.label,
+                style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.SemiBold),
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Text(
+                text = tool.description,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+
+        IconButton(
+            onClick = onTogglePin,
+            enabled = canPin
+        ) {
+            Icon(
+                imageVector = if (isPinned) Icons.Filled.PushPin else Icons.Outlined.PushPin,
+                contentDescription = if (isPinned)
+                    stringResource(R.string.more_unpin_description, tool.label)
+                else
+                    stringResource(R.string.more_pin_description, tool.label),
+                tint = pinTint,
+                modifier = Modifier.size(20.dp)
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/com/example/netswissknife/app/ui/navigation/NavRoutes.kt
+++ b/app/src/main/kotlin/com/example/netswissknife/app/ui/navigation/NavRoutes.kt
@@ -9,6 +9,14 @@ import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Wifi
 import androidx.compose.ui.graphics.vector.ImageVector
 
+data class ToolInfo(
+    val route: String,
+    val label: String,
+    val shortLabel: String,
+    val icon: ImageVector,
+    val description: String
+)
+
 sealed class NavRoutes(
     val route: String,
     val label: String,
@@ -16,12 +24,22 @@ sealed class NavRoutes(
 ) {
     object Home : NavRoutes("home", "Home", Icons.Default.Home)
     object Ping : NavRoutes("ping", "Ping", Icons.Default.NetworkCheck)
-    object Traceroute : NavRoutes("traceroute", "Trace", Icons.Default.Router)
-    object Ports : NavRoutes("ports", "Ports", Icons.Default.Search)
-    object Lan : NavRoutes("lan", "LAN", Icons.Default.Wifi)
-    object Dns : NavRoutes("dns", "DNS", Icons.Default.Language)
+    object Traceroute : NavRoutes("traceroute", "Traceroute", Icons.Default.Router)
+    object Ports : NavRoutes("ports", "Port Scanner", Icons.Default.Search)
+    object Lan : NavRoutes("lan", "LAN Scanner", Icons.Default.Wifi)
+    object Dns : NavRoutes("dns", "DNS Lookup", Icons.Default.Language)
 
     companion object {
-        val bottomNavItems = listOf(Home, Ping, Traceroute, Ports, Lan, Dns)
+        /** All navigable tool screens (excluding Home). */
+        val allTools = listOf(
+            ToolInfo("ping",       "Ping",         "Ping",  Icons.Default.NetworkCheck, "ICMP round-trip latency"),
+            ToolInfo("traceroute", "Traceroute",   "Trace", Icons.Default.Router,       "Network path hop analysis"),
+            ToolInfo("ports",      "Port Scanner", "Ports", Icons.Default.Search,       "TCP port reachability"),
+            ToolInfo("lan",        "LAN Scanner",  "LAN",   Icons.Default.Wifi,         "Local device discovery"),
+            ToolInfo("dns",        "DNS Lookup",   "DNS",   Icons.Default.Language,     "Resolve hostnames & records"),
+        )
+
+        /** Default pinned routes shown in the bottom nav (max MAX_PINNED). */
+        val defaultPinnedRoutes = listOf("ping", "dns", "ports")
     }
 }

--- a/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/HomeScreen.kt
+++ b/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/HomeScreen.kt
@@ -24,11 +24,6 @@ import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Language
-import androidx.compose.material.icons.filled.NetworkCheck
-import androidx.compose.material.icons.filled.Router
-import androidx.compose.material.icons.filled.Search
-import androidx.compose.material.icons.filled.Wifi
 import androidx.compose.material.icons.outlined.Hub
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.Icon
@@ -46,28 +41,17 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.example.netswissknife.app.R
+import com.example.netswissknife.app.ui.navigation.NavRoutes
+import com.example.netswissknife.app.ui.navigation.ToolInfo
 import kotlinx.coroutines.delay
 
-private data class ToolCardItem(
-    val name: String,
-    val description: String,
-    val icon: ImageVector
-)
-
-private val toolCards = listOf(
-    ToolCardItem("Ping",         "ICMP round-trip latency",     Icons.Default.NetworkCheck),
-    ToolCardItem("Traceroute",   "Network path hop analysis",   Icons.Default.Router),
-    ToolCardItem("Port Scanner", "TCP port reachability",       Icons.Default.Search),
-    ToolCardItem("LAN Scanner",  "Local device discovery",      Icons.Default.Wifi),
-    ToolCardItem("DNS Lookup",   "Resolve hostnames & records", Icons.Default.Language),
-)
-
 @Composable
-fun HomeScreen() {
+fun HomeScreen(onNavigate: (String) -> Unit) {
     var headerVisible by remember { mutableStateOf(false) }
     var cardsVisible  by remember { mutableStateOf(false) }
 
@@ -94,7 +78,7 @@ fun HomeScreen() {
             visible = cardsVisible,
             enter   = fadeIn(tween(400, delayMillis = 100))
         ) {
-            ToolGrid()
+            ToolGrid(onNavigate = onNavigate)
         }
     }
 }
@@ -112,7 +96,7 @@ private fun HeroHeader() {
                     )
                 )
             )
-            .padding(horizontal = 24.dp, vertical = 32.dp),
+            .padding(horizontal = 24.dp, vertical = 28.dp),
         contentAlignment = Alignment.Center
     ) {
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
@@ -131,7 +115,7 @@ private fun HeroHeader() {
             Box(
                 modifier = Modifier
                     .scale(iconScale)
-                    .size(80.dp)
+                    .size(72.dp)
                     .clip(CircleShape)
                     .background(MaterialTheme.colorScheme.primary),
                 contentAlignment = Alignment.Center
@@ -140,23 +124,23 @@ private fun HeroHeader() {
                     imageVector        = Icons.Outlined.Hub,
                     contentDescription = null,
                     tint               = MaterialTheme.colorScheme.onPrimary,
-                    modifier           = Modifier.size(44.dp)
+                    modifier           = Modifier.size(40.dp)
                 )
             }
 
-            Box(Modifier.height(16.dp))
+            Box(Modifier.height(12.dp))
 
             Text(
-                text      = "Net Swiss Knife",
+                text      = stringResource(R.string.app_name),
                 style     = MaterialTheme.typography.displaySmall.copy(fontWeight = FontWeight.Bold),
                 color     = MaterialTheme.colorScheme.onPrimaryContainer,
                 textAlign = TextAlign.Center
             )
 
-            Box(Modifier.height(6.dp))
+            Box(Modifier.height(4.dp))
 
             Text(
-                text      = "Your all-in-one Android networking toolkit",
+                text      = stringResource(R.string.home_subtitle),
                 style     = MaterialTheme.typography.bodyMedium,
                 color     = MaterialTheme.colorScheme.onSurfaceVariant,
                 textAlign = TextAlign.Center
@@ -166,21 +150,33 @@ private fun HeroHeader() {
 }
 
 @Composable
-private fun ToolGrid() {
-    LazyVerticalGrid(
-        columns               = GridCells.Fixed(2),
-        contentPadding        = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
-        verticalArrangement   = Arrangement.spacedBy(12.dp)
-    ) {
-        itemsIndexed(toolCards) { index, tool ->
-            AnimatedToolCard(tool = tool, delayMs = index * 60)
+private fun ToolGrid(onNavigate: (String) -> Unit) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text     = stringResource(R.string.home_all_tools),
+            style    = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
+            color    = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.padding(horizontal = 20.dp, vertical = 8.dp)
+        )
+        LazyVerticalGrid(
+            columns               = GridCells.Fixed(2),
+            contentPadding        = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalArrangement   = Arrangement.spacedBy(12.dp)
+        ) {
+            itemsIndexed(NavRoutes.allTools) { index, tool ->
+                AnimatedToolCard(
+                    tool    = tool,
+                    delayMs = index * 60,
+                    onClick = { onNavigate(tool.route) }
+                )
+            }
         }
     }
 }
 
 @Composable
-private fun AnimatedToolCard(tool: ToolCardItem, delayMs: Int) {
+private fun AnimatedToolCard(tool: ToolInfo, delayMs: Int, onClick: () -> Unit) {
     var visible by remember { mutableStateOf(false) }
     LaunchedEffect(Unit) {
         delay(delayMs.toLong())
@@ -190,15 +186,16 @@ private fun AnimatedToolCard(tool: ToolCardItem, delayMs: Int) {
     val cardScale by animateFloatAsState(
         targetValue   = if (visible) 1f else 0.85f,
         animationSpec = tween(durationMillis = 300, easing = EaseOutBack),
-        label         = "card-scale-${tool.name}"
+        label         = "card-scale-${tool.route}"
     )
     val cardAlpha by animateFloatAsState(
         targetValue   = if (visible) 1f else 0f,
         animationSpec = tween(250),
-        label         = "card-alpha-${tool.name}"
+        label         = "card-alpha-${tool.route}"
     )
 
     ElevatedCard(
+        onClick  = onClick,
         modifier = Modifier
             .fillMaxWidth()
             .scale(cardScale)
@@ -225,7 +222,7 @@ private fun AnimatedToolCard(tool: ToolCardItem, delayMs: Int) {
             }
 
             Text(
-                text  = tool.name,
+                text  = tool.label,
                 style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold)
             )
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,6 +2,20 @@
 <resources>
     <string name="app_name">Net Swiss Knife</string>
 
+    <!-- Home Screen -->
+    <string name="home_subtitle">Your all-in-one Android networking toolkit</string>
+    <string name="home_all_tools">All Tools</string>
+
+    <!-- Bottom Navigation -->
+    <string name="nav_home">Home</string>
+    <string name="nav_more">More</string>
+
+    <!-- More Tools Sheet -->
+    <string name="more_sheet_title">All Tools</string>
+    <string name="more_sheet_subtitle">Pin up to %1$d tools to the navigation bar</string>
+    <string name="more_pin_description">Pin %1$s</string>
+    <string name="more_unpin_description">Unpin %1$s</string>
+
     <!-- DNS Screen -->
     <string name="dns_screen_title">DNS Lookup</string>
     <string name="dns_screen_subtitle">Query DNS records for any domain</string>


### PR DESCRIPTION
- HomeScreen: tool cards are now tappable and navigate to their respective tool
  (uses ElevatedCard's onClick, replaces non-interactive layout)
- HomeScreen: drives from NavRoutes.allTools so new tools appear automatically
- NavRoutes: extract ToolInfo data class with route, label, shortLabel, icon,
  description; add allTools list and defaultPinnedRoutes
- Bottom nav: replaced fixed 6-item bar with Home + pinned tools + "More" button
  - AppNavigationViewModel holds pinned state (default: Ping, DNS, Ports)
  - Supports up to 3 pinned tools; toggle pin from the "More" sheet
- MoreToolsSheet: new ModalBottomSheet showing all tools with animated pin toggle
  - Icon background and tint animate between pinned/unpinned colours
  - Pin button disabled (but not hidden) when max pins reached
  - Tapping any row navigates directly to that tool
- strings.xml: added home_subtitle, home_all_tools, nav_home, nav_more,
  more_sheet_title/subtitle, more_pin/unpin_description

https://claude.ai/code/session_01574RwW3X6viGSNv38L2SbE