### PR TITLE
fix: resolve traceroute "no such file or directory" on Android

### DIFF
--- a/core-network/src/main/kotlin/com/example/netswissknife/core/network/traceroute/TracerouteRepositoryImpl.kt
+++ b/core-network/src/main/kotlin/com/example/netswissknife/core/network/traceroute/TracerouteRepositoryImpl.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
+import java.io.File
 import java.net.InetAddress
 
 /**
@@ -12,6 +13,10 @@ import java.net.InetAddress
  *
  * On Android, raw ICMP sockets require root privileges, so we rely on the
  * shell binary which uses TTL-expired ICMP probes internally.
+ *
+ * Binary search order:
+ *   /system/bin/traceroute → /system/xbin/traceroute → traceroute (PATH)
+ *   /system/bin/tracepath  → /system/xbin/tracepath  → tracepath  (PATH)
  *
  * @param commandBuilder  Injectable for testing – defaults to the real binary launcher.
  */
@@ -23,9 +28,41 @@ class TracerouteRepositoryImpl(
         fun build(host: String, maxHops: Int, timeoutSec: Int, queries: Int): List<String>
     }
 
+    private enum class BinaryType { TRACEROUTE, TRACEPATH }
+
     companion object {
+        private val BINARY_CANDIDATES: List<Pair<String, BinaryType>> = listOf(
+            "/system/bin/traceroute" to BinaryType.TRACEROUTE,
+            "/system/xbin/traceroute" to BinaryType.TRACEROUTE,
+            "traceroute" to BinaryType.TRACEROUTE,
+            "/system/bin/tracepath" to BinaryType.TRACEPATH,
+            "/system/xbin/tracepath" to BinaryType.TRACEPATH,
+            "tracepath" to BinaryType.TRACEPATH,
+        )
+
+        private fun isExecutable(binary: String): Boolean = try {
+            if (binary.startsWith("/")) {
+                File(binary).let { it.exists() && it.canExecute() }
+            } else {
+                ProcessBuilder(listOf("which", binary)).start().waitFor() == 0
+            }
+        } catch (_: Exception) { false }
+
+        private fun detectBinary(): Pair<String, BinaryType>? =
+            BINARY_CANDIDATES.firstOrNull { (bin, _) -> isExecutable(bin) }
+
         val DefaultCommandBuilder = CommandBuilder { host, maxHops, timeoutSec, queries ->
-            listOf("traceroute", "-n", "-m", "$maxHops", "-q", "$queries", "-w", "$timeoutSec", host)
+            val (binary, type) = detectBinary()
+                ?: throw IllegalStateException(
+                    "No traceroute binary found on this device. " +
+                    "Tried: traceroute, tracepath in /system/bin, /system/xbin, and PATH."
+                )
+            when (type) {
+                BinaryType.TRACEROUTE ->
+                    listOf(binary, "-n", "-m", "$maxHops", "-q", "$queries", "-w", "$timeoutSec", host)
+                BinaryType.TRACEPATH ->
+                    listOf(binary, "-m", "$maxHops", host)
+            }
         }
     }
 
@@ -36,7 +73,12 @@ class TracerouteRepositoryImpl(
         queriesPerHop: Int
     ): Flow<HopResult> = flow {
         val timeoutSec = (timeoutMs / 1000).coerceAtLeast(1)
-        val cmd = commandBuilder.build(host, maxHops, timeoutSec, queriesPerHop)
+
+        val cmd = try {
+            commandBuilder.build(host, maxHops, timeoutSec, queriesPerHop)
+        } catch (e: Exception) {
+            throw IllegalStateException("traceroute unavailable: ${e.message}", e)
+        }
 
         val process = try {
             ProcessBuilder(cmd)
@@ -46,14 +88,20 @@ class TracerouteRepositoryImpl(
             throw IllegalStateException("traceroute unavailable: ${e.message}", e)
         }
 
+        val isTracepath = cmd.firstOrNull()?.contains("tracepath") == true
+
         try {
             val reader = process.inputStream.bufferedReader()
             var lineIndex = 0
+            val emittedHops = mutableSetOf<Int>()
             var line: String?
             while (reader.readLine().also { line = it } != null) {
                 lineIndex++
-                if (lineIndex == 1) continue          // skip header
-                val hop = parseTracerouteLine(line!!) ?: continue
+                if (lineIndex == 1 && !isTracepath) continue  // skip traceroute header line
+                val hop = if (isTracepath) parseTracepathLine(line!!) else parseTracerouteLine(line!!)
+                hop ?: continue
+                // tracepath may repeat the same hop number; emit only the first occurrence
+                if (!emittedHops.add(hop.hopNumber)) continue
                 val enriched = if (hop.ip != null && hop.status == HopStatus.SUCCESS) {
                     hop.copy(hostname = resolveHostname(hop.ip))
                 } else hop
@@ -64,10 +112,10 @@ class TracerouteRepositoryImpl(
         }
     }.flowOn(Dispatchers.IO)
 
-    // ── Line parsing ──────────────────────────────────────────────────────────
+    // ── traceroute line parsing ────────────────────────────────────────────────
 
     /**
-     * Parses a single traceroute output line.
+     * Parses a single `traceroute` output line.
      *
      * Expected formats:
      *   " 1  192.168.1.1  1.234 ms  1.234 ms  1.234 ms"
@@ -99,6 +147,49 @@ class TracerouteRepositoryImpl(
 
         return HopResult(hopNum, ip, null, rtt, HopStatus.SUCCESS)
     }
+
+    // ── tracepath line parsing ─────────────────────────────────────────────────
+
+    /**
+     * Parses a single `tracepath` output line.
+     *
+     * Expected formats:
+     *   " 1?: [LOCALHOST]                                         pmtu 1500"  → skip
+     *   " 1:  192.168.1.1                                           1.234ms"  → hop
+     *   " 2:  no reply"                                                        → timeout
+     *   " 3:  10.0.0.1                                              5.6ms asymm 3"
+     */
+    internal fun parseTracepathLine(line: String): HopResult? {
+        val trimmed = line.trim()
+        if (trimmed.isEmpty()) return null
+
+        // Match "N:" or "N?:" prefix
+        val hopMatch = Regex("""^(\d+)\??:""").find(trimmed) ?: return null
+        val hopNum = hopMatch.groupValues[1].toIntOrNull() ?: return null
+
+        // Skip localhost discovery / PMTU announcement lines
+        if (trimmed.contains("[LOCALHOST]") || trimmed.contains("pmtu")) return null
+
+        val rest = trimmed.removePrefix(hopMatch.value).trim()
+
+        // Timeout
+        if (rest.startsWith("no reply") || rest.isBlank()) {
+            return HopResult(hopNum, null, null, null, HopStatus.TIMEOUT)
+        }
+
+        val parts = rest.split(Regex("\\s+"))
+        val ip = parts.firstOrNull { looksLikeIp(it) }
+            ?: return HopResult(hopNum, null, null, null, HopStatus.TIMEOUT)
+
+        // RTT token looks like "1.234ms" (no space before "ms")
+        val rtt = parts.mapNotNull { token ->
+            token.trimEnd().removeSuffix("ms").toDoubleOrNull()?.toLong()
+        }.firstOrNull()
+
+        return HopResult(hopNum, ip, null, rtt, HopStatus.SUCCESS)
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
 
     private fun looksLikeIp(token: String): Boolean {
         val parts = token.split(".")

--- a/core-network/src/test/kotlin/com/example/netswissknife/core/network/traceroute/TracerouteRepositoryImplTest.kt
+++ b/core-network/src/test/kotlin/com/example/netswissknife/core/network/traceroute/TracerouteRepositoryImplTest.kt
@@ -93,6 +93,56 @@ class TracerouteRepositoryImplTest {
         }
     }
 
+    // ── parseTracepathLine ────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("parseTracepathLine")
+    inner class ParseTracepathLine {
+
+        @Test
+        fun `returns null for blank line`() {
+            assertNull(impl.parseTracepathLine(""))
+        }
+
+        @Test
+        fun `skips localhost PMTU line`() {
+            assertNull(impl.parseTracepathLine(" 1?: [LOCALHOST]                                         pmtu 1500"))
+        }
+
+        @Test
+        fun `parses successful hop`() {
+            val result = impl.parseTracepathLine(" 1:  192.168.1.1                                           1.234ms")
+            assertNotNull(result)
+            assertEquals(1, result!!.hopNumber)
+            assertEquals("192.168.1.1", result.ip)
+            assertEquals(HopStatus.SUCCESS, result.status)
+            assertEquals(1L, result.rtTimeMs)
+        }
+
+        @Test
+        fun `parses timeout hop (no reply)`() {
+            val result = impl.parseTracepathLine(" 3:  no reply")
+            assertNotNull(result)
+            assertEquals(3, result!!.hopNumber)
+            assertNull(result.ip)
+            assertEquals(HopStatus.TIMEOUT, result.status)
+        }
+
+        @Test
+        fun `parses hop with asymm annotation`() {
+            val result = impl.parseTracepathLine(" 2:  10.0.0.1                                              5.6ms asymm 2")
+            assertNotNull(result)
+            assertEquals(2, result!!.hopNumber)
+            assertEquals("10.0.0.1", result.ip)
+            assertEquals(HopStatus.SUCCESS, result.status)
+        }
+
+        @Test
+        fun `returns null for non-numeric start`() {
+            assertNull(impl.parseTracepathLine("Resume: pmtu 1500 hops 8 back 8"))
+        }
+    }
+
     // ── Command builder injection ──────────────────────────────────────────────
 
     @Nested


### PR DESCRIPTION
## Summary

- Android devices don't ship with a `traceroute` binary, causing "no such file or directory" when the feature is used
- Added multi-path binary detection: checks `/system/bin/traceroute`, `/system/xbin/traceroute`, then PATH, before falling back to `tracepath` (widely available on Android without root)
- Added a `tracepath` output parser alongside the existing `traceroute` parser, with hop deduplication (tracepath emits the same hop number twice per probe)

## Test plan

- [ ] All existing `parseTracerouteLine` tests continue to pass
- [ ] New `parseTracepathLine` tests pass (blank line, PMTU skip, success, timeout, asymm annotation)
- [ ] `./gradlew :core-network:test` — BUILD SUCCESSFUL

https://claude.ai/code/session_0185jK3K4MR17cdPhxeVJAin