### PR TITLE
fix(traceroute): eliminate all AnimatedContent/Crossfade nesting to fix crash + switch to MapLibre demo tiles

### DIFF
--- a/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/TracerouteScreen.kt
+++ b/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/TracerouteScreen.kt
@@ -16,9 +16,8 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.togetherWith
+import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.background
-import androidx.compose.animation.expandVertically
-import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -888,13 +887,23 @@ private fun HopDetailList(hops: List<HopResult>) {
 private fun HopCard(hop: HopResult, index: Int) {
     val hopColor = rttColor(hop.rtTimeMs)
     var expanded by remember(hop.hopNumber) { mutableStateOf(false) }
+    // animateFloatAsState + animateContentSize replace AnimatedVisibility(expandVertically/shrinkVertically).
+    // AnimatedVisibility with size enter/exit specs uses SubcomposeLayout internally; nested inside
+    // AnimatedContent (and Crossfade which is itself AnimatedContent) it causes IllegalStateException
+    // when the outer animation exits while the inner expand/collapse animation is in progress.
+    // animateContentSize is a plain Modifier that never uses SubcomposeLayout.
+    val expandedAlpha by animateFloatAsState(
+        targetValue   = if (expanded) 1f else 0f,
+        animationSpec = tween(200),
+        label         = "expanded-alpha"
+    )
 
     OutlinedCard(
         modifier = Modifier
             .fillMaxWidth()
             .clickable { expanded = !expanded }
     ) {
-        Column {
+        Column(modifier = Modifier.animateContentSize(animationSpec = tween(200))) {
             Row(
                 modifier          = Modifier.padding(12.dp),
                 verticalAlignment = Alignment.CenterVertically
@@ -998,14 +1007,13 @@ private fun HopCard(hop: HopResult, index: Int) {
                 }
             }
 
-            // Expanded detail section
-            AnimatedVisibility(
-                visible = expanded,
-                enter   = expandVertically() + fadeIn(),
-                exit    = shrinkVertically() + fadeOut()
-            ) {
+            // Expanded detail section – rendered while alpha > 0 so the fade-out
+            // plays fully; animateContentSize on the parent Column handles height.
+            if (expanded || expandedAlpha > 0f) {
                 Column(
-                    modifier            = Modifier.padding(start = 60.dp, end = 12.dp, bottom = 12.dp),
+                    modifier            = Modifier
+                        .alpha(expandedAlpha)
+                        .padding(start = 60.dp, end = 12.dp, bottom = 12.dp),
                     verticalArrangement = Arrangement.spacedBy(4.dp)
                 ) {
                     HorizontalDivider(modifier = Modifier.padding(bottom = 4.dp))


### PR DESCRIPTION
## Summary

Fixes the recurring `java.lang.IllegalStateException` (no message) on the Traceroute screen. Three rounds of investigation revealed three separate `AnimatedContent`/`AnimatedVisibility` nesting violations — each one fixed in sequence as the crash trace evolved.

### Root cause (applies to all three fixes)

`AnimatedContent`, `Crossfade` (= `AnimatedContent` internally), and `AnimatedVisibility` with size-based specs (`expandVertically`, `shrinkVertically`) all use `SubcomposeLayout` internally. Nesting any of these inside the outer `AnimatedContent` (the state-machine) causes `IllegalStateException` when both animations run simultaneously: the two SubcomposeLayout instances fight over the slot table and the outgoing subcomposition reads a disposed `State<T>`.

### Three crash sites fixed

**Fix 1 — Per-hop `AnimatedVisibility` in `TracerouteRunningPanel`**
- Each hop used `AnimatedVisibility(enter = fadeIn + slideInVertically)` inside `AnimatedContent`'s SubcomposeLayout
- Crash trigger: hops arriving rapidly → their 250 ms enter-animations still in flight when `AnimatedContent` started its 200 ms Running→Finished exit
- **Fix:** `animateFloatAsState` + `Modifier.alpha` — no SubcomposeLayout

**Fix 2 — Expand/collapse `AnimatedVisibility` in `HopCard`**
- `AnimatedVisibility(enter = expandVertically + fadeIn, exit = shrinkVertically + fadeOut)` nested 2 levels deep (outer `AnimatedContent` + inner `Crossfade`)
- Crash trigger: expanding a hop card then switching tabs or starting a new trace
- **Fix:** `animateContentSize()` modifier + `animateFloatAsState` alpha — no SubcomposeLayout

**Fix 3 — `Crossfade` in `TracerouteFinishedPanel`**  
- `Crossfade` is `AnimatedContent` internally; nested inside the outer `AnimatedContent`
- Crash trigger: tapping Visual/Raw tab while the outer Running→Finished transition is still in progress (within its 300 ms window), or starting a new trace while the Crossfade is mid-animation
- **Fix:** replaced with plain `when` branch — instant tab switch, no nested SubcomposeLayout

**Bonus fix** — `mapCompositionReady` is now a sticky `remember { mutableStateOf(false) }` set via `LaunchedEffect(transition.isRunning)`, preventing `MaplibreMap` from being torn down and re-composed on any subsequent `transition.isRunning` flip.

### Map tile provider switch
Switched from CARTO Voyager to the official MapLibre demo tiles (`demotiles.maplibre.org`) per user request.

## Test plan

- [ ] Run traceroute to a host with many hops — verify hops animate in without crash
- [ ] Let traceroute complete — verify Running→Finished transition (with map) is crash-free
- [ ] Tap the Raw tab **immediately** after results appear (within 300 ms of completion) — previously the most reliable crash trigger
- [ ] Switch Visual↔Raw tabs multiple times — verify instant switch, no crash
- [ ] Expand one or more hop cards, then tap Raw — no crash
- [ ] Expand a hop card, then start a new traceroute — no crash
- [ ] Verify MapLibre map renders with demo tiles

https://claude.ai/code/session_01BF4jwv6hWdtDnt2Apz5Pb8