### PR TITLE
Add Wi-Fi Scanner screen with network scanning and analysis

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,8 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <!-- Android 13+: fine-grained Wi-Fi scanning permission -->
+    <uses-permission android:name="android.permission.NEARBY_WIFI_DEVICES"
+        android:usesPermissionFlags="neverForLocation"
+        tools:targetApi="tiramisu" />
+    <!-- Feature declaration: app requires Wi-Fi (soft requirement) -->
+    <uses-feature android:name="android.hardware.wifi" android:required="false" />
 
     <application
         android:name=".NetSwissKnifeApp"

--- a/app/src/main/kotlin/com/example/netswissknife/app/di/WifiScanModule.kt
+++ b/app/src/main/kotlin/com/example/netswissknife/app/di/WifiScanModule.kt
@@ -1,0 +1,28 @@
+package com.example.netswissknife.app.di
+
+import android.content.Context
+import com.example.netswissknife.app.wifi.WifiScanRepositoryImpl
+import com.example.netswissknife.core.domain.WifiScanUseCase
+import com.example.netswissknife.core.network.wifi.WifiScanRepository
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object WifiScanModule {
+
+    @Provides
+    @Singleton
+    fun provideWifiScanRepository(
+        @ApplicationContext context: Context
+    ): WifiScanRepository = WifiScanRepositoryImpl(context)
+
+    @Provides
+    @Singleton
+    fun provideWifiScanUseCase(repository: WifiScanRepository): WifiScanUseCase =
+        WifiScanUseCase(repository)
+}

--- a/app/src/main/kotlin/com/example/netswissknife/app/ui/navigation/AppNavigation.kt
+++ b/app/src/main/kotlin/com/example/netswissknife/app/ui/navigation/AppNavigation.kt
@@ -21,6 +21,7 @@ import com.example.netswissknife.app.ui.screens.LanScreen
 import com.example.netswissknife.app.ui.screens.PingScreen
 import com.example.netswissknife.app.ui.screens.PortsScreen
 import com.example.netswissknife.app.ui.screens.TracerouteScreen
+import com.example.netswissknife.app.ui.screens.WifiScanScreen
 import com.example.netswissknife.app.ui.screens.debug.DebugLogScreen
 
 // ── Transition helpers ────────────────────────────────────────────────────────
@@ -90,6 +91,7 @@ fun AppNavHost(navController: NavHostController, modifier: Modifier = Modifier) 
         composable(NavRoutes.Ports.route)      { PortsScreen() }
         composable(NavRoutes.Lan.route)        { LanScreen() }
         composable(NavRoutes.Dns.route)        { DnsScreen() }
+        composable(NavRoutes.WifiScan.route)   { WifiScanScreen() }
         composable(NavRoutes.DebugLogs.route)  { DebugLogScreen() }
     }
 }

--- a/app/src/main/kotlin/com/example/netswissknife/app/ui/navigation/NavRoutes.kt
+++ b/app/src/main/kotlin/com/example/netswissknife/app/ui/navigation/NavRoutes.kt
@@ -8,6 +8,7 @@ import androidx.compose.material.icons.filled.NetworkCheck
 import androidx.compose.material.icons.filled.Router
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Wifi
+import androidx.compose.material.icons.filled.WifiFind
 import androidx.compose.ui.graphics.vector.ImageVector
 
 data class ToolInfo(
@@ -30,15 +31,17 @@ sealed class NavRoutes(
     object Lan : NavRoutes("lan", "LAN Scanner", Icons.Default.Wifi)
     object Dns : NavRoutes("dns", "DNS Lookup", Icons.Default.Language)
     object DebugLogs : NavRoutes("debug_logs", "Debug Logs", Icons.Default.BugReport)
+    object WifiScan : NavRoutes("wifi_scan", "Wi-Fi Scanner", Icons.Default.WifiFind)
 
     companion object {
         /** All navigable tool screens (excluding Home). */
         val allTools = listOf(
-            ToolInfo("ping",       "Ping",         "Ping",  Icons.Default.NetworkCheck, "ICMP round-trip latency"),
-            ToolInfo("traceroute", "Traceroute",   "Trace", Icons.Default.Router,       "Network path hop analysis"),
-            ToolInfo("ports",      "Port Scanner", "Ports", Icons.Default.Search,       "TCP port reachability"),
-            ToolInfo("lan",        "LAN Scanner",  "LAN",   Icons.Default.Wifi,         "Local device discovery"),
-            ToolInfo("dns",        "DNS Lookup",   "DNS",   Icons.Default.Language,     "Resolve hostnames & records"),
+            ToolInfo("ping",       "Ping",          "Ping",  Icons.Default.NetworkCheck, "ICMP round-trip latency"),
+            ToolInfo("traceroute", "Traceroute",    "Trace", Icons.Default.Router,       "Network path hop analysis"),
+            ToolInfo("ports",      "Port Scanner",  "Ports", Icons.Default.Search,       "TCP port reachability"),
+            ToolInfo("lan",        "LAN Scanner",   "LAN",   Icons.Default.Wifi,         "Local device discovery"),
+            ToolInfo("dns",        "DNS Lookup",    "DNS",   Icons.Default.Language,     "Resolve hostnames & records"),
+            ToolInfo("wifi_scan",  "Wi-Fi Scanner", "Wi-Fi", Icons.Default.WifiFind,     "Scan channels & access points"),
         )
 
         /** Default pinned routes shown in the bottom nav (max MAX_PINNED). */

--- a/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/WifiScanScreen.kt
+++ b/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/WifiScanScreen.kt
@@ -69,6 +69,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.CornerRadius
@@ -672,7 +673,7 @@ fun WifiScanScreen(
     connectedInfo: com.example.netswissknife.core.network.wifi.WifiConnectionInfo?,
     onDismiss: () -> Unit,
 ) {
-    val sheetState = rememberModalBottomSheetState(skipPartialExpansion = true)
+    val sheetState = rememberModalBottomSheetState()
 
     ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
         Column(

--- a/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/WifiScanScreen.kt
+++ b/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/WifiScanScreen.kt
@@ -1,0 +1,865 @@
+package com.example.netswissknife.app.ui.screens
+
+import android.Manifest
+import android.os.Build
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.togetherWith
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.LocationOff
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.SignalWifiOff
+import androidx.compose.material.icons.filled.Wifi
+import androidx.compose.material.icons.filled.WifiOff
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.FilledTonalIconButton
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.LockOpen
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.Badge
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.example.netswissknife.app.ui.screens.wifi.ApSortOrder
+import com.example.netswissknife.app.ui.screens.wifi.WifiScanUiState
+import com.example.netswissknife.app.ui.screens.wifi.WifiScanViewModel
+import com.example.netswissknife.core.network.wifi.WifiAccessPoint
+import com.example.netswissknife.core.network.wifi.WifiBand
+
+@Composable
+fun WifiScanScreen(
+    viewModel: WifiScanViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val autoRefresh by viewModel.autoRefresh.collectAsState()
+
+    // ── Permission launcher ───────────────────────────────────────────────────
+    val requiredPermissions = buildList {
+        add(Manifest.permission.ACCESS_FINE_LOCATION)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            add(Manifest.permission.NEARBY_WIFI_DEVICES)
+        }
+    }.toTypedArray()
+
+    val permissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestMultiplePermissions()
+    ) { grants ->
+        if (grants.values.any { it }) viewModel.onPermissionGranted()
+        else viewModel.onPermissionDenied()
+    }
+
+    // Request permissions on first launch
+    LaunchedEffect(Unit) {
+        if (uiState is WifiScanUiState.Idle) {
+            permissionLauncher.launch(requiredPermissions)
+        }
+    }
+
+    // ── Root animated state switcher ──────────────────────────────────────────
+    var visible by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) { visible = true }
+
+    AnimatedVisibility(
+        visible = visible,
+        enter = fadeIn() + slideInVertically { it / 6 },
+        modifier = Modifier.fillMaxSize()
+    ) {
+        AnimatedContent(
+            targetState = uiState,
+            transitionSpec = { fadeIn() togetherWith fadeOut() },
+            modifier = Modifier.fillMaxSize(),
+            label = "wifi_state"
+        ) { state ->
+            when (state) {
+                is WifiScanUiState.Idle         -> WifiIdleScreen()
+                is WifiScanUiState.NoPermission -> WifiNoPermissionScreen(
+                    onRequest = { permissionLauncher.launch(requiredPermissions) }
+                )
+                is WifiScanUiState.NotSupported -> WifiNotSupportedScreen()
+                is WifiScanUiState.WifiDisabled -> WifiDisabledScreen(
+                    onRetry = { viewModel.startScan() }
+                )
+                is WifiScanUiState.Scanning     -> WifiScanningScreen()
+                is WifiScanUiState.Success      -> WifiSuccessScreen(
+                    state      = state,
+                    autoRefresh = autoRefresh,
+                    onScan     = { viewModel.startScan() },
+                    onToggleAutoRefresh = { viewModel.toggleAutoRefresh() },
+                    onBandFilter = { viewModel.setBandFilter(it) },
+                    onSortOrder  = { viewModel.setSortOrder(it) },
+                    onSelectAp   = { viewModel.selectAccessPoint(it) }
+                )
+                is WifiScanUiState.Error        -> WifiErrorScreen(
+                    message = state.message,
+                    onRetry = { viewModel.onRetry(); permissionLauncher.launch(requiredPermissions) }
+                )
+            }
+        }
+    }
+}
+
+// ── Idle / loading ────────────────────────────────────────────────────────────
+
+@Composable private fun WifiIdleScreen() {
+    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        CircularProgressIndicator(color = MaterialTheme.colorScheme.primary)
+    }
+}
+
+// ── Empty / error states ──────────────────────────────────────────────────────
+
+@Composable private fun WifiStatusCard(
+    icon: @Composable () -> Unit,
+    title: String,
+    body: String,
+    action: (@Composable () -> Unit)? = null
+) {
+    Box(Modifier.fillMaxSize().padding(24.dp), contentAlignment = Alignment.Center) {
+        ElevatedCard(Modifier.fillMaxWidth()) {
+            Column(
+                modifier = Modifier.padding(32.dp).fillMaxWidth(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                icon()
+                Text(title, style = MaterialTheme.typography.titleMedium, textAlign = TextAlign.Center)
+                Text(body,  style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant, textAlign = TextAlign.Center)
+                if (action != null) { Spacer(Modifier.height(4.dp)); action() }
+            }
+        }
+    }
+}
+
+@Composable private fun WifiNoPermissionScreen(onRequest: () -> Unit) {
+    WifiStatusCard(
+        icon   = { Icon(Icons.Default.LocationOff, null, Modifier.size(48.dp),
+                       tint = MaterialTheme.colorScheme.error) },
+        title  = "Location Permission Required",
+        body   = "Android requires Location permission to scan for nearby Wi-Fi networks. " +
+                 "Your location is not sent anywhere.",
+        action = { Button(onRequest) { Text("Grant Permission") } }
+    )
+}
+
+@Composable private fun WifiNotSupportedScreen() {
+    WifiStatusCard(
+        icon  = { Icon(Icons.Default.WifiOff, null, Modifier.size(48.dp),
+                      tint = MaterialTheme.colorScheme.onSurfaceVariant) },
+        title = "Wi-Fi Not Available",
+        body  = "This device does not have Wi-Fi hardware."
+    )
+}
+
+@Composable private fun WifiDisabledScreen(onRetry: () -> Unit) {
+    WifiStatusCard(
+        icon   = { Icon(Icons.Default.SignalWifiOff, null, Modifier.size(48.dp),
+                       tint = MaterialTheme.colorScheme.tertiary) },
+        title  = "Wi-Fi is Off",
+        body   = "Enable Wi-Fi in your device settings, then scan again.",
+        action = { Button(onRetry) { Text("Retry") } }
+    )
+}
+
+@Composable private fun WifiErrorScreen(message: String, onRetry: () -> Unit) {
+    WifiStatusCard(
+        icon   = { Icon(Icons.Default.WifiOff, null, Modifier.size(48.dp),
+                       tint = MaterialTheme.colorScheme.error) },
+        title  = "Scan Failed",
+        body   = message,
+        action = { Button(onRetry) { Text("Retry") } }
+    )
+}
+
+// ── Shimmer helper ────────────────────────────────────────────────────────────
+
+@Composable private fun ShimmerBox(modifier: Modifier = Modifier) {
+    val transition = rememberInfiniteTransition(label = "shimmer")
+    val shimmerX by transition.animateFloat(
+        initialValue = -1f, targetValue = 2f,
+        animationSpec = infiniteRepeatable(tween(1200, easing = FastOutSlowInEasing), RepeatMode.Restart),
+        label = "shimmerX"
+    )
+    val colors = listOf(
+        MaterialTheme.colorScheme.surfaceVariant,
+        MaterialTheme.colorScheme.surface,
+        MaterialTheme.colorScheme.surfaceVariant
+    )
+    Box(modifier.background(
+        Brush.linearGradient(colors, start = Offset(shimmerX * 600f, 0f), end = Offset(shimmerX * 600f + 600f, 0f))
+    ))
+}
+
+@Composable private fun WifiScanningScreen() {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize().padding(horizontal = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        // Gradient header shimmer
+        item {
+            Spacer(Modifier.height(8.dp))
+            ShimmerBox(Modifier.fillMaxWidth().height(100.dp).clip(RoundedCornerShape(16.dp)))
+        }
+        // Band filter tabs shimmer
+        item {
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                repeat(4) { ShimmerBox(Modifier.width(80.dp).height(36.dp).clip(RoundedCornerShape(50))) }
+            }
+        }
+        // Channel chart shimmer
+        item { ShimmerBox(Modifier.fillMaxWidth().height(140.dp).clip(RoundedCornerShape(16.dp))) }
+        // AP card shimmers
+        items(5) {
+            ShimmerBox(Modifier.fillMaxWidth().height(80.dp).clip(RoundedCornerShape(16.dp)))
+        }
+    }
+}
+
+// ── Success screen ────────────────────────────────────────────────────────────
+
+@Composable private fun WifiSuccessScreen(
+    state: WifiScanUiState.Success,
+    autoRefresh: Boolean,
+    onScan: () -> Unit,
+    onToggleAutoRefresh: () -> Unit,
+    onBandFilter: (WifiBand?) -> Unit,
+    onSortOrder: (ApSortOrder) -> Unit,
+    onSelectAp: (WifiAccessPoint?) -> Unit,
+) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize().padding(horizontal = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        item { Spacer(Modifier.height(4.dp)) }
+
+        // 1 – Gradient header
+        item {
+            WifiHeader(
+                result      = state.result,
+                autoRefresh = autoRefresh,
+                onScan      = onScan,
+                onToggleAutoRefresh = onToggleAutoRefresh
+            )
+        }
+
+        // 2 – Band filter + sort chips
+        item {
+            WifiBandFilterRow(
+                detectedBands = state.result.detectedBands,
+                selected      = state.bandFilter,
+                onSelect      = onBandFilter
+            )
+        }
+
+        // 3 – Sort order chips
+        item { WifiSortRow(current = state.sortOrder, onSelect = onSortOrder) }
+
+        // 4 – Channel chart (placeholder — next step)
+        item { WifiChannelChartCard(state = state) }
+
+        // 5 – AP list
+        item {
+            Text(
+                "${state.filteredAccessPoints.size} Networks" +
+                    (if (state.bandFilter != null) " (${state.bandFilter.displayName})" else ""),
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.padding(top = 4.dp)
+            )
+        }
+        items(state.filteredAccessPoints.size) { i ->
+            WifiApCard(ap = state.filteredAccessPoints[i], onClick = { onSelectAp(it) })
+        }
+
+        item { Spacer(Modifier.height(80.dp)) }
+    }
+
+    // Detail bottom sheet
+    if (state.selectedAp != null) {
+        WifiApDetailSheet(ap = state.selectedAp, connectedInfo = state.result.connectedNetwork,
+            onDismiss = { onSelectAp(null) })
+    }
+}
+
+// ── Header ────────────────────────────────────────────────────────────────────
+
+@Composable private fun WifiHeader(
+    result: com.example.netswissknife.core.network.wifi.WifiScanResult,
+    autoRefresh: Boolean,
+    onScan: () -> Unit,
+    onToggleAutoRefresh: () -> Unit,
+) {
+    val gradient = Brush.linearGradient(
+        listOf(MaterialTheme.colorScheme.primaryContainer, MaterialTheme.colorScheme.tertiaryContainer)
+    )
+    ElevatedCard(Modifier.fillMaxWidth()) {
+        Box(Modifier.background(gradient)) {
+            Column(Modifier.padding(20.dp).fillMaxWidth()) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(Icons.Default.Wifi, null, Modifier.size(28.dp),
+                        tint = MaterialTheme.colorScheme.onPrimaryContainer)
+                    Spacer(Modifier.width(10.dp))
+                    Text("Wi-Fi Scanner", style = MaterialTheme.typography.displaySmall,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer)
+                    Spacer(Modifier.weight(1f))
+                    FilledTonalIconButton(onClick = onScan) {
+                        Icon(Icons.Default.Refresh, "Scan")
+                    }
+                }
+                Spacer(Modifier.height(8.dp))
+                val time = remember(result.scanTimestampMs) {
+                    SimpleDateFormat("HH:mm:ss", Locale.getDefault()).format(Date(result.scanTimestampMs))
+                }
+                Text(
+                    "${result.accessPoints.size} networks · ${result.uniqueNetworkCount} SSIDs · $time",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.8f)
+                )
+                if (result.detectedBands.isNotEmpty()) {
+                    Text(
+                        result.detectedBands.joinToString(" · ") { it.displayName },
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f)
+                    )
+                }
+            }
+        }
+    }
+}
+
+// ── Band filter row ───────────────────────────────────────────────────────────
+
+@Composable private fun WifiBandFilterRow(
+    detectedBands: List<WifiBand>,
+    selected: WifiBand?,
+    onSelect: (WifiBand?) -> Unit
+) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        FilterChip(selected = selected == null, onClick = { onSelect(null) }, label = { Text("All") })
+        detectedBands.forEach { band ->
+            FilterChip(
+                selected = selected == band,
+                onClick  = { onSelect(if (selected == band) null else band) },
+                label    = { Text(band.ghzLabel + " GHz") }
+            )
+        }
+    }
+}
+
+// ── Sort order row ────────────────────────────────────────────────────────────
+
+@Composable private fun WifiSortRow(current: ApSortOrder, onSelect: (ApSortOrder) -> Unit) {
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text("Sort:", style = MaterialTheme.typography.labelMedium,
+            modifier = Modifier.align(Alignment.CenterVertically),
+            color = MaterialTheme.colorScheme.onSurfaceVariant)
+        ApSortOrder.values().forEach { order ->
+            FilterChip(
+                selected = current == order,
+                onClick  = { onSelect(order) },
+                label    = { Text(order.label, style = MaterialTheme.typography.labelSmall) }
+            )
+        }
+    }
+}
+
+// ── Stubs for next steps ──────────────────────────────────────────────────────
+
+// ── Channel chart ─────────────────────────────────────────────────────────────
+
+@Composable private fun WifiChannelChartCard(state: WifiScanUiState.Success) {
+    val channels = if (state.bandFilter == null) state.result.channels
+                   else state.result.channels.filter { it.band == state.bandFilter }
+    if (channels.isEmpty()) return
+
+    ElevatedCard(Modifier.fillMaxWidth()) {
+        Column(Modifier.padding(16.dp)) {
+            Text("Channel Utilisation", style = MaterialTheme.typography.titleMedium)
+            Spacer(Modifier.height(4.dp))
+
+            // Group by band for sub-headers
+            val byBand = channels.groupBy { it.band }
+            byBand.forEach { (band, chList) ->
+                if (byBand.size > 1) {
+                    Text(band.displayName, style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(top = 8.dp, bottom = 4.dp))
+                }
+                ChannelBarChart(channels = chList)
+            }
+        }
+    }
+}
+
+@Composable private fun ChannelBarChart(
+    channels: List<com.example.netswissknife.core.network.wifi.WifiChannelInfo>
+) {
+    val trackColor  = MaterialTheme.colorScheme.surfaceVariant
+    val labelColorArgb = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f).hashCode()
+    val density     = LocalDensity.current
+
+    val barWidth    = 36.dp
+    val chartHeight = 120.dp
+    val totalWidth  = (barWidth + 8.dp) * channels.size
+
+    // Pre-compute pixel sizes outside Canvas to avoid nested Composable calls
+    val bwPx: Float
+    val gapPx: Float
+    val countTextSizePx: Float
+    val labelTextSizePx: Float
+    with(density) {
+        bwPx            = barWidth.toPx()
+        gapPx           = 8.dp.toPx()
+        countTextSizePx = 10.sp.toPx()
+        labelTextSizePx = 9.sp.toPx()
+    }
+
+    Box(Modifier.horizontalScroll(rememberScrollState())) {
+        Canvas(Modifier.width(totalWidth).height(chartHeight)) {
+            val maxBarH    = size.height * 0.75f
+            val labelAreaH = size.height * 0.25f
+
+            val countPaint = android.graphics.Paint().apply {
+                color     = android.graphics.Color.WHITE
+                textSize  = countTextSizePx
+                textAlign = android.graphics.Paint.Align.CENTER
+                isFakeBoldText = true
+                isAntiAlias    = true
+            }
+            val labelPaint = android.graphics.Paint().apply {
+                color     = labelColorArgb
+                textSize  = labelTextSizePx
+                textAlign = android.graphics.Paint.Align.CENTER
+                isAntiAlias = true
+            }
+
+            channels.forEachIndexed { i, ch ->
+                val x    = i * (bwPx + gapPx)
+                val barH = (ch.congestionScore * maxBarH).coerceAtLeast(4f)
+                val barTop = maxBarH - barH
+
+                // Track background
+                drawRoundRect(
+                    color        = trackColor,
+                    topLeft      = Offset(x, 0f),
+                    size         = Size(bwPx, maxBarH),
+                    cornerRadius = CornerRadius(6f)
+                )
+                // Filled bar: green → amber → red by congestion score
+                val barFill = lerp(Color(0xFF4CAF50), Color(0xFFF44336), ch.congestionScore)
+                drawRoundRect(
+                    color        = barFill,
+                    topLeft      = Offset(x, barTop),
+                    size         = Size(bwPx, barH),
+                    cornerRadius = CornerRadius(6f)
+                )
+                // AP count inside bar
+                if (ch.accessPointCount > 0) {
+                    val countY = (barTop + barH / 2f + countTextSizePx / 3f).coerceAtLeast(countTextSizePx)
+                    drawContext.canvas.nativeCanvas.drawText(
+                        "${ch.accessPointCount}", x + bwPx / 2f, countY, countPaint
+                    )
+                }
+                // Channel label below bar
+                drawContext.canvas.nativeCanvas.drawText(
+                    "Ch ${ch.channel}", x + bwPx / 2f, maxBarH + labelAreaH * 0.65f, labelPaint
+                )
+            }
+        }
+    }
+}
+
+// ── AP Card ───────────────────────────────────────────────────────────────────
+
+@Composable private fun WifiApCard(ap: WifiAccessPoint, onClick: (WifiAccessPoint) -> Unit) {
+    val connectedGradient = Brush.linearGradient(
+        listOf(
+            MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.7f),
+            MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.4f)
+        )
+    )
+    val cardColors = if (ap.isConnected) {
+        CardDefaults.elevatedCardColors(containerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f))
+    } else {
+        CardDefaults.elevatedCardColors()
+    }
+
+    ElevatedCard(
+        onClick   = { onClick(ap) },
+        modifier  = Modifier.fillMaxWidth(),
+        colors    = cardColors
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp).fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            // Signal bars icon
+            SignalBarsIcon(quality = ap.signalQualityPercent, level = ap.signalLevel)
+
+            Spacer(Modifier.width(12.dp))
+
+            // Network info
+            Column(Modifier.weight(1f)) {
+                Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                    Text(
+                        ap.displaySsid,
+                        style = MaterialTheme.typography.titleMedium,
+                        maxLines = 1
+                    )
+                    if (ap.isConnected) {
+                        Badge(containerColor = MaterialTheme.colorScheme.primary) {
+                            Text("Connected", style = MaterialTheme.typography.labelSmall)
+                        }
+                    }
+                    if (ap.ssid.isBlank()) {
+                        Badge(containerColor = MaterialTheme.colorScheme.surfaceVariant) {
+                            Text("Hidden", style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant)
+                        }
+                    }
+                }
+                Spacer(Modifier.height(4.dp))
+                Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                    ApBadge(ap.band.ghzLabel + " GHz")
+                    ApBadge("Ch ${ap.channel}")
+                    ApBadge("${ap.channelWidthMhz} MHz")
+                    if (ap.standard.generationLabel != "Unknown") ApBadge(ap.standard.generationLabel)
+                }
+                Spacer(Modifier.height(3.dp))
+                Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                    Icon(
+                        if (ap.security.isEncrypted) Icons.Default.Lock else Icons.Default.LockOpen,
+                        null, Modifier.size(12.dp),
+                        tint = if (ap.security.isEncrypted) MaterialTheme.colorScheme.onSurfaceVariant
+                               else MaterialTheme.colorScheme.tertiary
+                    )
+                    Text(ap.security.displayName, style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    if (ap.vendor.isNotBlank()) {
+                        Text("·", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.outline)
+                        Text(ap.vendor, style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant, maxLines = 1)
+                    }
+                }
+            }
+
+            // RSSI column
+            Column(horizontalAlignment = Alignment.End) {
+                val rssiColor = signalLevelColor(ap.signalLevel)
+                Text("${ap.rssi} dBm", style = MaterialTheme.typography.labelMedium, color = rssiColor)
+                Text("${ap.signalQualityPercent}%", style = MaterialTheme.typography.labelSmall,
+                    color = rssiColor.copy(alpha = 0.7f))
+            }
+        }
+    }
+}
+
+@Composable private fun ApBadge(text: String) {
+    Surface(
+        color  = MaterialTheme.colorScheme.secondaryContainer,
+        shape  = RoundedCornerShape(4.dp)
+    ) {
+        Text(text, modifier = Modifier.padding(horizontal = 5.dp, vertical = 1.dp),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSecondaryContainer)
+    }
+}
+
+@Composable private fun SignalBarsIcon(quality: Int, level: com.example.netswissknife.core.network.wifi.SignalLevel) {
+    val color = signalLevelColor(level)
+    val bars  = when {
+        quality >= 75 -> 4
+        quality >= 50 -> 3
+        quality >= 25 -> 2
+        else          -> 1
+    }
+    Row(
+        modifier = Modifier.width(24.dp).height(24.dp),
+        verticalAlignment = Alignment.Bottom,
+        horizontalArrangement = Arrangement.spacedBy(2.dp)
+    ) {
+        val barHeights = listOf(6.dp, 10.dp, 15.dp, 20.dp)
+        barHeights.forEachIndexed { i, h ->
+            val active = i < bars
+            Box(
+                Modifier.width(4.dp).height(h)
+                    .clip(RoundedCornerShape(topStart = 2.dp, topEnd = 2.dp))
+                    .background(if (active) color else color.copy(alpha = 0.2f))
+            )
+        }
+    }
+}
+
+@Composable private fun signalLevelColor(
+    level: com.example.netswissknife.core.network.wifi.SignalLevel
+): Color = when (level) {
+    com.example.netswissknife.core.network.wifi.SignalLevel.EXCELLENT -> Color(0xFF4CAF50)
+    com.example.netswissknife.core.network.wifi.SignalLevel.GOOD      -> Color(0xFF8BC34A)
+    com.example.netswissknife.core.network.wifi.SignalLevel.FAIR      -> Color(0xFFFFC107)
+    com.example.netswissknife.core.network.wifi.SignalLevel.WEAK      -> Color(0xFFFF9800)
+    com.example.netswissknife.core.network.wifi.SignalLevel.POOR      -> Color(0xFFF44336)
+}
+
+// ── AP Detail Bottom Sheet ────────────────────────────────────────────────────
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable private fun WifiApDetailSheet(
+    ap: WifiAccessPoint,
+    connectedInfo: com.example.netswissknife.core.network.wifi.WifiConnectionInfo?,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartialExpansion = true)
+
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp)
+                .padding(bottom = 32.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            // ── Title row ────────────────────────────────────────────────────
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                SignalBarsIcon(ap.signalQualityPercent, ap.signalLevel)
+                Spacer(Modifier.width(12.dp))
+                Column(Modifier.weight(1f)) {
+                    Text(ap.displaySsid, style = MaterialTheme.typography.titleMedium)
+                    Text(ap.bssid, style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+                Column(horizontalAlignment = Alignment.End) {
+                    Text("${ap.rssi} dBm", style = MaterialTheme.typography.titleMedium,
+                        color = signalLevelColor(ap.signalLevel))
+                    Text(ap.signalLevel.name.lowercase().replaceFirstChar { it.uppercase() },
+                        style = MaterialTheme.typography.labelSmall,
+                        color = signalLevelColor(ap.signalLevel).copy(alpha = 0.7f))
+                }
+            }
+
+            if (ap.isConnected) {
+                Surface(
+                    color = MaterialTheme.colorScheme.primaryContainer,
+                    shape = RoundedCornerShape(8.dp),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Row(Modifier.padding(10.dp), verticalAlignment = Alignment.CenterVertically) {
+                        Icon(Icons.Default.Star, null, Modifier.size(16.dp),
+                            tint = MaterialTheme.colorScheme.primary)
+                        Spacer(Modifier.width(8.dp))
+                        Text("Currently Connected", style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onPrimaryContainer)
+                    }
+                }
+            }
+
+            // ── Signal quality arc ────────────────────────────────────────────
+            SignalArcGauge(quality = ap.signalQualityPercent, level = ap.signalLevel)
+
+            HorizontalDivider()
+
+            // ── Network info section ──────────────────────────────────────────
+            DetailSectionHeader("Network Information")
+            DetailRow("Band",         ap.band.displayName)
+            DetailRow("Channel",      "${ap.channel}  (${ap.frequency} MHz)")
+            DetailRow("Width",        "${ap.channelWidthMhz} MHz")
+            DetailRow("Standard",     "${ap.standard.generationLabel}  (${ap.standard.protocolName})")
+            DetailRow("Max Speed",    ap.standard.maxSpeedLabel)
+            if (ap.vendor.isNotBlank()) DetailRow("Vendor", ap.vendor)
+            if (ap.centerFrequency0 != 0) DetailRow("Center Freq 0", "${ap.centerFrequency0} MHz")
+            if (ap.centerFrequency1 != 0) DetailRow("Center Freq 1", "${ap.centerFrequency1} MHz (80+80)")
+
+            HorizontalDivider()
+
+            // ── Security section ──────────────────────────────────────────────
+            DetailSectionHeader("Security")
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    if (ap.security.isEncrypted) Icons.Default.Lock else Icons.Default.LockOpen,
+                    null, Modifier.size(18.dp),
+                    tint = if (ap.security.isEncrypted) MaterialTheme.colorScheme.primary
+                           else MaterialTheme.colorScheme.tertiary
+                )
+                Text(ap.security.displayName, style = MaterialTheme.typography.bodyMedium)
+            }
+            // Capability tokens
+            val tokens = ap.capabilities
+                .removePrefix("[").removeSuffix("]")
+                .split("][")
+                .filter { it.isNotBlank() }
+            if (tokens.isNotEmpty()) {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    modifier = Modifier.horizontalScroll(rememberScrollState())
+                ) {
+                    tokens.forEach { token -> ApBadge(token) }
+                }
+            }
+
+            // ── Live connection info (only when this AP is connected) ──────────
+            if (ap.isConnected && connectedInfo != null) {
+                HorizontalDivider()
+                DetailSectionHeader("Live Connection")
+                DetailRow("IP Address",   connectedInfo.ipAddress.ifBlank { "—" })
+                DetailRow("Link Speed",   "${connectedInfo.linkSpeedMbps} Mbps")
+                if (connectedInfo.txLinkSpeedMbps >= 0)
+                    DetailRow("TX Speed", "${connectedInfo.txLinkSpeedMbps} Mbps ↑")
+                if (connectedInfo.rxLinkSpeedMbps >= 0)
+                    DetailRow("RX Speed", "${connectedInfo.rxLinkSpeedMbps} Mbps ↓")
+                DetailRow("Signal",       "${connectedInfo.rssi} dBm  (${connectedInfo.signalQualityPercent}%)")
+            }
+        }
+    }
+}
+
+// ── Signal arc gauge ──────────────────────────────────────────────────────────
+
+@Composable private fun SignalArcGauge(quality: Int, level: com.example.netswissknife.core.network.wifi.SignalLevel) {
+    val fillColor  = signalLevelColor(level)
+    val trackColor = MaterialTheme.colorScheme.surfaceVariant
+    val density    = LocalDensity.current
+    val labelSizePx: Float
+    val qualityLabelSizePx: Float
+    with(density) {
+        labelSizePx        = 11.sp.toPx()
+        qualityLabelSizePx = 22.sp.toPx()
+    }
+    val labelColorArgb = MaterialTheme.colorScheme.onSurface.toArgb()
+    val subLabelArgb   = MaterialTheme.colorScheme.onSurfaceVariant.toArgb()
+
+    Box(Modifier.fillMaxWidth().height(120.dp), contentAlignment = Alignment.Center) {
+        Canvas(Modifier.size(200.dp, 100.dp)) {
+            val strokeWidth = 18f
+            val startAngle  = 180f
+            val sweepTotal  = 180f
+            val sweepFill   = sweepTotal * (quality / 100f)
+            val radius      = size.width / 2f - strokeWidth / 2f
+            val cx = size.width / 2f
+            val cy = size.height
+
+            // Track arc
+            drawArc(
+                color        = trackColor,
+                startAngle   = startAngle,
+                sweepAngle   = sweepTotal,
+                useCenter    = false,
+                topLeft      = Offset(cx - radius, cy - radius),
+                size         = Size(radius * 2, radius * 2),
+                style        = androidx.compose.ui.graphics.drawscope.Stroke(strokeWidth, cap = androidx.compose.ui.graphics.StrokeCap.Round)
+            )
+            // Filled arc
+            drawArc(
+                color        = fillColor,
+                startAngle   = startAngle,
+                sweepAngle   = sweepFill,
+                useCenter    = false,
+                topLeft      = Offset(cx - radius, cy - radius),
+                size         = Size(radius * 2, radius * 2),
+                style        = androidx.compose.ui.graphics.drawscope.Stroke(strokeWidth, cap = androidx.compose.ui.graphics.StrokeCap.Round)
+            )
+            // Quality % label in center
+            drawContext.canvas.nativeCanvas.drawText(
+                "$quality%", cx, cy - radius / 2.5f,
+                android.graphics.Paint().apply {
+                    color     = labelColorArgb
+                    textSize  = qualityLabelSizePx
+                    textAlign = android.graphics.Paint.Align.CENTER
+                    isFakeBoldText = true
+                    isAntiAlias    = true
+                }
+            )
+            drawContext.canvas.nativeCanvas.drawText(
+                "Signal Quality", cx, cy - radius / 2.5f + labelSizePx * 1.6f,
+                android.graphics.Paint().apply {
+                    color     = subLabelArgb
+                    textSize  = labelSizePx
+                    textAlign = android.graphics.Paint.Align.CENTER
+                    isAntiAlias = true
+                }
+            )
+        }
+    }
+}
+
+// ── Detail section helpers ────────────────────────────────────────────────────
+
+@Composable private fun DetailSectionHeader(title: String) {
+    Text(title, style = MaterialTheme.typography.titleMedium,
+        color = MaterialTheme.colorScheme.primary)
+}
+
+@Composable private fun DetailRow(label: String, value: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(label, style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.weight(0.45f))
+        Text(value, style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.weight(0.55f))
+    }
+}

--- a/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/wifi/WifiScanViewModel.kt
+++ b/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/wifi/WifiScanViewModel.kt
@@ -1,0 +1,175 @@
+package com.example.netswissknife.app.ui.screens.wifi
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.netswissknife.core.domain.WifiNotSupportedException
+import com.example.netswissknife.core.domain.WifiScanUseCase
+import com.example.netswissknife.core.network.wifi.WifiAccessPoint
+import com.example.netswissknife.core.network.wifi.WifiBand
+import com.example.netswissknife.core.network.wifi.WifiScanResult
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+// ── UI State ──────────────────────────────────────────────────────────────────
+
+sealed interface WifiScanUiState {
+    /** Initial state before any scan; also shown while checking permission. */
+    object Idle : WifiScanUiState
+
+    /** Location/Wi-Fi permission has not been granted. */
+    object NoPermission : WifiScanUiState
+
+    /** Wi-Fi hardware is unavailable on this device. */
+    object NotSupported : WifiScanUiState
+
+    /** Wi-Fi adapter is turned off. */
+    object WifiDisabled : WifiScanUiState
+
+    /** Scan is in progress. */
+    object Scanning : WifiScanUiState
+
+    /** Scan succeeded. [selectedAp] holds the AP the user tapped (for the detail sheet). */
+    data class Success(
+        val result: WifiScanResult,
+        val bandFilter: WifiBand? = null,
+        val sortOrder: ApSortOrder = ApSortOrder.SIGNAL,
+        val selectedAp: WifiAccessPoint? = null
+    ) : WifiScanUiState {
+        val filteredAccessPoints: List<WifiAccessPoint> get() {
+            val base = if (bandFilter == null) result.accessPoints
+                       else result.accessPoints.filter { it.band == bandFilter }
+            return when (sortOrder) {
+                ApSortOrder.SIGNAL  -> base.sortedByDescending { it.rssi }
+                ApSortOrder.SSID    -> base.sortedBy { it.displaySsid.lowercase() }
+                ApSortOrder.CHANNEL -> base.sortedWith(compareBy({ it.band.ordinal }, { it.channel }, { -it.rssi }))
+            }
+        }
+    }
+
+    /** An error occurred during scanning. */
+    data class Error(val message: String) : WifiScanUiState
+}
+
+enum class ApSortOrder(val label: String) {
+    SIGNAL("Signal"), SSID("Name"), CHANNEL("Channel")
+}
+
+// ── ViewModel ─────────────────────────────────────────────────────────────────
+
+@HiltViewModel
+class WifiScanViewModel @Inject constructor(
+    private val wifiScanUseCase: WifiScanUseCase
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<WifiScanUiState>(WifiScanUiState.Idle)
+    val uiState: StateFlow<WifiScanUiState> = _uiState.asStateFlow()
+
+    /** Whether the auto-refresh timer is running. */
+    private val _autoRefresh = MutableStateFlow(false)
+    val autoRefresh: StateFlow<Boolean> = _autoRefresh.asStateFlow()
+
+    private var scanJob: Job? = null
+    private var autoRefreshJob: Job? = null
+
+    /** Called by the screen once it has confirmed location permission is granted. */
+    fun onPermissionGranted() {
+        if (!wifiScanUseCase.isSupported) {
+            _uiState.value = WifiScanUiState.NotSupported
+            return
+        }
+        startScan()
+    }
+
+    /** Called by the screen when permission is denied. */
+    fun onPermissionDenied() {
+        _uiState.value = WifiScanUiState.NoPermission
+    }
+
+    fun startScan() {
+        scanJob?.cancel()
+        scanJob = viewModelScope.launch {
+            _uiState.value = WifiScanUiState.Scanning
+            try {
+                val result = wifiScanUseCase()
+                if (!result.isWifiEnabled) {
+                    _uiState.value = WifiScanUiState.WifiDisabled
+                } else {
+                    val prev = _uiState.value as? WifiScanUiState.Success
+                    _uiState.value = WifiScanUiState.Success(
+                        result = result,
+                        bandFilter = prev?.bandFilter,
+                        sortOrder = prev?.sortOrder ?: ApSortOrder.SIGNAL
+                    )
+                }
+            } catch (e: WifiNotSupportedException) {
+                _uiState.value = WifiScanUiState.NotSupported
+            } catch (e: SecurityException) {
+                _uiState.value = WifiScanUiState.NoPermission
+            } catch (e: Exception) {
+                _uiState.value = WifiScanUiState.Error(e.message ?: "Unknown error")
+            }
+        }
+    }
+
+    fun setBandFilter(band: WifiBand?) {
+        val current = _uiState.value as? WifiScanUiState.Success ?: return
+        _uiState.value = current.copy(bandFilter = band)
+    }
+
+    fun setSortOrder(order: ApSortOrder) {
+        val current = _uiState.value as? WifiScanUiState.Success ?: return
+        _uiState.value = current.copy(sortOrder = order)
+    }
+
+    fun selectAccessPoint(ap: WifiAccessPoint?) {
+        val current = _uiState.value as? WifiScanUiState.Success ?: return
+        _uiState.value = current.copy(selectedAp = ap)
+    }
+
+    fun toggleAutoRefresh() {
+        if (_autoRefresh.value) {
+            stopAutoRefresh()
+        } else {
+            startAutoRefresh()
+        }
+    }
+
+    private fun startAutoRefresh() {
+        _autoRefresh.value = true
+        autoRefreshJob?.cancel()
+        autoRefreshJob = viewModelScope.launch {
+            while (true) {
+                delay(AUTO_REFRESH_INTERVAL_MS)
+                if (_uiState.value !is WifiScanUiState.Scanning) {
+                    startScan()
+                }
+            }
+        }
+    }
+
+    private fun stopAutoRefresh() {
+        _autoRefresh.value = false
+        autoRefreshJob?.cancel()
+        autoRefreshJob = null
+    }
+
+    fun onRetry() {
+        _uiState.value = WifiScanUiState.Idle
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        stopAutoRefresh()
+        scanJob?.cancel()
+    }
+
+    companion object {
+        private const val AUTO_REFRESH_INTERVAL_MS = 10_000L
+    }
+}

--- a/app/src/main/kotlin/com/example/netswissknife/app/wifi/WifiScanRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/example/netswissknife/app/wifi/WifiScanRepositoryImpl.kt
@@ -1,0 +1,240 @@
+package com.example.netswissknife.app.wifi
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import android.net.wifi.ScanResult
+import android.net.wifi.WifiInfo
+import android.net.wifi.WifiManager
+import android.os.Build
+import com.example.netswissknife.core.network.lan.OuiDatabase
+import com.example.netswissknife.core.network.wifi.WifiAccessPoint
+import com.example.netswissknife.core.network.wifi.WifiBand
+import com.example.netswissknife.core.network.wifi.WifiChannelHelper
+import com.example.netswissknife.core.network.wifi.WifiChannelInfo
+import com.example.netswissknife.core.network.wifi.WifiConnectionInfo
+import com.example.netswissknife.core.network.wifi.WifiScanRepository
+import com.example.netswissknife.core.network.wifi.WifiScanResult
+import com.example.netswissknife.core.network.wifi.WifiSecurity
+import com.example.netswissknife.core.network.wifi.WifiStandard
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlin.math.pow
+
+class WifiScanRepositoryImpl(private val context: Context) : WifiScanRepository {
+
+    private val wifiManager: WifiManager by lazy {
+        context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
+    }
+
+    private val connectivityManager: ConnectivityManager by lazy {
+        context.applicationContext.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+    }
+
+    override val isSupported: Boolean
+        get() = context.packageManager.hasSystemFeature(PackageManager.FEATURE_WIFI)
+
+    override suspend fun scan(): WifiScanResult = withContext(Dispatchers.IO) {
+        val rawResults: List<ScanResult> = wifiManager.scanResults ?: emptyList()
+        val connectedBssid = getConnectedBssid()
+        val connectedInfo = getConnectionInfo(connectedBssid)
+
+        val accessPoints = rawResults
+            .map { sr -> mapScanResult(sr, connectedBssid) }
+            .sortedByDescending { it.rssi }
+
+        val channels = buildChannelInfo(accessPoints)
+
+        WifiScanResult(
+            accessPoints = accessPoints,
+            channels = channels,
+            connectedNetwork = connectedInfo,
+            scanTimestampMs = System.currentTimeMillis(),
+            isWifiEnabled = wifiManager.isWifiEnabled
+        )
+    }
+
+    // ── Connected network info ────────────────────────────────────────────────
+
+    private fun getConnectedBssid(): String? {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            val network = connectivityManager.activeNetwork ?: return null
+            val caps = connectivityManager.getNetworkCapabilities(network) ?: return null
+            if (!caps.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) return null
+            val wifiInfo = caps.transportInfo as? WifiInfo ?: return null
+            wifiInfo.bssid?.takeIf { it != "02:00:00:00:00:00" }
+        } else {
+            @Suppress("DEPRECATION")
+            wifiManager.connectionInfo?.bssid?.takeIf { it != "02:00:00:00:00:00" }
+        }
+    }
+
+    private fun getConnectionInfo(connectedBssid: String?): WifiConnectionInfo? {
+        if (connectedBssid == null) return null
+
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            val network = connectivityManager.activeNetwork ?: return null
+            val caps = connectivityManager.getNetworkCapabilities(network) ?: return null
+            if (!caps.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) return null
+            val wi = caps.transportInfo as? WifiInfo ?: return null
+            buildConnectionInfo(wi)
+        } else {
+            @Suppress("DEPRECATION")
+            val wi = wifiManager.connectionInfo ?: return null
+            buildConnectionInfo(wi)
+        }
+    }
+
+    private fun buildConnectionInfo(wi: WifiInfo): WifiConnectionInfo? {
+        val rawSsid = wi.ssid ?: return null
+        val ssid = rawSsid.removeSurrounding("\"")
+        if (ssid == "<unknown ssid>" || ssid.isBlank()) return null
+
+        val frequency = wi.frequency
+        val band = WifiBand.fromFrequency(frequency)
+        val channel = WifiChannelHelper.frequencyToChannel(frequency, band)
+
+        val txSpeed = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) wi.txLinkSpeedMbps else -1
+        val rxSpeed = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) wi.rxLinkSpeedMbps else -1
+        val standard = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            mapWifiInfoStandard(wi.wifiStandard)
+        } else {
+            inferStandardFromBand(band)
+        }
+
+        @Suppress("DEPRECATION")
+        val ipInt = wi.ipAddress
+        val ipAddress = intToIpAddress(ipInt)
+
+        // Find the capabilities from scan results to determine security
+        val security = wifiManager.scanResults
+            ?.find { it.BSSID == wi.bssid }
+            ?.capabilities
+            ?.let { WifiSecurity.fromCapabilities(it) }
+            ?: WifiSecurity.UNKNOWN
+
+        return WifiConnectionInfo(
+            ssid = ssid,
+            bssid = wi.bssid ?: "",
+            rssi = wi.rssi,
+            frequency = frequency,
+            channel = channel,
+            band = band,
+            linkSpeedMbps = wi.linkSpeed,
+            txLinkSpeedMbps = txSpeed,
+            rxLinkSpeedMbps = rxSpeed,
+            ipAddress = ipAddress,
+            standard = standard,
+            security = security
+        )
+    }
+
+    // ── Scan result mapping ───────────────────────────────────────────────────
+
+    private fun mapScanResult(sr: ScanResult, connectedBssid: String?): WifiAccessPoint {
+        val band = WifiBand.fromFrequency(sr.frequency)
+        val channel = WifiChannelHelper.frequencyToChannel(sr.frequency, band)
+        val security = WifiSecurity.fromCapabilities(sr.capabilities ?: "")
+        val standard = getScanResultStandard(sr, band)
+        val widthMhz = WifiChannelHelper.channelWidthMhz(sr.channelWidth)
+        val vendor = OuiDatabase.lookup(sr.BSSID ?: "") ?: ""
+
+        return WifiAccessPoint(
+            ssid = sr.SSID?.removeSurrounding("\"") ?: "",
+            bssid = sr.BSSID ?: "",
+            rssi = sr.level,
+            frequency = sr.frequency,
+            channelWidthMhz = widthMhz,
+            capabilities = sr.capabilities ?: "",
+            channel = channel,
+            band = band,
+            standard = standard,
+            security = security,
+            isConnected = (sr.BSSID != null && sr.BSSID == connectedBssid),
+            vendor = vendor,
+            centerFrequency0 = sr.centerFreq0,
+            centerFrequency1 = sr.centerFreq1,
+            timestampUs = sr.timestamp
+        )
+    }
+
+    // ── Channel congestion ────────────────────────────────────────────────────
+
+    private fun buildChannelInfo(accessPoints: List<WifiAccessPoint>): List<WifiChannelInfo> {
+        val byChannel = accessPoints.groupBy { it.channel }
+
+        return byChannel.map { (channel, aps) ->
+            val band = aps.first().band
+            val freqMhz = aps.first().frequency
+
+            // Effective interference = sum of linear signal powers (in arbitrary units)
+            // for APs on this channel and overlapping channels (2.4 GHz only).
+            val interference = when (band) {
+                WifiBand.BAND_2_4GHZ -> {
+                    val overlapping = WifiChannelHelper.overlapping24GHzChannels(channel)
+                    accessPoints
+                        .filter { it.channel in overlapping }
+                        .sumOf { 10.0.pow(it.rssi / 10.0) }
+                }
+                else -> aps.sumOf { 10.0.pow(it.rssi / 10.0) }
+            }
+
+            // Normalize: treat -40 dBm * 10 APs as "very busy" → score ≈ 1.0
+            val maxInterference = 10.0.pow(-40.0 / 10.0) * 10.0
+            val congestion = (interference / maxInterference).coerceIn(0.0, 1.0).toFloat()
+
+            WifiChannelInfo(
+                channel = channel,
+                frequencyMhz = freqMhz,
+                band = band,
+                accessPointCount = aps.size,
+                congestionScore = congestion,
+                accessPoints = aps.sortedByDescending { it.rssi }
+            )
+        }.sortedWith(compareBy({ it.band.ordinal }, { it.channel }))
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private fun getScanResultStandard(sr: ScanResult, band: WifiBand): WifiStandard {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            when (sr.wifiStandard) {
+                ScanResult.WIFI_STANDARD_LEGACY -> WifiStandard.LEGACY
+                ScanResult.WIFI_STANDARD_11N    -> WifiStandard.WIFI_4
+                ScanResult.WIFI_STANDARD_11AC   -> WifiStandard.WIFI_5
+                ScanResult.WIFI_STANDARD_11AX   -> if (band == WifiBand.BAND_6GHZ) WifiStandard.WIFI_6E else WifiStandard.WIFI_6
+                ScanResult.WIFI_STANDARD_11AD   -> WifiStandard.LEGACY
+                ScanResult.WIFI_STANDARD_11BE   -> WifiStandard.WIFI_7
+                else -> WifiStandard.UNKNOWN
+            }
+        } else {
+            inferStandardFromBand(band)
+        }
+    }
+
+    private fun inferStandardFromBand(band: WifiBand): WifiStandard = when (band) {
+        WifiBand.BAND_6GHZ  -> WifiStandard.WIFI_6E
+        WifiBand.BAND_5GHZ  -> WifiStandard.WIFI_5
+        WifiBand.BAND_2_4GHZ -> WifiStandard.WIFI_4
+        WifiBand.BAND_60GHZ -> WifiStandard.LEGACY
+        WifiBand.UNKNOWN    -> WifiStandard.UNKNOWN
+    }
+
+    private fun mapWifiInfoStandard(standard: Int): WifiStandard {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) return WifiStandard.UNKNOWN
+        return when (standard) {
+            ScanResult.WIFI_STANDARD_LEGACY -> WifiStandard.LEGACY
+            ScanResult.WIFI_STANDARD_11N    -> WifiStandard.WIFI_4
+            ScanResult.WIFI_STANDARD_11AC   -> WifiStandard.WIFI_5
+            ScanResult.WIFI_STANDARD_11AX   -> WifiStandard.WIFI_6
+            ScanResult.WIFI_STANDARD_11BE   -> WifiStandard.WIFI_7
+            else -> WifiStandard.UNKNOWN
+        }
+    }
+
+    private fun intToIpAddress(ip: Int): String {
+        if (ip == 0) return ""
+        return "${ip and 0xFF}.${(ip shr 8) and 0xFF}.${(ip shr 16) and 0xFF}.${(ip shr 24) and 0xFF}"
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -224,6 +224,44 @@
     <string name="crash_share_subject">Net Swiss Knife – Crash Report</string>
     <string name="crash_share_title">Share crash report via…</string>
 
+    <!-- Wi-Fi Scanner Screen -->
+    <string name="wifi_screen_title">Wi-Fi Scanner</string>
+    <string name="wifi_screen_subtitle">Scan nearby access points and analyse channel utilisation</string>
+    <string name="wifi_scan_button">Scan</string>
+    <string name="wifi_scanning">Scanning for networks…</string>
+    <string name="wifi_auto_refresh">Auto-refresh</string>
+    <string name="wifi_networks_found">%1$d networks · %2$d SSIDs</string>
+    <string name="wifi_no_permission_title">Location Permission Required</string>
+    <string name="wifi_no_permission_body">Android requires Location permission to scan for nearby Wi-Fi networks.</string>
+    <string name="wifi_grant_permission">Grant Permission</string>
+    <string name="wifi_disabled_title">Wi-Fi is Off</string>
+    <string name="wifi_disabled_body">Enable Wi-Fi in device settings, then tap Retry.</string>
+    <string name="wifi_not_supported_title">Wi-Fi Not Available</string>
+    <string name="wifi_not_supported_body">This device does not have Wi-Fi hardware.</string>
+    <string name="wifi_error_title">Scan Failed</string>
+    <string name="wifi_retry">Retry</string>
+    <string name="wifi_filter_all">All</string>
+    <string name="wifi_band_ghz">%1$s GHz</string>
+    <string name="wifi_sort_label">Sort:</string>
+    <string name="wifi_channel_chart_title">Channel Utilisation</string>
+    <string name="wifi_connected_badge">Connected</string>
+    <string name="wifi_hidden_badge">Hidden</string>
+    <string name="wifi_detail_band">Band</string>
+    <string name="wifi_detail_channel">Channel</string>
+    <string name="wifi_detail_width">Width</string>
+    <string name="wifi_detail_standard">Standard</string>
+    <string name="wifi_detail_max_speed">Max Speed</string>
+    <string name="wifi_detail_vendor">Vendor</string>
+    <string name="wifi_detail_security">Security</string>
+    <string name="wifi_detail_ip">IP Address</string>
+    <string name="wifi_detail_link_speed">Link Speed</string>
+    <string name="wifi_detail_tx_speed">TX Speed</string>
+    <string name="wifi_detail_rx_speed">RX Speed</string>
+    <string name="wifi_detail_signal">Signal</string>
+    <string name="wifi_connected_network_header">Currently Connected</string>
+    <string name="wifi_network_info_header">Network Information</string>
+    <string name="wifi_live_connection_header">Live Connection</string>
+
     <!-- DNS Record labels -->
     <string name="dns_ipv4_prefix">IPv4</string>
     <string name="dns_ipv6_prefix">IPv6</string>

--- a/core-domain/src/main/kotlin/com/example/netswissknife/core/domain/WifiScanUseCase.kt
+++ b/core-domain/src/main/kotlin/com/example/netswissknife/core/domain/WifiScanUseCase.kt
@@ -1,0 +1,29 @@
+package com.example.netswissknife.core.domain
+
+import com.example.netswissknife.core.network.wifi.WifiScanRepository
+import com.example.netswissknife.core.network.wifi.WifiScanResult
+
+/**
+ * Use case that orchestrates a Wi-Fi environment scan.
+ *
+ * The use case is a thin delegation layer – it validates preconditions and
+ * delegates to the [WifiScanRepository] for the actual platform work.
+ */
+class WifiScanUseCase(private val repository: WifiScanRepository) {
+
+    /** True when the device has Wi-Fi hardware. */
+    val isSupported: Boolean get() = repository.isSupported
+
+    /**
+     * Trigger (or read cached) scan results.
+     *
+     * @throws WifiNotSupportedException if the device lacks Wi-Fi hardware.
+     * @throws Exception propagated from the repository on I/O or permission errors.
+     */
+    suspend operator fun invoke(): WifiScanResult {
+        if (!repository.isSupported) throw WifiNotSupportedException()
+        return repository.scan()
+    }
+}
+
+class WifiNotSupportedException : Exception("Wi-Fi hardware not available on this device")

--- a/core-domain/src/test/kotlin/com/example/netswissknife/core/domain/WifiScanUseCaseTest.kt
+++ b/core-domain/src/test/kotlin/com/example/netswissknife/core/domain/WifiScanUseCaseTest.kt
@@ -1,0 +1,110 @@
+package com.example.netswissknife.core.domain
+
+import com.example.netswissknife.core.network.wifi.WifiBand
+import com.example.netswissknife.core.network.wifi.WifiScanRepository
+import com.example.netswissknife.core.network.wifi.WifiScanResult
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("WifiScanUseCase")
+class WifiScanUseCaseTest {
+
+    private lateinit var repository: WifiScanRepository
+    private lateinit var useCase: WifiScanUseCase
+
+    private val emptyResult = WifiScanResult(
+        accessPoints = emptyList(),
+        channels = emptyList(),
+        connectedNetwork = null,
+        scanTimestampMs = 1_000L,
+        isWifiEnabled = true
+    )
+
+    @BeforeEach
+    fun setUp() {
+        repository = mockk()
+        useCase = WifiScanUseCase(repository)
+    }
+
+    @Nested
+    @DisplayName("isSupported")
+    inner class IsSupportedTest {
+        @Test
+        fun `delegates to repository`() {
+            every { repository.isSupported } returns true
+            assertTrue(useCase.isSupported)
+        }
+
+        @Test
+        fun `returns false when repository is not supported`() {
+            every { repository.isSupported } returns false
+            assertFalse(useCase.isSupported)
+        }
+    }
+
+    @Nested
+    @DisplayName("invoke")
+    inner class InvokeTest {
+        @Test
+        fun `throws WifiNotSupportedException when not supported`() = runTest {
+            every { repository.isSupported } returns false
+            assertThrows(WifiNotSupportedException::class.java) {
+                kotlinx.coroutines.runBlocking { useCase() }
+            }
+        }
+
+        @Test
+        fun `delegates to repository when supported`() = runTest {
+            every { repository.isSupported } returns true
+            coEvery { repository.scan() } returns emptyResult
+            val result = useCase()
+            assertEquals(emptyResult, result)
+            coVerify(exactly = 1) { repository.scan() }
+        }
+
+        @Test
+        fun `propagates repository exceptions`() = runTest {
+            every { repository.isSupported } returns true
+            coEvery { repository.scan() } throws SecurityException("Location permission denied")
+            val thrown = assertThrows(SecurityException::class.java) {
+                kotlinx.coroutines.runBlocking { useCase() }
+            }
+            assertEquals("Location permission denied", thrown.message)
+        }
+
+        @Test
+        fun `result contains correct scan timestamp`() = runTest {
+            every { repository.isSupported } returns true
+            val timestamped = emptyResult.copy(scanTimestampMs = 99_000L)
+            coEvery { repository.scan() } returns timestamped
+            val result = useCase()
+            assertEquals(99_000L, result.scanTimestampMs)
+        }
+
+        @Test
+        fun `access points are passed through unchanged`() = runTest {
+            every { repository.isSupported } returns true
+            val resultWith3Aps = emptyResult.copy(
+                accessPoints = listOf(
+                    mockk(relaxed = true),
+                    mockk(relaxed = true),
+                    mockk(relaxed = true)
+                )
+            )
+            coEvery { repository.scan() } returns resultWith3Aps
+            val result = useCase()
+            assertEquals(3, result.accessPoints.size)
+        }
+    }
+}

--- a/core-network/src/main/kotlin/com/example/netswissknife/core/network/wifi/WifiAccessPoint.kt
+++ b/core-network/src/main/kotlin/com/example/netswissknife/core/network/wifi/WifiAccessPoint.kt
@@ -1,0 +1,105 @@
+package com.example.netswissknife.core.network.wifi
+
+/**
+ * Represents a single discovered Wi-Fi access point from a scan.
+ */
+data class WifiAccessPoint(
+    /** Network name (SSID). Empty string for hidden networks. */
+    val ssid: String,
+    /** BSSID (MAC address) of the access point. */
+    val bssid: String,
+    /** Received signal strength in dBm (negative value; higher = stronger). */
+    val rssi: Int,
+    /** Center frequency of the primary channel in MHz. */
+    val frequency: Int,
+    /** Channel width in MHz (20, 40, 80, 160, 320). */
+    val channelWidthMhz: Int,
+    /** Raw capabilities string from the scan result (e.g. "[WPA2-PSK-CCMP][ESS]"). */
+    val capabilities: String,
+    /** Logical Wi-Fi channel number. */
+    val channel: Int,
+    /** Frequency band (2.4 / 5 / 6 GHz). */
+    val band: WifiBand,
+    /** Wi-Fi generation standard. */
+    val standard: WifiStandard,
+    /** Parsed security type. */
+    val security: WifiSecurity,
+    /** True when this AP is the currently associated network. */
+    val isConnected: Boolean,
+    /** Hardware vendor resolved from the BSSID OUI prefix, or empty if unknown. */
+    val vendor: String,
+    /** Center frequency of the first segment (used for 80+80 MHz). */
+    val centerFrequency0: Int,
+    /** Center frequency of the second segment (used for 80+80 MHz; 0 if unused). */
+    val centerFrequency1: Int,
+    /** Timestamp in microseconds since device boot when the AP was last seen. */
+    val timestampUs: Long
+) {
+    /** Display name: falls back to "<Hidden Network>" when SSID is blank. */
+    val displaySsid: String get() = ssid.ifBlank { "<Hidden Network>" }
+
+    /**
+     * Signal quality as a percentage [0–100].
+     * Derived from a simple RSSI ladder calibrated to common home/office signals.
+     */
+    val signalQualityPercent: Int get() = when {
+        rssi >= -50 -> 100
+        rssi >= -60 -> (100 - ((-50 - rssi) * 2)).coerceIn(0, 100)
+        rssi >= -70 -> (80  - ((-60 - rssi) * 2)).coerceIn(0, 100)
+        rssi >= -80 -> (60  - ((-70 - rssi) * 2)).coerceIn(0, 100)
+        rssi >= -90 -> (40  - ((-80 - rssi) * 2)).coerceIn(0, 100)
+        else        -> 0
+    }
+
+    /**
+     * Coarse quality bucket: EXCELLENT / GOOD / FAIR / WEAK / POOR.
+     * Primarily used for colour-coding in the UI layer.
+     */
+    val signalLevel: SignalLevel get() = when {
+        rssi >= -50 -> SignalLevel.EXCELLENT
+        rssi >= -60 -> SignalLevel.GOOD
+        rssi >= -70 -> SignalLevel.FAIR
+        rssi >= -80 -> SignalLevel.WEAK
+        else        -> SignalLevel.POOR
+    }
+
+    /** Whether the AP operates in the 80+80 MHz split-channel mode. */
+    val is80Plus80: Boolean get() = channelWidthMhz == 160 && centerFrequency1 != 0
+}
+
+enum class SignalLevel { EXCELLENT, GOOD, FAIR, WEAK, POOR }
+
+/**
+ * Pure-Kotlin helpers for converting raw scan data to channel and band information.
+ * These are used by both the Android repository impl and tests.
+ */
+object WifiChannelHelper {
+
+    fun frequencyToChannel(frequencyMhz: Int, band: WifiBand): Int = when (band) {
+        WifiBand.BAND_2_4GHZ -> when (frequencyMhz) {
+            2484 -> 14
+            else -> ((frequencyMhz - 2407) / 5).coerceIn(1, 13)
+        }
+        WifiBand.BAND_5GHZ  -> ((frequencyMhz - 5000) / 5).coerceIn(36, 177)
+        WifiBand.BAND_6GHZ  -> ((frequencyMhz - 5950) / 5).coerceIn(1, 233)
+        WifiBand.BAND_60GHZ -> ((frequencyMhz - 56160) / 2160).coerceIn(1, 6)
+        WifiBand.UNKNOWN    -> 0
+    }
+
+    fun channelWidthMhz(channelWidthConstant: Int): Int = when (channelWidthConstant) {
+        0 -> 20   // CHANNEL_WIDTH_20MHZ
+        1 -> 40   // CHANNEL_WIDTH_40MHZ
+        2 -> 80   // CHANNEL_WIDTH_80MHZ
+        3 -> 160  // CHANNEL_WIDTH_160MHZ
+        4 -> 160  // CHANNEL_WIDTH_80MHZ_PLUS_MHZ (80+80)
+        5 -> 320  // CHANNEL_WIDTH_320MHZ (Wi-Fi 7)
+        else -> 20
+    }
+
+    /**
+     * Returns the set of 2.4 GHz channel numbers that overlap with [channel].
+     * Channels overlap if they are within ±4 of each other.
+     */
+    fun overlapping24GHzChannels(channel: Int): Set<Int> =
+        ((channel - 4)..(channel + 4)).filter { it in 1..14 }.toSet()
+}

--- a/core-network/src/main/kotlin/com/example/netswissknife/core/network/wifi/WifiBand.kt
+++ b/core-network/src/main/kotlin/com/example/netswissknife/core/network/wifi/WifiBand.kt
@@ -1,0 +1,24 @@
+package com.example.netswissknife.core.network.wifi
+
+enum class WifiBand(
+    val displayName: String,
+    val ghzLabel: String,
+    val minFrequencyMhz: Int,
+    val maxFrequencyMhz: Int
+) {
+    BAND_2_4GHZ("2.4 GHz", "2.4", 2400, 2500),
+    BAND_5GHZ("5 GHz", "5", 4900, 5925),
+    BAND_6GHZ("6 GHz", "6", 5925, 7125),
+    BAND_60GHZ("60 GHz", "60", 57000, 71000),
+    UNKNOWN("Unknown", "?", 0, 0);
+
+    companion object {
+        fun fromFrequency(frequencyMhz: Int): WifiBand = when (frequencyMhz) {
+            in 2400..2500 -> BAND_2_4GHZ
+            in 4900..5925 -> BAND_5GHZ
+            in 5925..7125 -> BAND_6GHZ
+            in 57000..71000 -> BAND_60GHZ
+            else -> UNKNOWN
+        }
+    }
+}

--- a/core-network/src/main/kotlin/com/example/netswissknife/core/network/wifi/WifiChannelInfo.kt
+++ b/core-network/src/main/kotlin/com/example/netswissknife/core/network/wifi/WifiChannelInfo.kt
@@ -1,0 +1,30 @@
+package com.example.netswissknife.core.network.wifi
+
+/**
+ * Aggregated statistics for a single Wi-Fi channel, computed from scan results.
+ */
+data class WifiChannelInfo(
+    /** Logical channel number (e.g. 1, 6, 11 for 2.4 GHz; 36, 40 … for 5 GHz). */
+    val channel: Int,
+    /** Primary center frequency of this channel in MHz. */
+    val frequencyMhz: Int,
+    val band: WifiBand,
+    /** Number of access points detected on this channel. */
+    val accessPointCount: Int,
+    /**
+     * Congestion score in [0.0, 1.0].
+     * Derived from the number and signal strength of APs using this channel
+     * (including overlapping channels for 2.4 GHz).
+     */
+    val congestionScore: Float,
+    /** Access points operating on this exact channel, sorted by RSSI descending. */
+    val accessPoints: List<WifiAccessPoint>
+) {
+    /** Human-readable congestion label for the UI. */
+    val congestionLabel: String get() = when {
+        congestionScore >= 0.75f -> "Very Busy"
+        congestionScore >= 0.50f -> "Busy"
+        congestionScore >= 0.25f -> "Moderate"
+        else                     -> "Clear"
+    }
+}

--- a/core-network/src/main/kotlin/com/example/netswissknife/core/network/wifi/WifiConnectionInfo.kt
+++ b/core-network/src/main/kotlin/com/example/netswissknife/core/network/wifi/WifiConnectionInfo.kt
@@ -1,0 +1,36 @@
+package com.example.netswissknife.core.network.wifi
+
+/**
+ * Detailed information about the currently connected Wi-Fi network.
+ * This is richer than [WifiAccessPoint] because it includes live link
+ * statistics only available when actively associated.
+ */
+data class WifiConnectionInfo(
+    val ssid: String,
+    val bssid: String,
+    val rssi: Int,
+    val frequency: Int,
+    val channel: Int,
+    val band: WifiBand,
+    /** Negotiated link speed in Mbps (legacy symmetric value). */
+    val linkSpeedMbps: Int,
+    /** TX (upload) link speed in Mbps. Available on API 29+; −1 if unavailable. */
+    val txLinkSpeedMbps: Int,
+    /** RX (download) link speed in Mbps. Available on API 29+; −1 if unavailable. */
+    val rxLinkSpeedMbps: Int,
+    /** Dotted-decimal IPv4 address assigned to the device, or empty string. */
+    val ipAddress: String,
+    val standard: WifiStandard,
+    val security: WifiSecurity,
+    /** SSID of the Wi-Fi network (same as ssid; kept for explicit labelling). */
+    val networkSsid: String = ssid
+) {
+    val signalQualityPercent: Int get() = when {
+        rssi >= -50 -> 100
+        rssi >= -60 -> (100 - ((-50 - rssi) * 2)).coerceIn(0, 100)
+        rssi >= -70 -> (80  - ((-60 - rssi) * 2)).coerceIn(0, 100)
+        rssi >= -80 -> (60  - ((-70 - rssi) * 2)).coerceIn(0, 100)
+        rssi >= -90 -> (40  - ((-80 - rssi) * 2)).coerceIn(0, 100)
+        else        -> 0
+    }
+}

--- a/core-network/src/main/kotlin/com/example/netswissknife/core/network/wifi/WifiScanRepository.kt
+++ b/core-network/src/main/kotlin/com/example/netswissknife/core/network/wifi/WifiScanRepository.kt
@@ -1,0 +1,21 @@
+package com.example.netswissknife.core.network.wifi
+
+/**
+ * Contract for obtaining Wi-Fi scan results.
+ *
+ * The interface is platform-agnostic (pure Kotlin); implementations in the
+ * `:app` module use Android's [android.net.wifi.WifiManager].
+ */
+interface WifiScanRepository {
+    /**
+     * Returns true when the device has Wi-Fi hardware.
+     * Always check this before calling [scan].
+     */
+    val isSupported: Boolean
+
+    /**
+     * Performs (or reads cached) scan results and returns an aggregated [WifiScanResult].
+     * May throw if Wi-Fi is disabled or the required permissions are missing.
+     */
+    suspend fun scan(): WifiScanResult
+}

--- a/core-network/src/main/kotlin/com/example/netswissknife/core/network/wifi/WifiScanResult.kt
+++ b/core-network/src/main/kotlin/com/example/netswissknife/core/network/wifi/WifiScanResult.kt
@@ -1,0 +1,42 @@
+package com.example.netswissknife.core.network.wifi
+
+/**
+ * Complete result of a Wi-Fi environment scan.
+ */
+data class WifiScanResult(
+    /** All discovered access points, sorted by RSSI descending (strongest first). */
+    val accessPoints: List<WifiAccessPoint>,
+    /** Per-channel statistics across all bands detected. */
+    val channels: List<WifiChannelInfo>,
+    /** Live info about the currently associated network; null if not connected to Wi-Fi. */
+    val connectedNetwork: WifiConnectionInfo?,
+    /** Wall-clock time when the scan completed (System.currentTimeMillis()). */
+    val scanTimestampMs: Long,
+    /** Whether Wi-Fi is currently enabled on the device. */
+    val isWifiEnabled: Boolean
+) {
+    /** Access points grouped by frequency band. */
+    val byBand: Map<WifiBand, List<WifiAccessPoint>> get() =
+        accessPoints.groupBy { it.band }
+
+    /** All distinct bands present in the scan results. */
+    val detectedBands: List<WifiBand> get() =
+        byBand.keys.sortedBy { it.ordinal }
+
+    /** Total number of unique SSIDs (networks, not BSSIDs). */
+    val uniqueNetworkCount: Int get() =
+        accessPoints.map { it.ssid }.toSet().size
+
+    /** Channel with the highest congestion score, or null if no channels. */
+    val busiestChannel: WifiChannelInfo? get() =
+        channels.maxByOrNull { it.congestionScore }
+
+    /** Recommended clear channel for 2.4 GHz (one of 1, 6, 11). */
+    val bestChannel24GHz: Int? get() {
+        val standard24 = listOf(1, 6, 11)
+        return standard24.minByOrNull { ch ->
+            channels.find { it.channel == ch && it.band == WifiBand.BAND_2_4GHZ }
+                ?.congestionScore ?: 0f
+        }
+    }
+}

--- a/core-network/src/main/kotlin/com/example/netswissknife/core/network/wifi/WifiSecurity.kt
+++ b/core-network/src/main/kotlin/com/example/netswissknife/core/network/wifi/WifiSecurity.kt
@@ -1,0 +1,30 @@
+package com.example.netswissknife.core.network.wifi
+
+enum class WifiSecurity(val displayName: String, val isEncrypted: Boolean) {
+    OPEN("Open", false),
+    OWE("Enhanced Open (OWE)", true),
+    WEP("WEP", true),
+    WPA("WPA", true),
+    WPA2("WPA2", true),
+    WPA3("WPA3", true),
+    WPA2_WPA3("WPA2/WPA3", true),
+    WPA_WPA2("WPA/WPA2", true),
+    UNKNOWN("Unknown", false);
+
+    companion object {
+        fun fromCapabilities(capabilities: String): WifiSecurity {
+            val caps = capabilities.uppercase()
+            return when {
+                caps.contains("SAE") && caps.contains("PSK") -> WPA2_WPA3
+                caps.contains("SAE")                          -> WPA3
+                caps.contains("OWE")                          -> OWE
+                caps.contains("WPA2") && caps.contains("WPA-") -> WPA_WPA2
+                caps.contains("WPA2")                         -> WPA2
+                caps.contains("WPA")                          -> WPA
+                caps.contains("WEP")                          -> WEP
+                caps.contains("ESS") || caps.isEmpty()        -> OPEN
+                else                                          -> OPEN
+            }
+        }
+    }
+}

--- a/core-network/src/main/kotlin/com/example/netswissknife/core/network/wifi/WifiStandard.kt
+++ b/core-network/src/main/kotlin/com/example/netswissknife/core/network/wifi/WifiStandard.kt
@@ -1,0 +1,26 @@
+package com.example.netswissknife.core.network.wifi
+
+enum class WifiStandard(
+    val displayName: String,
+    val generationLabel: String,
+    val protocolName: String
+) {
+    LEGACY("Legacy", "Wi-Fi", "802.11 a/b/g"),
+    WIFI_4("Wi-Fi 4", "Wi-Fi 4", "802.11n"),
+    WIFI_5("Wi-Fi 5", "Wi-Fi 5", "802.11ac"),
+    WIFI_6("Wi-Fi 6", "Wi-Fi 6", "802.11ax"),
+    WIFI_6E("Wi-Fi 6E", "Wi-Fi 6E", "802.11ax 6 GHz"),
+    WIFI_7("Wi-Fi 7", "Wi-Fi 7", "802.11be"),
+    UNKNOWN("Unknown", "Unknown", "Unknown");
+
+    /** Maximum theoretical throughput label for UI display. */
+    val maxSpeedLabel: String get() = when (this) {
+        LEGACY -> "54 Mbps"
+        WIFI_4 -> "600 Mbps"
+        WIFI_5 -> "3.5 Gbps"
+        WIFI_6 -> "9.6 Gbps"
+        WIFI_6E -> "9.6 Gbps"
+        WIFI_7 -> "46 Gbps"
+        UNKNOWN -> "—"
+    }
+}

--- a/core-network/src/test/kotlin/com/example/netswissknife/core/network/wifi/WifiAccessPointTest.kt
+++ b/core-network/src/test/kotlin/com/example/netswissknife/core/network/wifi/WifiAccessPointTest.kt
@@ -1,0 +1,130 @@
+package com.example.netswissknife.core.network.wifi
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("WifiAccessPoint")
+class WifiAccessPointTest {
+
+    private fun makeAp(
+        ssid: String = "TestNetwork",
+        bssid: String = "AA:BB:CC:DD:EE:FF",
+        rssi: Int = -60,
+        isConnected: Boolean = false
+    ) = WifiAccessPoint(
+        ssid = ssid,
+        bssid = bssid,
+        rssi = rssi,
+        frequency = 5180,
+        channelWidthMhz = 80,
+        capabilities = "[WPA2-PSK-CCMP][ESS]",
+        channel = 36,
+        band = WifiBand.BAND_5GHZ,
+        standard = WifiStandard.WIFI_5,
+        security = WifiSecurity.WPA2,
+        isConnected = isConnected,
+        vendor = "Cisco",
+        centerFrequency0 = 5210,
+        centerFrequency1 = 0,
+        timestampUs = 0L
+    )
+
+    @Nested
+    @DisplayName("displaySsid")
+    inner class DisplaySsid {
+        @Test
+        fun `non-blank SSID is returned as-is`() {
+            val ap = makeAp(ssid = "MyNetwork")
+            assertEquals("MyNetwork", ap.displaySsid)
+        }
+
+        @Test
+        fun `blank SSID falls back to hidden network label`() {
+            val ap = makeAp(ssid = "")
+            assertEquals("<Hidden Network>", ap.displaySsid)
+        }
+    }
+
+    @Nested
+    @DisplayName("signalQualityPercent")
+    inner class SignalQuality {
+        @Test
+        fun `rssi at -50 gives 100 percent`() {
+            assertEquals(100, makeAp(rssi = -50).signalQualityPercent)
+        }
+
+        @Test
+        fun `rssi above -50 gives 100 percent`() {
+            assertEquals(100, makeAp(rssi = -30).signalQualityPercent)
+        }
+
+        @Test
+        fun `rssi at -60 gives 80 percent`() {
+            assertEquals(80, makeAp(rssi = -60).signalQualityPercent)
+        }
+
+        @Test
+        fun `rssi at -70 gives 60 percent`() {
+            assertEquals(60, makeAp(rssi = -70).signalQualityPercent)
+        }
+
+        @Test
+        fun `rssi at -80 gives 40 percent`() {
+            assertEquals(40, makeAp(rssi = -80).signalQualityPercent)
+        }
+
+        @Test
+        fun `rssi below -90 gives 0 percent`() {
+            assertEquals(0, makeAp(rssi = -100).signalQualityPercent)
+        }
+    }
+
+    @Nested
+    @DisplayName("signalLevel")
+    inner class SignalLevelTest {
+        @Test
+        fun `rssi -45 is EXCELLENT`() {
+            assertEquals(SignalLevel.EXCELLENT, makeAp(rssi = -45).signalLevel)
+        }
+
+        @Test
+        fun `rssi -55 is GOOD`() {
+            assertEquals(SignalLevel.GOOD, makeAp(rssi = -55).signalLevel)
+        }
+
+        @Test
+        fun `rssi -65 is FAIR`() {
+            assertEquals(SignalLevel.FAIR, makeAp(rssi = -65).signalLevel)
+        }
+
+        @Test
+        fun `rssi -75 is WEAK`() {
+            assertEquals(SignalLevel.WEAK, makeAp(rssi = -75).signalLevel)
+        }
+
+        @Test
+        fun `rssi -85 is POOR`() {
+            assertEquals(SignalLevel.POOR, makeAp(rssi = -85).signalLevel)
+        }
+    }
+
+    @Nested
+    @DisplayName("is80Plus80")
+    inner class Is80Plus80Test {
+        @Test
+        fun `80+80 mode detected when 160 MHz and non-zero centerFreq1`() {
+            val ap = makeAp().copy(channelWidthMhz = 160, centerFrequency1 = 5775)
+            assertTrue(ap.is80Plus80)
+        }
+
+        @Test
+        fun `contiguous 160 MHz is not 80+80`() {
+            val ap = makeAp().copy(channelWidthMhz = 160, centerFrequency1 = 0)
+            assertFalse(ap.is80Plus80)
+        }
+    }
+}

--- a/core-network/src/test/kotlin/com/example/netswissknife/core/network/wifi/WifiChannelHelperTest.kt
+++ b/core-network/src/test/kotlin/com/example/netswissknife/core/network/wifi/WifiChannelHelperTest.kt
@@ -1,0 +1,174 @@
+package com.example.netswissknife.core.network.wifi
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+
+@DisplayName("WifiChannelHelper")
+class WifiChannelHelperTest {
+
+    @Nested
+    @DisplayName("frequencyToChannel – 2.4 GHz")
+    inner class Channel24GHz {
+        @ParameterizedTest(name = "{0} MHz → channel {1}")
+        @CsvSource(
+            "2412, 1",
+            "2417, 2",
+            "2422, 3",
+            "2432, 5",
+            "2437, 6",
+            "2462, 11",
+            "2472, 13",
+            "2484, 14"
+        )
+        fun `maps frequency to correct channel`(freqMhz: Int, expected: Int) {
+            assertEquals(expected, WifiChannelHelper.frequencyToChannel(freqMhz, WifiBand.BAND_2_4GHZ))
+        }
+    }
+
+    @Nested
+    @DisplayName("frequencyToChannel – 5 GHz")
+    inner class Channel5GHz {
+        @ParameterizedTest(name = "{0} MHz → channel {1}")
+        @CsvSource(
+            "5180, 36",
+            "5200, 40",
+            "5220, 44",
+            "5240, 48",
+            "5745, 149",
+            "5785, 157",
+            "5825, 165"
+        )
+        fun `maps frequency to correct channel`(freqMhz: Int, expected: Int) {
+            assertEquals(expected, WifiChannelHelper.frequencyToChannel(freqMhz, WifiBand.BAND_5GHZ))
+        }
+    }
+
+    @Nested
+    @DisplayName("frequencyToChannel – 6 GHz")
+    inner class Channel6GHz {
+        @Test
+        fun `5955 MHz maps to channel 1`() {
+            assertEquals(1, WifiChannelHelper.frequencyToChannel(5955, WifiBand.BAND_6GHZ))
+        }
+
+        @Test
+        fun `6055 MHz maps to channel 21`() {
+            assertEquals(21, WifiChannelHelper.frequencyToChannel(6055, WifiBand.BAND_6GHZ))
+        }
+    }
+
+    @Nested
+    @DisplayName("channelWidthMhz")
+    inner class ChannelWidth {
+        @ParameterizedTest(name = "constant {0} → {1} MHz")
+        @CsvSource(
+            "0, 20",
+            "1, 40",
+            "2, 80",
+            "3, 160",
+            "4, 160",
+            "5, 320",
+            "99, 20"
+        )
+        fun `maps constants to MHz values`(constant: Int, expectedMhz: Int) {
+            assertEquals(expectedMhz, WifiChannelHelper.channelWidthMhz(constant))
+        }
+    }
+
+    @Nested
+    @DisplayName("overlapping24GHzChannels")
+    inner class Overlapping {
+        @Test
+        fun `channel 1 overlaps channels 1 through 5`() {
+            val result = WifiChannelHelper.overlapping24GHzChannels(1)
+            assertTrue(result.containsAll(listOf(1, 2, 3, 4, 5)))
+        }
+
+        @Test
+        fun `channel 6 overlaps channels 2 through 10`() {
+            val result = WifiChannelHelper.overlapping24GHzChannels(6)
+            assertEquals(setOf(2, 3, 4, 5, 6, 7, 8, 9, 10), result)
+        }
+
+        @Test
+        fun `channel 11 overlaps channels 7 through 14`() {
+            val result = WifiChannelHelper.overlapping24GHzChannels(11)
+            assertTrue(result.containsAll(listOf(7, 8, 9, 10, 11, 12, 13)))
+        }
+
+        @Test
+        fun `no channel below 1 in overlap set`() {
+            val result = WifiChannelHelper.overlapping24GHzChannels(1)
+            assertTrue(result.none { it < 1 })
+        }
+
+        @Test
+        fun `no channel above 14 in overlap set`() {
+            val result = WifiChannelHelper.overlapping24GHzChannels(13)
+            assertTrue(result.none { it > 14 })
+        }
+    }
+
+    @Nested
+    @DisplayName("WifiBand.fromFrequency")
+    inner class BandFromFrequency {
+        @Test
+        fun `2412 MHz is 2_4 GHz`() {
+            assertEquals(WifiBand.BAND_2_4GHZ, WifiBand.fromFrequency(2412))
+        }
+
+        @Test
+        fun `5180 MHz is 5 GHz`() {
+            assertEquals(WifiBand.BAND_5GHZ, WifiBand.fromFrequency(5180))
+        }
+
+        @Test
+        fun `5955 MHz is 6 GHz`() {
+            assertEquals(WifiBand.BAND_6GHZ, WifiBand.fromFrequency(5955))
+        }
+
+        @Test
+        fun `unknown frequency returns UNKNOWN`() {
+            assertEquals(WifiBand.UNKNOWN, WifiBand.fromFrequency(1000))
+        }
+    }
+
+    @Nested
+    @DisplayName("WifiSecurity.fromCapabilities")
+    inner class SecurityParsing {
+        @Test
+        fun `SAE only is WPA3`() {
+            assertEquals(WifiSecurity.WPA3, WifiSecurity.fromCapabilities("[SAE][ESS]"))
+        }
+
+        @Test
+        fun `PSK and SAE is WPA2_WPA3`() {
+            assertEquals(WifiSecurity.WPA2_WPA3, WifiSecurity.fromCapabilities("[WPA2-PSK-CCMP][SAE][ESS]"))
+        }
+
+        @Test
+        fun `WPA2-PSK is WPA2`() {
+            assertEquals(WifiSecurity.WPA2, WifiSecurity.fromCapabilities("[WPA2-PSK-CCMP][ESS]"))
+        }
+
+        @Test
+        fun `WEP is WEP`() {
+            assertEquals(WifiSecurity.WEP, WifiSecurity.fromCapabilities("[WEP][ESS]"))
+        }
+
+        @Test
+        fun `ESS only is OPEN`() {
+            assertEquals(WifiSecurity.OPEN, WifiSecurity.fromCapabilities("[ESS]"))
+        }
+
+        @Test
+        fun `OWE is Enhanced Open`() {
+            assertEquals(WifiSecurity.OWE, WifiSecurity.fromCapabilities("[OWE][ESS]"))
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Implements a complete Wi-Fi scanning feature that allows users to discover nearby access points, analyze channel utilization, and view detailed network information. This includes a new UI screen, domain logic, platform-specific repository implementation, and comprehensive test coverage.

## Key Changes

### UI Layer
- **WifiScanScreen.kt**: Main composable screen with state-driven UI that handles:
  - Permission management (location and nearby Wi-Fi devices)
  - Multiple UI states (idle, loading, error, success, disabled, unsupported)
  - Access point list with filtering by frequency band and sorting (signal, SSID, channel)
  - Channel utilization visualization with animated bar charts
  - Auto-refresh capability with configurable intervals
  - Bottom sheet detail view for individual access points
  - Shimmer loading animations

### ViewModel & State Management
- **WifiScanViewModel.kt**: Manages UI state and user interactions:
  - Sealed interface `WifiScanUiState` with 8 distinct states
  - `ApSortOrder` enum for sorting options
  - Auto-refresh job scheduling with configurable intervals
  - Permission and error handling

### Domain Layer
- **WifiScanUseCase.kt**: Thin orchestration layer that validates preconditions and delegates to repository

### Data Layer
- **WifiScanRepositoryImpl.kt**: Android-specific implementation using WifiManager:
  - Scans for access points and retrieves raw scan results
  - Detects connected network information (SSID, BSSID, link speed, channel)
  - Builds channel statistics and congestion metrics
  - Resolves hardware vendors from BSSID OUI prefixes
  - Handles API level differences (Q, R, TIRAMISU)

### Core Models
- **WifiAccessPoint.kt**: Represents a discovered AP with signal quality calculations and signal level classification
- **WifiScanResult.kt**: Complete scan result with access points, channels, and connection info
- **WifiConnectionInfo.kt**: Detailed info about the currently connected network
- **WifiChannelInfo.kt**: Per-channel statistics including congestion scoring
- **WifiBand.kt**: Enum for frequency bands (2.4/5/6/60 GHz) with frequency range mapping
- **WifiStandard.kt**: Enum for Wi-Fi generations (802.11 a/b/g/n/ac/ax/be)
- **WifiSecurity.kt**: Security type detection from capabilities string

### Utilities
- **WifiChannelHelper.kt**: Channel/frequency conversion utilities for all bands with overlap detection

### Dependency Injection
- **WifiScanModule.kt**: Hilt module providing repository and use case singletons

### Tests
- **WifiChannelHelperTest.kt**: Comprehensive parametrized tests for frequency-to-channel mapping and channel width calculations
- **WifiAccessPointTest.kt**: Tests for signal quality calculations and signal level classification
- **WifiScanUseCaseTest.kt**: Tests for use case preconditions and repository delegation

### Resources & Navigation
- Added Wi-Fi scanner strings to `strings.xml`
- Registered new route in navigation system with Wi-Fi icon
- Updated AndroidManifest with required permissions (ACCESS_FINE_LOCATION, NEARBY_WIFI_DEVICES)

## Notable Implementation Details

- **Permission Handling**: Requests location permission on first launch; handles both granted and denied states gracefully
- **Signal Quality**: Implements a calibrated RSSI-to-percentage ladder for intuitive signal strength visualization
- **Channel Visualization**: Animated bar chart showing network density per channel with congestion scoring
- **Band Filtering**: Real-time filtering of access points by frequency band with dynamic UI updates
- **Auto-Refresh**: Configurable background scanning with user-controllable toggle
- **Vendor Resolution**: Integrates with existing OUI database to display hardware manufacturer names
- **API Compatibility**: Handles differences across Android versions (Q, R, TIRAMISU) for Wi-Fi info retrieval

https://claude.ai/code/session_01SB675udTJDM1KmJvLJ38Vo