### PR TITLE
fix: log OSM tile 403 errors to AppLogger and enable osmdroid debug mode

### DIFF
--- a/app/src/main/kotlin/com/example/netswissknife/app/NetSwissKnifeApp.kt
+++ b/app/src/main/kotlin/com/example/netswissknife/app/NetSwissKnifeApp.kt
@@ -11,8 +11,8 @@ import org.osmdroid.config.Configuration
 class NetSwissKnifeApp : Application() {
     override fun onCreate() {
         super.onCreate()
-        initOsmdroid()
         AppLogger.init(this)
+        initOsmdroid()
         installCrashHandler()
         AppLogger.i("App", "NetSwissKnife started (versionName=${packageManager.getPackageInfo(packageName, 0).versionName})")
     }
@@ -37,6 +37,10 @@ class NetSwissKnifeApp : Application() {
         // Keep concurrent downloads low to avoid triggering rate-limit blocks
         osmConfig.tileDownloadThreads = 2
         osmConfig.tileDownloadMaxQueueSize = 40
+        // Enable osmdroid's verbose HTTP logging so tile errors (including 403 status codes)
+        // appear in logcat under tag "OsmDroid" – invaluable for diagnosing tile server rejections
+        osmConfig.isDebugMode = true
+        AppLogger.i("OsmInit", "OSM tile provider configured – User-Agent: ${osmConfig.userAgentValue}")
     }
 
     private fun installCrashHandler() {

--- a/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/TracerouteScreen.kt
+++ b/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/TracerouteScreen.kt
@@ -112,7 +112,7 @@ import com.example.netswissknife.core.network.traceroute.HopResult
 import com.example.netswissknife.core.network.traceroute.HopStatus
 import com.example.netswissknife.core.network.traceroute.TracerouteProbeType
 import com.example.netswissknife.core.network.traceroute.TracerouteResult
-import org.osmdroid.tileprovider.tilesource.TileSourceFactory
+import com.example.netswissknife.app.util.LoggingMapTileProvider
 import org.osmdroid.util.BoundingBox
 import org.osmdroid.util.GeoPoint
 import org.osmdroid.views.MapView
@@ -748,8 +748,9 @@ private fun OsmTracerouteMap(hops: List<HopResult>, modifier: Modifier = Modifie
         AndroidView(
             modifier = Modifier.matchParentSize(),
             factory = { ctx ->
-                MapView(ctx).also { mapViewRef.value = it }.apply {
-                    setTileSource(TileSourceFactory.MAPNIK)   // OSM standard tiles
+                // LoggingMapTileProvider wraps MAPNIK and writes tile failures to AppLogger
+                val tileProvider = LoggingMapTileProvider(ctx)
+                MapView(ctx, tileProvider).also { mapViewRef.value = it }.apply {
                     setMultiTouchControls(true)
                     controller.setZoom(2.0)
                     controller.setCenter(GeoPoint(20.0, 10.0))

--- a/app/src/main/kotlin/com/example/netswissknife/app/util/LoggingMapTileProvider.kt
+++ b/app/src/main/kotlin/com/example/netswissknife/app/util/LoggingMapTileProvider.kt
@@ -1,0 +1,28 @@
+package com.example.netswissknife.app.util
+
+import android.content.Context
+import org.osmdroid.tileprovider.MapTileProviderBasic
+import org.osmdroid.tileprovider.MapTileRequestState
+import org.osmdroid.tileprovider.tilesource.TileSourceFactory
+import org.osmdroid.util.MapTileIndex
+
+/**
+ * A [MapTileProviderBasic] that forwards tile-load failures to [AppLogger].
+ *
+ * When a tile download fails (e.g. HTTP 403, network error, or timeout) osmdroid calls
+ * [mapTileRequestFailed]. We intercept that callback to write a warning entry to the app's
+ * persistent debug log so the failure shows up both in logcat and in the in-app log file.
+ *
+ * Actual HTTP response codes (403 etc.) are printed by osmdroid itself when
+ * [org.osmdroid.config.Configuration.isDebugMode] is true – see [NetSwissKnifeApp] – under
+ * the "OsmDroid" logcat tag.
+ */
+class LoggingMapTileProvider(context: Context) :
+    MapTileProviderBasic(context, TileSourceFactory.MAPNIK) {
+
+    override fun mapTileRequestFailed(pState: MapTileRequestState) {
+        super.mapTileRequestFailed(pState)
+        val tile = MapTileIndex.toString(pState.mapTile)
+        AppLogger.w("OsmTile", "Tile download failed: $tile (check OsmDroid logcat tag for HTTP status code)")
+    }
+}


### PR DESCRIPTION
- Enable osmConfig.isDebugMode=true so osmdroid logs HTTP response codes
  (including 403) to logcat under tag "OsmDroid" on every failed tile fetch
- Add AppLogger.i on startup to persist the exact User-Agent string being
  sent so it can be verified from the in-app debug log
- Introduce LoggingMapTileProvider (subclass of MapTileProviderBasic) that
  overrides mapTileRequestFailed() to write tile download failures to AppLogger
  (persisted to debug.log, visible via the in-app log viewer)
- Wire LoggingMapTileProvider into the MapView in TracerouteScreen instead of
  the implicit default provider
- Fix AppLogger.init() ordering: init before initOsmdroid() so the UA log
  entry is persisted to the log file and not just emitted to logcat

https://claude.ai/code/session_01Lso6pURjdNtdCf7MavAUZB