### PR TITLE
fix: resolve LAN scanner crash and add in-app debug logging

### DIFF
--- a/app/src/main/kotlin/com/example/netswissknife/app/MainActivity.kt
+++ b/app/src/main/kotlin/com/example/netswissknife/app/MainActivity.kt
@@ -80,7 +80,13 @@ fun NetSwissKnifeApp(navController: NavHostController) {
             },
             onTogglePin  = navViewModel::togglePin,
             maxPinned    = AppNavigationViewModel.MAX_PINNED,
-            onDismiss    = { showMoreSheet = false }
+            onDismiss    = { showMoreSheet = false },
+            onDebugLogsClick = {
+                showMoreSheet = false
+                navController.navigate(NavRoutes.DebugLogs.route) {
+                    launchSingleTop = true
+                }
+            },
         )
     }
 }

--- a/app/src/main/kotlin/com/example/netswissknife/app/NetSwissKnifeApp.kt
+++ b/app/src/main/kotlin/com/example/netswissknife/app/NetSwissKnifeApp.kt
@@ -1,7 +1,14 @@
 package com.example.netswissknife.app
 
 import android.app.Application
+import com.example.netswissknife.app.util.AppLogger
 import dagger.hilt.android.HiltAndroidApp
 
 @HiltAndroidApp
-class NetSwissKnifeApp : Application()
+class NetSwissKnifeApp : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        AppLogger.init(this)
+        AppLogger.i("App", "NetSwissKnife started (versionName=${packageManager.getPackageInfo(packageName, 0).versionName})")
+    }
+}

--- a/app/src/main/kotlin/com/example/netswissknife/app/ui/navigation/AppNavigation.kt
+++ b/app/src/main/kotlin/com/example/netswissknife/app/ui/navigation/AppNavigation.kt
@@ -21,6 +21,7 @@ import com.example.netswissknife.app.ui.screens.LanScreen
 import com.example.netswissknife.app.ui.screens.PingScreen
 import com.example.netswissknife.app.ui.screens.PortsScreen
 import com.example.netswissknife.app.ui.screens.TracerouteScreen
+import com.example.netswissknife.app.ui.screens.debug.DebugLogScreen
 
 // ── Transition helpers ────────────────────────────────────────────────────────
 
@@ -89,5 +90,6 @@ fun AppNavHost(navController: NavHostController, modifier: Modifier = Modifier) 
         composable(NavRoutes.Ports.route)      { PortsScreen() }
         composable(NavRoutes.Lan.route)        { LanScreen() }
         composable(NavRoutes.Dns.route)        { DnsScreen() }
+        composable(NavRoutes.DebugLogs.route)  { DebugLogScreen() }
     }
 }

--- a/app/src/main/kotlin/com/example/netswissknife/app/ui/navigation/MoreToolsSheet.kt
+++ b/app/src/main/kotlin/com/example/netswissknife/app/ui/navigation/MoreToolsSheet.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.BugReport
 import androidx.compose.material.icons.filled.PushPin
 import androidx.compose.material.icons.outlined.PushPin
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -43,7 +44,8 @@ fun MoreToolsSheet(
     onNavigate: (String) -> Unit,
     onTogglePin: (String) -> Unit,
     maxPinned: Int,
-    onDismiss: () -> Unit
+    onDismiss: () -> Unit,
+    onDebugLogsClick: () -> Unit = {},
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
@@ -89,6 +91,52 @@ fun MoreToolsSheet(
                     HorizontalDivider(
                         modifier = Modifier.padding(start = 64.dp),
                         color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
+                    )
+                }
+            }
+
+            Spacer(Modifier.height(16.dp))
+
+            HorizontalDivider()
+
+            Spacer(Modifier.height(8.dp))
+
+            // Developer / debug section
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable(onClick = onDebugLogsClick)
+                    .padding(vertical = 10.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(44.dp)
+                        .clip(RoundedCornerShape(12.dp))
+                        .background(MaterialTheme.colorScheme.errorContainer),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.BugReport,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onErrorContainer,
+                        modifier = Modifier.size(22.dp),
+                    )
+                }
+                Column(
+                    modifier = Modifier
+                        .weight(1f)
+                        .padding(horizontal = 14.dp),
+                ) {
+                    Text(
+                        text = stringResource(R.string.debug_log_title),
+                        style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.SemiBold),
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                    Text(
+                        text = stringResource(R.string.debug_log_subtitle),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
             }

--- a/app/src/main/kotlin/com/example/netswissknife/app/ui/navigation/NavRoutes.kt
+++ b/app/src/main/kotlin/com/example/netswissknife/app/ui/navigation/NavRoutes.kt
@@ -1,6 +1,7 @@
 package com.example.netswissknife.app.ui.navigation
 
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.BugReport
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Language
 import androidx.compose.material.icons.filled.NetworkCheck
@@ -28,6 +29,7 @@ sealed class NavRoutes(
     object Ports : NavRoutes("ports", "Port Scanner", Icons.Default.Search)
     object Lan : NavRoutes("lan", "LAN Scanner", Icons.Default.Wifi)
     object Dns : NavRoutes("dns", "DNS Lookup", Icons.Default.Language)
+    object DebugLogs : NavRoutes("debug_logs", "Debug Logs", Icons.Default.BugReport)
 
     companion object {
         /** All navigable tool screens (excluding Home). */

--- a/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/debug/DebugLogScreen.kt
+++ b/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/debug/DebugLogScreen.kt
@@ -1,0 +1,230 @@
+package com.example.netswissknife.app.ui.screens.debug
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.slideInVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.BugReport
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.netswissknife.app.R
+import com.example.netswissknife.app.util.AppLogger
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+@Composable
+fun DebugLogScreen() {
+    var logContent by remember { mutableStateOf("Loading…") }
+    var showClearDialog by remember { mutableStateOf(false) }
+    var visible by remember { mutableStateOf(false) }
+    val clipboard = LocalClipboardManager.current
+    val scope = rememberCoroutineScope()
+
+    fun reload() {
+        scope.launch {
+            logContent = withContext(Dispatchers.IO) { AppLogger.getLogContent() }
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        visible = true
+        reload()
+    }
+
+    AnimatedVisibility(
+        visible = visible,
+        enter = fadeIn(tween(400)) + slideInVertically(tween(400)) { it / 6 },
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            // Header card
+            ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(
+                            Brush.linearGradient(
+                                colors = listOf(
+                                    MaterialTheme.colorScheme.tertiaryContainer,
+                                    MaterialTheme.colorScheme.secondaryContainer,
+                                ),
+                                start = Offset(0f, 0f),
+                                end = Offset(Float.MAX_VALUE, Float.MAX_VALUE),
+                            )
+                        )
+                        .padding(20.dp),
+                ) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(16.dp),
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .size(52.dp)
+                                .clip(CircleShape)
+                                .background(MaterialTheme.colorScheme.tertiary.copy(alpha = 0.15f)),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.BugReport,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.tertiary,
+                                modifier = Modifier.size(28.dp),
+                            )
+                        }
+                        Column {
+                            Text(
+                                text = stringResource(R.string.debug_log_title),
+                                style = MaterialTheme.typography.displaySmall,
+                                color = MaterialTheme.colorScheme.onTertiaryContainer,
+                            )
+                            Text(
+                                text = stringResource(R.string.debug_log_subtitle),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.75f),
+                            )
+                        }
+                    }
+                }
+            }
+
+            // Action buttons
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                FilledTonalButton(
+                    onClick = { reload() },
+                    modifier = Modifier.weight(1f),
+                ) {
+                    Icon(Icons.Default.Refresh, contentDescription = null, modifier = Modifier.size(18.dp))
+                    Spacer(Modifier.width(4.dp))
+                    Text(stringResource(R.string.debug_log_refresh))
+                }
+                FilledTonalButton(
+                    onClick = { clipboard.setText(AnnotatedString(logContent)) },
+                    modifier = Modifier.weight(1f),
+                ) {
+                    Icon(Icons.Default.ContentCopy, contentDescription = null, modifier = Modifier.size(18.dp))
+                    Spacer(Modifier.width(4.dp))
+                    Text(stringResource(R.string.debug_log_copy))
+                }
+                OutlinedButton(
+                    onClick = { showClearDialog = true },
+                    modifier = Modifier.weight(1f),
+                ) {
+                    Icon(Icons.Default.Delete, contentDescription = null, modifier = Modifier.size(18.dp))
+                    Spacer(Modifier.width(4.dp))
+                    Text(stringResource(R.string.debug_log_clear))
+                }
+            }
+
+            // Log content card
+            ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f))
+                        .padding(12.dp),
+                ) {
+                    val hScroll = rememberScrollState()
+                    Text(
+                        text = logContent,
+                        style = MaterialTheme.typography.bodySmall.copy(
+                            fontFamily = FontFamily.Monospace,
+                            fontSize = 11.sp,
+                        ),
+                        color = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .horizontalScroll(hScroll),
+                        softWrap = false,
+                    )
+                }
+            }
+
+            Spacer(Modifier.height(8.dp))
+        }
+    }
+
+    if (showClearDialog) {
+        AlertDialog(
+            onDismissRequest = { showClearDialog = false },
+            title = { Text(stringResource(R.string.debug_log_clear_confirm_title)) },
+            text = { Text(stringResource(R.string.debug_log_clear_confirm_body)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    showClearDialog = false
+                    scope.launch {
+                        withContext(Dispatchers.IO) { AppLogger.clearLogs() }
+                        reload()
+                    }
+                }) {
+                    Text(
+                        stringResource(R.string.debug_log_clear),
+                        color = MaterialTheme.colorScheme.error,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showClearDialog = false }) {
+                    Text(stringResource(R.string.debug_log_cancel))
+                }
+            },
+            shape = RoundedCornerShape(16.dp),
+        )
+    }
+}

--- a/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/lan/LanScanViewModel.kt
+++ b/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/lan/LanScanViewModel.kt
@@ -2,6 +2,7 @@ package com.example.netswissknife.app.ui.screens.lan
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.netswissknife.app.util.AppLogger
 import com.example.netswissknife.core.domain.LanScanFlowResult
 import com.example.netswissknife.core.domain.LanScanParams
 import com.example.netswissknife.core.domain.LanScanUseCase
@@ -9,12 +10,16 @@ import com.example.netswissknife.core.network.lan.LanHost
 import com.example.netswissknife.core.network.lan.LanScanSummary
 import com.example.netswissknife.core.network.lan.SubnetUtils
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
+
+private const val TAG = "LanScanViewModel"
 
 /** All possible UI states for the LAN scanner screen. */
 sealed interface LanScanUiState {
@@ -60,6 +65,7 @@ class LanScanViewModel @Inject constructor(
     private var scanJob: Job? = null
 
     init {
+        AppLogger.i(TAG, "ViewModel created")
         refreshSubnet()
     }
 
@@ -71,17 +77,28 @@ class LanScanViewModel @Inject constructor(
 
     fun onConcurrencyChange(value: Int) { _concurrency.value = value }
 
-    /** Detects the current subnet from active network interfaces. */
+    /** Detects the current subnet from active network interfaces on an IO thread. */
     fun refreshSubnet() {
         viewModelScope.launch {
             _isSubnetLoading.value = true
-            // SubnetUtils.getCurrentSubnet() uses java.net.NetworkInterface (blocking I/O on a
-            // background dispatcher would be ideal but it's very fast on device).
-            val detected = SubnetUtils.getCurrentSubnet()
-            if (_subnet.value.isBlank()) {
-                _subnet.value = detected ?: "192.168.1.0/24"
+            AppLogger.d(TAG, "refreshSubnet: starting subnet detection")
+            try {
+                // Run on IO – NetworkInterface reads from /proc/net, which is blocking I/O
+                val detected = withContext(Dispatchers.IO) {
+                    SubnetUtils.getCurrentSubnet()
+                }
+                AppLogger.i(TAG, "refreshSubnet: detected subnet = $detected")
+                if (_subnet.value.isBlank()) {
+                    _subnet.value = detected ?: "192.168.1.0/24"
+                }
+            } catch (e: Exception) {
+                AppLogger.e(TAG, "refreshSubnet: failed to detect subnet", e)
+                if (_subnet.value.isBlank()) {
+                    _subnet.value = "192.168.1.0/24"
+                }
+            } finally {
+                _isSubnetLoading.value = false
             }
-            _isSubnetLoading.value = false
         }
     }
 
@@ -95,6 +112,8 @@ class LanScanViewModel @Inject constructor(
             concurrency = _concurrency.value,
         )
 
+        AppLogger.i(TAG, "startScan: subnet=${params.subnet} timeoutMs=${params.timeoutMs} concurrency=${params.concurrency}")
+
         _uiState.value = LanScanUiState.Scanning(
             hosts = emptyList(),
             scannedCount = 0,
@@ -102,40 +121,49 @@ class LanScanViewModel @Inject constructor(
         )
 
         scanJob = viewModelScope.launch {
-            lanScanUseCase(params).collect { result ->
-                when (result) {
-                    is LanScanFlowResult.ValidationError -> {
-                        _uiState.value = LanScanUiState.Error(result.message)
-                    }
+            try {
+                lanScanUseCase(params).collect { result ->
+                    when (result) {
+                        is LanScanFlowResult.ValidationError -> {
+                            AppLogger.w(TAG, "startScan: validation error – ${result.message}")
+                            _uiState.value = LanScanUiState.Error(result.message)
+                        }
 
-                    is LanScanFlowResult.HostFound -> {
-                        liveHosts.add(result.host)
-                        _uiState.value = LanScanUiState.Scanning(
-                            hosts = liveHosts.toList(),
-                            scannedCount = result.scannedCount,
-                            totalCount = result.totalCount,
-                        )
-                    }
-
-                    is LanScanFlowResult.ScanProgress -> {
-                        val current = _uiState.value
-                        if (current is LanScanUiState.Scanning) {
-                            _uiState.value = current.copy(
+                        is LanScanFlowResult.HostFound -> {
+                            AppLogger.d(TAG, "startScan: host found – ip=${result.host.ip} ping=${result.host.pingTimeMs}ms ports=${result.host.openPorts}")
+                            liveHosts.add(result.host)
+                            _uiState.value = LanScanUiState.Scanning(
+                                hosts = liveHosts.toList(),
                                 scannedCount = result.scannedCount,
                                 totalCount = result.totalCount,
                             )
                         }
-                    }
 
-                    is LanScanFlowResult.ScanComplete -> {
-                        _uiState.value = LanScanUiState.Finished(result.summary)
+                        is LanScanFlowResult.ScanProgress -> {
+                            val current = _uiState.value
+                            if (current is LanScanUiState.Scanning) {
+                                _uiState.value = current.copy(
+                                    scannedCount = result.scannedCount,
+                                    totalCount = result.totalCount,
+                                )
+                            }
+                        }
+
+                        is LanScanFlowResult.ScanComplete -> {
+                            AppLogger.i(TAG, "startScan: scan complete – scanned=${result.summary.totalScanned} alive=${result.summary.aliveHosts} duration=${result.summary.scanDurationMs}ms")
+                            _uiState.value = LanScanUiState.Finished(result.summary)
+                        }
                     }
                 }
+            } catch (e: Exception) {
+                AppLogger.e(TAG, "startScan: unexpected exception during scan", e)
+                _uiState.value = LanScanUiState.Error("Scan failed: ${e.message ?: "Unknown error"}")
             }
         }
     }
 
     fun onStopScan() {
+        AppLogger.i(TAG, "onStopScan: cancelling scan job")
         scanJob?.cancel()
         val current = _uiState.value
         if (current is LanScanUiState.Scanning) {
@@ -151,6 +179,7 @@ class LanScanViewModel @Inject constructor(
     }
 
     fun onClear() {
+        AppLogger.d(TAG, "onClear")
         scanJob?.cancel()
         _uiState.value = LanScanUiState.Idle
     }

--- a/app/src/main/kotlin/com/example/netswissknife/app/util/AppLogger.kt
+++ b/app/src/main/kotlin/com/example/netswissknife/app/util/AppLogger.kt
@@ -1,0 +1,109 @@
+package com.example.netswissknife.app.util
+
+import android.content.Context
+import android.util.Log
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Application-wide debug logger. Writes entries to both Logcat and an in-app log file
+ * stored in the app's private files directory (no storage permissions required).
+ *
+ * Call [init] once from [Application.onCreate] before any logging.
+ * Read the accumulated log via [getLogContent]. Clear it with [clearLogs].
+ */
+object AppLogger {
+
+    private const val LOGCAT_TAG = "NetSwissKnife"
+    private const val LOG_FILE_NAME = "debug.log"
+    private const val LOG_BACKUP_NAME = "debug.log.bak"
+
+    /** Max size of the active log file before it is rotated to the backup file. */
+    private const val MAX_LOG_BYTES = 512 * 1024 // 512 KB
+
+    @Volatile
+    private var logFile: File? = null
+
+    private val dateFmt = object : ThreadLocal<SimpleDateFormat>() {
+        override fun initialValue() =
+            SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", Locale.US)
+    }
+
+    // ── Lifecycle ─────────────────────────────────────────────────────────────
+
+    fun init(context: Context) {
+        logFile = File(context.filesDir, LOG_FILE_NAME)
+        i("AppLogger", "Logger initialized – log file: ${logFile?.absolutePath}")
+    }
+
+    // ── Logging API ───────────────────────────────────────────────────────────
+
+    fun d(tag: String, message: String) = write("D", tag, message)
+
+    fun i(tag: String, message: String) = write("I", tag, message)
+
+    fun w(tag: String, message: String) = write("W", tag, message)
+
+    fun e(tag: String, message: String, throwable: Throwable? = null) {
+        val full = if (throwable != null) "$message\n${throwable.stackTraceToString()}" else message
+        write("E", tag, full)
+    }
+
+    // ── Content access ────────────────────────────────────────────────────────
+
+    /**
+     * Returns the full content of the log file, newest entries at the bottom.
+     * If a backup file also exists (from rotation) it is prepended.
+     */
+    fun getLogContent(): String {
+        val file = logFile ?: return "Logger not initialized – call AppLogger.init() first."
+        if (!file.exists()) return "(No log entries yet)"
+        return synchronized(this) {
+            val backup = File(file.parent, LOG_BACKUP_NAME)
+            val backupText = if (backup.exists()) backup.readText() + "\n--- LOG ROTATED ---\n\n" else ""
+            backupText + file.readText()
+        }
+    }
+
+    /** Deletes the log file and its backup. */
+    fun clearLogs() {
+        val file = logFile ?: return
+        synchronized(this) {
+            file.delete()
+            File(file.parent, LOG_BACKUP_NAME).delete()
+        }
+        i("AppLogger", "Logs cleared")
+    }
+
+    // ── Internal ──────────────────────────────────────────────────────────────
+
+    private fun write(level: String, tag: String, message: String) {
+        // Always emit to Logcat so adb logcat works too
+        when (level) {
+            "D" -> Log.d(LOGCAT_TAG, "[$tag] $message")
+            "I" -> Log.i(LOGCAT_TAG, "[$tag] $message")
+            "W" -> Log.w(LOGCAT_TAG, "[$tag] $message")
+            "E" -> Log.e(LOGCAT_TAG, "[$tag] $message")
+            else -> Log.v(LOGCAT_TAG, "[$tag] $message")
+        }
+
+        // Also persist to file
+        val file = logFile ?: return
+        val entry = "${dateFmt.get()!!.format(Date())} [$level/$tag] $message\n"
+        synchronized(this) {
+            // Rotate when the file gets too large
+            if (file.exists() && file.length() > MAX_LOG_BYTES) {
+                val backup = File(file.parent, LOG_BACKUP_NAME)
+                backup.delete()
+                file.renameTo(backup)
+            }
+            try {
+                file.appendText(entry)
+            } catch (_: Exception) {
+                // Swallow – logging must never crash the app
+            }
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -198,6 +198,16 @@
     <string name="lan_open_ports_title">Open Ports (%1$d)</string>
     <string name="lan_no_open_ports">None detected</string>
 
+    <!-- Debug Log Screen -->
+    <string name="debug_log_title">Debug Logs</string>
+    <string name="debug_log_subtitle">Internal app diagnostics and crash traces</string>
+    <string name="debug_log_refresh">Refresh</string>
+    <string name="debug_log_copy">Copy</string>
+    <string name="debug_log_clear">Clear</string>
+    <string name="debug_log_clear_confirm_title">Clear all logs?</string>
+    <string name="debug_log_clear_confirm_body">This will permanently delete the debug log file. This action cannot be undone.</string>
+    <string name="debug_log_cancel">Cancel</string>
+
     <!-- DNS Record labels -->
     <string name="dns_ipv4_prefix">IPv4</string>
     <string name="dns_ipv6_prefix">IPv6</string>


### PR DESCRIPTION
Crash root cause: refreshSubnet() called SubnetUtils.getCurrentSubnet()
(which reads /proc/net via NetworkInterface) on the main dispatcher inside
viewModelScope.launch without withContext(Dispatchers.IO). This blocking
I/O on the main thread can trigger a StrictMode violation or
NetworkOnMainThreadException on certain Android versions, crashing the app
on screen open before any scan starts.

Fixes applied:
- Wrap SubnetUtils.getCurrentSubnet() in withContext(Dispatchers.IO) so
  the blocking I/O runs off the main thread
- Add try/catch in refreshSubnet() to surface errors gracefully instead
  of propagating an unhandled exception through viewModelScope
- Add try/catch in startScan() collect block so unexpected repository
  exceptions update the Error UI state instead of crashing the app

Debug logging additions:
- AppLogger: singleton backed by a rotating file in filesDir (no storage
  permission needed); mirrors all entries to Logcat under "NetSwissKnife"
- LanScanViewModel: logs subnet detection, scan lifecycle events, host
  discoveries, and all error paths
- NetSwissKnifeApp.onCreate(): initialises AppLogger on startup

In-app log viewer:
- DebugLogScreen: animated Material 3 screen with monospace log display,
  Refresh / Copy / Clear actions, and a confirmation dialog before clearing
- NavRoutes.DebugLogs ("debug_logs") registered in AppNavHost
- MoreToolsSheet: "Debug Logs" entry at the bottom of the sheet (below
  a divider, styled with errorContainer colours)
- MainActivity: routes MoreToolsSheet's onDebugLogsClick to the new screen

https://claude.ai/code/session_01HpTvMHK3nrbDXGXTRLCQvv