### PR TITLE
fix: correct CancellationException swallowing, connection leak, and ignored timeout

### DIFF
--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/lan/LanScanViewModel.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/lan/LanScanViewModel.kt
@@ -11,6 +11,7 @@ import net.aieat.netswissknife.core.network.lan.LanScanSummary
 import net.aieat.netswissknife.core.network.lan.SubnetUtils
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -160,6 +161,8 @@ class LanScanViewModel @Inject constructor(
                         }
                     }
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 AppLogger.e(TAG, "startScan: unexpected exception during scan", e)
                 _uiState.value = LanScanUiState.Error("Scan failed: ${e.message ?: "Unknown error"}")

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/wifi/WifiScanViewModel.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/wifi/WifiScanViewModel.kt
@@ -107,8 +107,6 @@ class WifiScanViewModel @Inject constructor(
                         bandFilter = prev?.bandFilter,
                         sortOrder = prev?.sortOrder ?: ApSortOrder.SIGNAL
                     )
-                    // Begin automatic refresh after the first successful scan (idempotent
-                    // if the refresh cycle is already running from a previous call).
                     if (!_autoRefresh.value) startAutoRefresh()
                 }
             } catch (e: CancellationException) {

--- a/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/portscan/PortScanRepositoryImpl.kt
+++ b/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/portscan/PortScanRepositoryImpl.kt
@@ -31,24 +31,23 @@ data class PortConnectResult(
  * Ports are tested in batches of [concurrency] simultaneously using coroutines.
  * For each open port, a brief banner read is attempted on well-known service ports.
  *
- * @param checker     Functional hook for the TCP probe. Defaults to the real socket implementation.
- * @param timeoutMs   Connection timeout (used in [DEFAULT_CHECKER] when [checker] is default).
+ * @param checker  Functional hook for the TCP probe. Pass null to use the real socket
+ *                 implementation, which honours the [scan] `timeoutMs` parameter.
  */
 class PortScanRepositoryImpl(
-    private val checker: PortConnectChecker = DEFAULT_CHECKER,
+    private val checker: PortConnectChecker? = null,
 ) : PortScanRepository {
 
     companion object {
         /**
-         * Default TCP checker: attempts a real socket connection and optionally reads a banner.
-         * The timeout is passed as the per-call socket timeout.
+         * Returns a TCP checker that uses [timeoutMs] for the connection timeout.
          */
-        val DEFAULT_CHECKER: PortConnectChecker = { host, port ->
+        fun defaultChecker(timeoutMs: Int): PortConnectChecker = { host, port ->
             val start = System.currentTimeMillis()
             var socket: Socket? = null
             try {
                 socket = Socket()
-                socket.connect(InetSocketAddress(host, port), 2000)
+                socket.connect(InetSocketAddress(host, port), timeoutMs)
                 val responseTime = System.currentTimeMillis() - start
 
                 // Attempt banner grab for open port (short read)
@@ -82,6 +81,7 @@ class PortScanRepositoryImpl(
         timeoutMs: Int,
         concurrency: Int
     ): Flow<PortScanUpdate> = flow {
+        val effectiveChecker = checker ?: defaultChecker(timeoutMs)
         val startTime = System.currentTimeMillis()
         val results = mutableListOf<PortScanResult>()
         var scannedCount = 0
@@ -99,7 +99,7 @@ class PortScanRepositoryImpl(
             coroutineScope {
                 val deferreds = chunk.map { port ->
                     async(Dispatchers.IO) {
-                        val connectResult = checker(host, port)
+                        val connectResult = effectiveChecker(host, port)
                         val portInfo = WellKnownPorts.getInfo(port)
                         PortScanResult(
                             port = port,

--- a/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/traceroute/GeoIpRepositoryImpl.kt
+++ b/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/traceroute/GeoIpRepositoryImpl.kt
@@ -35,9 +35,13 @@ class GeoIpRepositoryImpl : GeoIpRepository {
             conn.requestMethod  = "GET"
             conn.setRequestProperty("Accept", "application/json")
 
-            if (conn.responseCode != 200) return@withContext null
+            if (conn.responseCode != 200) {
+                conn.disconnect()
+                return@withContext null
+            }
 
-            val body = conn.inputStream.bufferedReader().readText()
+            val body = conn.inputStream.use { it.bufferedReader().readText() }
+            conn.disconnect()
             parseIpInfoResponse(ip, body)
         } catch (_: Exception) {
             null


### PR DESCRIPTION
## Summary

- **LanScanViewModel**: `catch (e: Exception)` was swallowing `CancellationException`, breaking cooperative cancellation. Pressing Stop would show an error state instead of partial scan results. Fixed by re-throwing `CancellationException` before the generic catch.
- **GeoIpRepositoryImpl**: `HttpURLConnection` and `InputStream` were never closed after each geo-IP lookup, leaking HTTP connections (one per traceroute hop on cache miss). Fixed with `inputStream.use {}` and `conn.disconnect()` on both the success and non-200 paths.
- **PortScanRepositoryImpl**: The `timeoutMs` parameter accepted by `scan()` was silently ignored — `DEFAULT_CHECKER` hardcoded 2000ms regardless of the user's setting. Replaced the static `DEFAULT_CHECKER` property with `defaultChecker(timeoutMs)` resolved at scan time. Test injection via the `checker` constructor parameter is unchanged.
- **WifiScanViewModel**: Removed a misleading comment that described the `if (!_autoRefresh.value)` guard as making `startAutoRefresh()` "idempotent" (the method itself is not idempotent).

## Test plan

- [ ] All existing unit tests pass (`./gradlew test`)
- [ ] LanScan: start a scan, press Stop mid-scan — verify partial results shown (not error)
- [ ] PortScan: change timeout in settings, scan a filtered host — verify scan respects the configured timeout
- [ ] Traceroute: run a multi-hop trace — verify no connection pool exhaustion under repeated use

🤖 Generated with [Claude Code](https://claude.com/claude-code)