### PR TITLE
fix: replace Float.MAX_VALUE with Offset.Infinite in linearGradient calls

### DIFF
--- a/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/debug/DebugLogScreen.kt
+++ b/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/debug/DebugLogScreen.kt
@@ -105,7 +105,7 @@ fun DebugLogScreen() {
                                     MaterialTheme.colorScheme.secondaryContainer,
                                 ),
                                 start = Offset(0f, 0f),
-                                end = Offset(Float.MAX_VALUE, Float.MAX_VALUE),
+                                end = Offset.Infinite,
                             )
                         )
                         .padding(20.dp),

--- a/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/lan/LanScanScreen.kt
+++ b/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/lan/LanScanScreen.kt
@@ -184,7 +184,7 @@ private fun LanHeaderCard() {
                             MaterialTheme.colorScheme.secondaryContainer,
                         ),
                         start = Offset(0f, 0f),
-                        end = Offset(Float.MAX_VALUE, Float.MAX_VALUE),
+                        end = Offset.Infinite,
                     )
                 )
                 .padding(20.dp),


### PR DESCRIPTION
Android's native LinearGradient rejects Float.MAX_VALUE coordinates on
newer API levels, crashing with IllegalArgumentException on nativeCreate.
Using Offset.Infinite lets Compose resolve the end point to the actual
drawable size at draw time, which is both correct and safe.

Fixes crash on LAN Scanner launch. Same fix applied to DebugLogScreen.

https://claude.ai/code/session_01VDu2hUmNRYkJ7eCUo7Wctw