### PR TITLE
fix: add contentKey to DnsScreen and WifiScanScreen AnimatedContent

### DIFF
--- a/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/DnsScreen.kt
+++ b/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/DnsScreen.kt
@@ -146,6 +146,7 @@ fun DnsScreen(viewModel: DnsViewModel = hiltViewModel()) {
                         (fadeIn(tween(300)) + slideInVertically(tween(300)) { it / 8 })
                             .togetherWith(fadeOut(tween(200)))
                     },
+                    contentKey = { it::class },
                     label = "dns-result-state"
                 ) { state ->
                     when (state) {

--- a/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/TracerouteScreen.kt
+++ b/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/TracerouteScreen.kt
@@ -1092,8 +1092,10 @@ private fun TracerouteErrorPanel(
     onRetry: () -> Unit,
     onClear: () -> Unit
 ) {
+    var scaleTarget by remember { mutableStateOf(0.85f) }
+    LaunchedEffect(Unit) { scaleTarget = 1f }
     val scale by animateFloatAsState(
-        targetValue   = 1f,
+        targetValue   = scaleTarget,
         animationSpec = spring(Spring.DampingRatioMediumBouncy),
         label         = "error-scale"
     )

--- a/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/TracerouteScreen.kt
+++ b/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/TracerouteScreen.kt
@@ -182,9 +182,10 @@ fun TracerouteScreen(viewModel: TracerouteViewModel = hiltViewModel()) {
                         is TracerouteUiState.Idle     -> TracerouteIdlePrompt()
                         is TracerouteUiState.Running  -> TracerouteRunningPanel(state)
                         is TracerouteUiState.Finished -> TracerouteFinishedPanel(
-                            state          = state,
-                            onToggleMode   = viewModel::onToggleViewMode,
-                            onClear        = viewModel::onClear
+                            state               = state,
+                            onToggleMode        = viewModel::onToggleViewMode,
+                            onClear             = viewModel::onClear,
+                            mapCompositionReady = !transition.isRunning
                         )
                         is TracerouteUiState.Error    -> TracerouteErrorPanel(
                             state   = state,
@@ -549,7 +550,8 @@ private fun TracerouteRunningPanel(state: TracerouteUiState.Running) {
 private fun TracerouteFinishedPanel(
     state: TracerouteUiState.Finished,
     onToggleMode: () -> Unit,
-    onClear: () -> Unit
+    onClear: () -> Unit,
+    mapCompositionReady: Boolean = false
 ) {
     val result = state.result
     Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
@@ -611,6 +613,24 @@ private fun TracerouteFinishedPanel(
                                 textAlign = TextAlign.Center
                             )
                         }
+                    }
+                } else if (!mapCompositionReady) {
+                    // Defer MaplibreMap until the AnimatedContent enter-transition has
+                    // fully settled.  Composing MaplibreMap while the transition frame
+                    // is still executing causes the library's internal CompositionLocal
+                    // reads to fail with IllegalStateException.
+                    Box(
+                        modifier         = Modifier
+                            .fillMaxWidth()
+                            .height(280.dp)
+                            .clip(RoundedCornerShape(8.dp))
+                            .background(MaterialTheme.colorScheme.surfaceVariant),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator(
+                            modifier    = Modifier.size(28.dp),
+                            strokeWidth = 2.dp
+                        )
                     }
                 } else {
                     MaplibreTracerouteMap(

--- a/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/WifiScanScreen.kt
+++ b/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/WifiScanScreen.kt
@@ -130,6 +130,7 @@ fun WifiScanScreen(
         AnimatedContent(
             targetState = uiState,
             transitionSpec = { fadeIn() togetherWith fadeOut() },
+            contentKey = { it::class },
             modifier = Modifier.fillMaxSize(),
             label = "wifi_state"
         ) { state ->


### PR DESCRIPTION
DnsUiState.Success carries showRaw: Boolean, so toggling the raw view
emitted a new Success object, changing AnimatedContent equality and
firing a new enter/exit transition while the previous one was still
running. Same problem in WifiScanUiState.Success whose bandFilter,
sortOrder, and selectedAp fields all cause re-emission on user
interaction.

Multiple overlapping transition compositions shared the same remember()
slots and caused Compose to throw IllegalStateException when snapshot
state was read during an animation frame — the same root cause fixed in
78af778 for Ping/Traceroute/Ports/LanScan, but DnsScreen and
WifiScanScreen were missed in that pass.

Fix: add contentKey = { it::class } to both AnimatedContent calls so
transitions only fire on sealed-class type changes (Idle→Loading→
Success/Error), not on field mutations within the same type.

Also fix TracerouteErrorPanel's animateFloatAsState which always
targeted 1f from first composition (initial == target, so the spring
never ran). Now uses a LaunchedEffect to drive the target from 0.85f
→ 1f so the intended bounce-in actually plays.

https://claude.ai/code/session_01H78HUeN3B1TZqX89L56wdL