### PR TITLE
fix(traceroute): resolve remaining IllegalStateException causes

### DIFF
--- a/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/DnsScreen.kt
+++ b/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/DnsScreen.kt
@@ -110,17 +110,19 @@ fun DnsScreen(viewModel: DnsViewModel = hiltViewModel()) {
 
     var visible by remember { mutableStateOf(false) }
     LaunchedEffect(Unit) { visible = true }
+    val screenAlpha by animateFloatAsState(
+        targetValue   = if (visible) 1f else 0f,
+        animationSpec = tween(400),
+        label         = "screen-alpha"
+    )
 
-    AnimatedVisibility(
-        visible = visible,
-        enter = fadeIn(tween(400)) + slideInVertically(tween(400)) { it / 6 }
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+            .alpha(screenAlpha),
+        contentPadding = PaddingValues(bottom = 32.dp)
     ) {
-        LazyColumn(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(MaterialTheme.colorScheme.background),
-            contentPadding = PaddingValues(bottom = 32.dp)
-        ) {
             item { DnsHeroHeader() }
 
             item {
@@ -172,7 +174,6 @@ fun DnsScreen(viewModel: DnsViewModel = hiltViewModel()) {
                 }
             }
         }
-    }
 }
 
 // ── Hero header ───────────────────────────────────────────────────────────────

--- a/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/PingScreen.kt
+++ b/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/PingScreen.kt
@@ -112,16 +112,16 @@ fun PingScreen(
     val timeoutMs by viewModel.timeoutMs.collectAsStateWithLifecycle()
     val packetSize by viewModel.packetSize.collectAsStateWithLifecycle()
 
-    // Screen entrance animation
     var visible by remember { mutableStateOf(false) }
     LaunchedEffect(Unit) { visible = true }
+    val screenAlpha by animateFloatAsState(
+        targetValue   = if (visible) 1f else 0f,
+        animationSpec = tween(400),
+        label         = "screen-alpha"
+    )
 
-    AnimatedVisibility(
-        visible = visible,
-        enter = fadeIn(tween(400)) + slideInVertically(tween(400)) { it / 4 }
-    ) {
-        LazyColumn(
-            modifier = Modifier.fillMaxSize(),
+    LazyColumn(
+        modifier = Modifier.fillMaxSize().alpha(screenAlpha),
             contentPadding = PaddingValues(16.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
@@ -175,7 +175,6 @@ fun PingScreen(
                 }
             }
         }
-    }
 }
 
 // ── Hero header ───────────────────────────────────────────────────────────────

--- a/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/PortsScreen.kt
+++ b/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/PortsScreen.kt
@@ -77,6 +77,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -113,23 +114,23 @@ fun PortsScreen(viewModel: PortScanViewModel = hiltViewModel()) {
     val timeoutMs by viewModel.timeoutMs.collectAsStateWithLifecycle()
     val concurrency by viewModel.concurrency.collectAsStateWithLifecycle()
 
-    // Screen entrance animation
     var screenVisible by remember { mutableStateOf(false) }
     LaunchedEffect(Unit) { screenVisible = true }
+    val screenAlpha by animateFloatAsState(
+        targetValue   = if (screenVisible) 1f else 0f,
+        animationSpec = tween(400),
+        label         = "screen-alpha"
+    )
 
     val keyboardController = LocalSoftwareKeyboardController.current
     val clipboard = LocalClipboardManager.current
     var showAll by remember { mutableStateOf(false) }
 
-    AnimatedVisibility(
-        visible = screenVisible,
-        enter = fadeIn(tween(400)) + slideInVertically(tween(400)) { it / 6 }
+    LazyColumn(
+        modifier = Modifier.fillMaxSize().alpha(screenAlpha),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
-        LazyColumn(
-            modifier = Modifier.fillMaxSize(),
-            contentPadding = PaddingValues(16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp)
-        ) {
             // ── Header ──────────────────────────────────────────────────────────
             item {
                 PortScanHeader()
@@ -279,7 +280,6 @@ fun PortsScreen(viewModel: PortScanViewModel = hiltViewModel()) {
                 }
             }
         }
-    }
 }
 
 // ── Header ───────────────────────────────────────────────────────────────────

--- a/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/TracerouteScreen.kt
+++ b/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/TracerouteScreen.kt
@@ -127,15 +127,10 @@ fun TracerouteScreen(viewModel: TracerouteViewModel = hiltViewModel()) {
     val probeType    by viewModel.probeType.collectAsStateWithLifecycle()
     val packetSize   by viewModel.packetSize.collectAsStateWithLifecycle()
 
-    // Use animateFloatAsState + alpha instead of AnimatedVisibility for the screen
-    // entrance animation.  AnimatedVisibility is backed by SubcomposeLayout; the
-    // AnimatedContent inside the LazyColumn item is also backed by SubcomposeLayout.
-    // If the ViewModel already holds a non-Idle state when the user navigates back to
-    // this screen (e.g. a trace is still running), the AnimatedContent can begin its
-    // own transition while the outer AnimatedVisibility entrance is still in flight.
-    // Two simultaneously-animating nested SubcomposeLayouts read each other's slot
-    // tables and produce IllegalStateException.  animateFloatAsState is a plain value
-    // animation with no SubcomposeLayout of its own, so nesting is safe.
+    // animateFloatAsState instead of AnimatedVisibility: both AnimatedVisibility and the
+    // inner AnimatedContent use SubcomposeLayout.  Two simultaneously-animating nested
+    // SubcomposeLayouts throw IllegalStateException (e.g. when a running trace completes
+    // during the 400 ms entrance animation on navigation return).
     var visible by remember { mutableStateOf(false) }
     LaunchedEffect(Unit) { visible = true }
     val screenAlpha by animateFloatAsState(

--- a/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/TracerouteScreen.kt
+++ b/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/TracerouteScreen.kt
@@ -127,18 +127,28 @@ fun TracerouteScreen(viewModel: TracerouteViewModel = hiltViewModel()) {
     val probeType    by viewModel.probeType.collectAsStateWithLifecycle()
     val packetSize   by viewModel.packetSize.collectAsStateWithLifecycle()
 
+    // Use animateFloatAsState + alpha instead of AnimatedVisibility for the screen
+    // entrance animation.  AnimatedVisibility is backed by SubcomposeLayout; the
+    // AnimatedContent inside the LazyColumn item is also backed by SubcomposeLayout.
+    // If the ViewModel already holds a non-Idle state when the user navigates back to
+    // this screen (e.g. a trace is still running), the AnimatedContent can begin its
+    // own transition while the outer AnimatedVisibility entrance is still in flight.
+    // Two simultaneously-animating nested SubcomposeLayouts read each other's slot
+    // tables and produce IllegalStateException.  animateFloatAsState is a plain value
+    // animation with no SubcomposeLayout of its own, so nesting is safe.
     var visible by remember { mutableStateOf(false) }
     LaunchedEffect(Unit) { visible = true }
+    val screenAlpha by animateFloatAsState(
+        targetValue   = if (visible) 1f else 0f,
+        animationSpec = tween(400),
+        label         = "screen-alpha"
+    )
 
-    AnimatedVisibility(
-        visible = visible,
-        enter   = fadeIn(tween(400)) + slideInVertically(tween(400)) { it / 4 }
+    LazyColumn(
+        modifier          = Modifier.fillMaxSize().alpha(screenAlpha),
+        contentPadding    = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
-        LazyColumn(
-            modifier          = Modifier.fillMaxSize(),
-            contentPadding    = PaddingValues(16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp)
-        ) {
             item { TracerouteHeroHeader() }
 
             item {
@@ -200,7 +210,6 @@ fun TracerouteScreen(viewModel: TracerouteViewModel = hiltViewModel()) {
                 }
             }
         }
-    }
 }
 
 // ── Hero header ───────────────────────────────────────────────────────────────

--- a/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/WifiScanScreen.kt
+++ b/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/WifiScanScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.animation.togetherWith
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
@@ -71,6 +72,7 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
@@ -121,17 +123,17 @@ fun WifiScanScreen(
     // ── Root animated state switcher ──────────────────────────────────────────
     var visible by remember { mutableStateOf(false) }
     LaunchedEffect(Unit) { visible = true }
+    val screenAlpha by animateFloatAsState(
+        targetValue   = if (visible) 1f else 0f,
+        animationSpec = tween(400),
+        label         = "screen-alpha"
+    )
 
-    AnimatedVisibility(
-        visible = visible,
-        enter = fadeIn() + slideInVertically { it / 6 },
-        modifier = Modifier.fillMaxSize()
-    ) {
-        AnimatedContent(
-            targetState = uiState,
-            transitionSpec = { fadeIn() togetherWith fadeOut() },
-            contentKey = { it::class },
-            modifier = Modifier.fillMaxSize(),
+    AnimatedContent(
+        targetState = uiState,
+        transitionSpec = { fadeIn() togetherWith fadeOut() },
+        contentKey = { it::class },
+        modifier = Modifier.fillMaxSize().alpha(screenAlpha),
             label = "wifi_state"
         ) { state ->
             when (state) {
@@ -159,7 +161,6 @@ fun WifiScanScreen(
                 )
             }
         }
-    }
 }
 
 // ── Idle / loading ────────────────────────────────────────────────────────────

--- a/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/traceroute/TracerouteViewModel.kt
+++ b/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/traceroute/TracerouteViewModel.kt
@@ -10,6 +10,7 @@ import com.example.netswissknife.core.network.traceroute.HopStatus
 import com.example.netswissknife.core.network.traceroute.TracerouteProbeType
 import com.example.netswissknife.core.network.traceroute.TracerouteResult
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -116,6 +117,10 @@ class TracerouteViewModel @Inject constructor(
         val startTime   = System.currentTimeMillis()
         val accumulated = mutableListOf<HopResult>()
 
+        // Transition to Running immediately so the UI responds before the first hop
+        // arrives.  If validation fails the first emission will overwrite this with Error.
+        _uiState.value = TracerouteUiState.Running(host = params.host.trim(), hops = emptyList())
+
         traceJob = viewModelScope.launch {
             try {
                 tracerouteUseCase(params).collect { result ->
@@ -144,6 +149,11 @@ class TracerouteViewModel @Inject constructor(
                         )
                     }
                 }
+            } catch (e: CancellationException) {
+                // Job was cancelled by onStop() or onClear(); those functions already set the
+                // correct UI state (Finished or Idle).  Re-throw so the coroutine machinery
+                // knows this coroutine ended due to cancellation, not a logic error.
+                throw e
             } catch (e: Exception) {
                 _uiState.value = TracerouteUiState.Error(e.message ?: "Traceroute failed")
             }

--- a/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/traceroute/TracerouteViewModel.kt
+++ b/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/traceroute/TracerouteViewModel.kt
@@ -114,12 +114,13 @@ class TracerouteViewModel @Inject constructor(
             probeType     = _probeType.value,
             packetSize    = _packetSize.value
         )
+        val trimmedHost = params.host.trim()
         val startTime   = System.currentTimeMillis()
         val accumulated = mutableListOf<HopResult>()
 
         // Transition to Running immediately so the UI responds before the first hop
         // arrives.  If validation fails the first emission will overwrite this with Error.
-        _uiState.value = TracerouteUiState.Running(host = params.host.trim(), hops = emptyList())
+        _uiState.value = TracerouteUiState.Running(host = trimmedHost, hops = emptyList())
 
         traceJob = viewModelScope.launch {
             try {
@@ -132,7 +133,7 @@ class TracerouteViewModel @Inject constructor(
                         is TracerouteFlowResult.Hop -> {
                             accumulated.add(result.hop)
                             _uiState.value = TracerouteUiState.Running(
-                                host = params.host.trim(),
+                                host = trimmedHost,
                                 hops = accumulated.toList()
                             )
                         }
@@ -142,7 +143,7 @@ class TracerouteViewModel @Inject constructor(
                 val current = _uiState.value
                 if (current is TracerouteUiState.Running) {
                     _uiState.value = if (current.hops.isEmpty()) {
-                        TracerouteUiState.Error("No route found to ${params.host.trim()}")
+                        TracerouteUiState.Error("No route found to $trimmedHost")
                     } else {
                         TracerouteUiState.Finished(
                             buildResult(current.host, current.hops, System.currentTimeMillis() - startTime)

--- a/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/wifi/WifiScanViewModel.kt
+++ b/app/src/main/kotlin/com/example/netswissknife/app/ui/screens/wifi/WifiScanViewModel.kt
@@ -8,6 +8,7 @@ import com.example.netswissknife.core.network.wifi.WifiAccessPoint
 import com.example.netswissknife.core.network.wifi.WifiBand
 import com.example.netswissknife.core.network.wifi.WifiScanResult
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -107,6 +108,8 @@ class WifiScanViewModel @Inject constructor(
                         sortOrder = prev?.sortOrder ?: ApSortOrder.SIGNAL
                     )
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: WifiNotSupportedException) {
                 _uiState.value = WifiScanUiState.NotSupported
             } catch (e: SecurityException) {


### PR DESCRIPTION
Three bugs fixed:

1. CancellationException swallowed by catch(e: Exception) in startTrace().
   When onStop() or onClear() cancelled the job, the CancellationException
   propagated into the generic catch block, which then set _uiState to Error
   and overwrote the Finished/Idle state that onStop/onClear had just written.
   Fix: catch CancellationException first and re-throw it so the coroutine
   ends cleanly and onStop/onClear's state update is preserved.

2. Outer AnimatedVisibility wrapping LazyColumn + AnimatedContent (ISE).
   AnimatedVisibility and AnimatedContent are both backed by SubcomposeLayout.
   When the ViewModel already holds a non-Idle state on navigation return (e.g.
   a trace is still running), the AnimatedContent transitions as soon as the
   screen is composed, while the 400ms AnimatedVisibility entrance animation is
   still in flight. Two simultaneously-animating nested SubcomposeLayouts race
   on the slot table and throw IllegalStateException.
   Fix: replace AnimatedVisibility with animateFloatAsState + Modifier.alpha,
   which has no SubcomposeLayout and is safe to nest alongside AnimatedContent.

3. UI state not set to Running before the coroutine launches in startTrace().
   Previously the state stayed at the prior value (Idle / Finished / Error)
   until the first hop arrived, causing the old panel to remain visible during
   the initial DNS-resolution delay. Now Running(emptyList) is written
   synchronously before the coroutine is launched; a ValidationError emission
   will immediately overwrite it with Error, so there is no observable flicker.

https://claude.ai/code/session_01C5pL6mP81Je8vXVmJwAmiC