### PR TITLE
fix(traceroute): remove Crossfade nested inside AnimatedContent + switch to MapLibre demo tiles

### DIFF
--- a/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/TracerouteScreen.kt
+++ b/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/TracerouteScreen.kt
@@ -2,7 +2,6 @@ package com.example.netswissknife.app.ui.screens
 
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.Crossfade
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.Spring
@@ -681,11 +680,15 @@ private fun TracerouteFinishedPanel(
             )
         }
 
-        Crossfade(targetState = state.viewMode, label = "view-mode") { mode ->
-            when (mode) {
-                TracerouteViewMode.Visual -> HopDetailList(result.hops)
-                TracerouteViewMode.Raw    -> RawOutputCard(result.rawOutput)
-            }
+        // Crossfade (= AnimatedContent internally, uses SubcomposeLayout) must NOT be
+        // nested inside the outer AnimatedContent – when both animations run simultaneously
+        // (e.g. outer Running→Finished transition still in flight while the user taps a tab)
+        // the two SubcomposeLayout instances fight over the slot table and the outgoing
+        // subcomposition reads a disposed State<T>, causing IllegalStateException.
+        // Plain when-branch with no animation is safe and avoids the nesting entirely.
+        when (state.viewMode) {
+            TracerouteViewMode.Visual -> HopDetailList(result.hops)
+            TracerouteViewMode.Raw    -> RawOutputCard(result.rawOutput)
         }
     }
 }
@@ -805,7 +808,7 @@ private fun MaplibreTracerouteMap(hops: List<HopResult>, modifier: Modifier = Mo
     MaplibreMap(
         modifier   = modifier,
         cameraState = cameraState,
-        baseStyle  = BaseStyle.Uri("https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json")
+        baseStyle  = BaseStyle.Uri("https://demotiles.maplibre.org/style.json")
     ) {
         // Polyline connecting hops in order
         LineLayer(


### PR DESCRIPTION
## Summary

Third and final fix for the traceroute `IllegalStateException` crash.

### Root cause

`Crossfade` is `AnimatedContent` internally and uses `SubcomposeLayout`. It was nested inside the outer `AnimatedContent` (state machine). When the user taps the Visual/Raw tab while the outer Running→Finished transition is still playing (within its 300 ms window), or starts a new traceroute while a tab-switch is mid-animation, both SubcomposeLayout instances run simultaneously. The outgoing subcomposition reads a disposed `State<T>` → `IllegalStateException`.

This produced the identical crash trace seen after the previous two fixes — same `fd.f(:1275) → AnimatedContent.a(:867) → AnimatedContent.c(:1322) → … → qm2.getValue → rx1.a` signature — because the crash mechanism is the same regardless of which nested `AnimatedContent` triggers it.

### Changes

- **`TracerouteFinishedPanel`**: replace `Crossfade(targetState = state.viewMode)` with a plain `when` branch. The tab-content switch is instant; the outer `AnimatedContent` already provides the animated entry for the whole Finished panel. Remove now-unused `Crossfade` import.
- **Map tiles**: switch from CARTO Voyager (`basemaps.cartocdn.com`) to official MapLibre demo tiles (`demotiles.maplibre.org`) per user request.

## Test plan

- [ ] Tap the Visual/Raw tab **immediately** after results appear (within 300 ms) — was the most reliable crash trigger
- [ ] Switch Visual↔Raw tabs multiple times — content switches instantly, no crash
- [ ] Start a new traceroute while the Finished panel is showing — no crash
- [ ] Verify the MapLibre map renders correctly with demo tiles

https://claude.ai/code/session_01BF4jwv6hWdtDnt2Apz5Pb8