### PR TITLE
fix: correct OSM tile User-Agent, enable 7-day cache, limit download threads

### DIFF
--- a/app/src/main/kotlin/com/example/netswissknife/app/NetSwissKnifeApp.kt
+++ b/app/src/main/kotlin/com/example/netswissknife/app/NetSwissKnifeApp.kt
@@ -1,6 +1,7 @@
 package com.example.netswissknife.app
 
 import android.app.Application
+import android.preference.PreferenceManager
 import com.example.netswissknife.app.crash.CrashHandler
 import com.example.netswissknife.app.util.AppLogger
 import dagger.hilt.android.HiltAndroidApp
@@ -10,13 +11,32 @@ import org.osmdroid.config.Configuration
 class NetSwissKnifeApp : Application() {
     override fun onCreate() {
         super.onCreate()
-        // OSMDroid: identify this app to tile servers per
-        // https://github.com/osmdroid/osmdroid/wiki/Important-notes-on-using-osmdroid-in-your-app
-        // packageName == BuildConfig.APPLICATION_ID at runtime
-        Configuration.getInstance().userAgentValue = packageName
+        initOsmdroid()
         AppLogger.init(this)
         installCrashHandler()
         AppLogger.i("App", "NetSwissKnife started (versionName=${packageManager.getPackageInfo(packageName, 0).versionName})")
+    }
+
+    private fun initOsmdroid() {
+        val versionName = try {
+            packageManager.getPackageInfo(packageName, 0).versionName ?: "1.0.0"
+        } catch (_: Exception) {
+            "1.0.0"
+        }
+        // Load osmdroid config from shared prefs (required for proper tile cache storage)
+        @Suppress("DEPRECATION")
+        val prefs = PreferenceManager.getDefaultSharedPreferences(this)
+        val osmConfig = Configuration.getInstance()
+        osmConfig.load(this, prefs)
+        // Distinctive User-Agent required by https://operations.osmfoundation.org/policies/tiles/
+        // Format: AppName/version (+contact_url) — generic/example IDs are blocked with 403
+        osmConfig.userAgentValue =
+            "NetSwissKnife/$versionName (+https://github.com/aieatassam/android-network-tools)"
+        // OSM tile usage policy mandates a minimum 7-day cache for tiles
+        osmConfig.expirationOverrideDuration = 7L * 24 * 60 * 60 * 1000
+        // Keep concurrent downloads low to avoid triggering rate-limit blocks
+        osmConfig.tileDownloadThreads = 2
+        osmConfig.tileDownloadMaxQueueSize = 40
     }
 
     private fun installCrashHandler() {


### PR DESCRIPTION
- Replace bare packageName UA with 'NetSwissKnife/<version> (+github_url)'
  per https://operations.osmfoundation.org/policies/tiles/ — generic/example
  package names (com.example.*) are blocked with 403
- Call Configuration.load(ctx, prefs) to initialise osmdroid's tile cache
  storage properly before overriding settings
- Set expirationOverrideDuration = 7 days as required by OSM tile usage policy
- Limit tileDownloadThreads=2 and tileDownloadMaxQueueSize=40 to avoid
  triggering server-side rate-limit blocks

https://claude.ai/code/session_01Cu6Xa6K7knUTPEMJysSrGp