### PR TITLE
fix: resolve 5 bugs found in codebase audit (TDD)

### DIFF
--- a/core-domain/src/main/kotlin/net/aieat/netswissknife/core/domain/TopologyDiscoveryUseCase.kt
+++ b/core-domain/src/main/kotlin/net/aieat/netswissknife/core/domain/TopologyDiscoveryUseCase.kt
@@ -7,7 +7,7 @@ import net.aieat.netswissknife.core.network.topology.*
 class TopologyDiscoveryUseCase(
     private val repository: TopologyDiscoveryRepository
 ) {
-    fun invoke(params: TopologyParams): Flow<TopologyDiscoveryEvent> {
+    operator fun invoke(params: TopologyParams): Flow<TopologyDiscoveryEvent> {
         val validation = TopologyParamsValidator.validate(params)
         if (!validation.isValid) {
             return flow {

--- a/core-domain/src/test/kotlin/net/aieat/netswissknife/core/domain/TopologyDiscoveryUseCaseTest.kt
+++ b/core-domain/src/test/kotlin/net/aieat/netswissknife/core/domain/TopologyDiscoveryUseCaseTest.kt
@@ -58,4 +58,23 @@ class TopologyDiscoveryUseCaseTest {
         assertEquals(1, events.size)
         assertTrue(events[0] is TopologyDiscoveryEvent.Error)
     }
+
+    @Test
+    fun `invoke can be called using operator syntax`() = runTest {
+        val mockGraph = TopologyGraph(
+            nodes = emptyList(),
+            links = emptyList(),
+            seedIp = "192.168.1.1",
+            queriedAt = System.currentTimeMillis()
+        )
+        every { repository.discover(validParams) } returns flowOf(
+            TopologyDiscoveryEvent.Complete(mockGraph)
+        )
+
+        // operator syntax: useCase(params) instead of useCase.invoke(params)
+        val events = useCase(validParams).toList()
+
+        assertEquals(1, events.size)
+        assertTrue(events[0] is TopologyDiscoveryEvent.Complete)
+    }
 }

--- a/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/HostValidator.kt
+++ b/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/HostValidator.kt
@@ -1,7 +1,10 @@
 package net.aieat.netswissknife.core.network
 
+import java.net.Inet6Address
+import java.net.InetAddress
+
 /**
- * Utility for validating hostnames and IP addresses.
+ * Utility for validating hostnames and IP addresses (IPv4 and IPv6).
  */
 object HostValidator {
     private val ipv4Regex = Regex(
@@ -13,12 +16,23 @@ object HostValidator {
 
     fun isValidIpv4(address: String): Boolean = ipv4Regex.matches(address)
 
+    fun isValidIpv6(address: String): Boolean {
+        if (!address.contains(':')) return false
+        return try {
+            InetAddress.getByName(address) is Inet6Address
+        } catch (_: Exception) {
+            false
+        }
+    }
+
     private val looksLikeIpv4 = Regex("""^\d+\.\d+\.\d+\.\d+$""")
 
     fun isValidHostname(host: String): Boolean {
         if (host.isBlank()) return false
         // If it looks like an IPv4 address (4 dot-separated groups of digits), require valid IPv4
         if (looksLikeIpv4.matches(host)) return isValidIpv4(host)
+        // IPv6 addresses contain colons
+        if (host.contains(':')) return isValidIpv6(host)
         return hostnameRegex.matches(host)
     }
 }

--- a/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/lan/SubnetUtils.kt
+++ b/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/lan/SubnetUtils.kt
@@ -94,8 +94,16 @@ object SubnetUtils {
         return longToIp(ipLong and mask)
     }
 
-    internal fun parseIpToLong(ip: String): Long =
-        ip.split(".").fold(0L) { acc, part -> (acc shl 8) or part.toLong() }
+    internal fun parseIpToLong(ip: String): Long {
+        val parts = ip.split(".")
+        require(parts.size == 4) { "Invalid IP address: $ip" }
+        return parts.fold(0L) { acc, part ->
+            val octet = part.toLongOrNull()
+                ?: throw IllegalArgumentException("Invalid IP address: $ip")
+            require(octet in 0..255) { "Invalid IP address octet $octet in: $ip" }
+            (acc shl 8) or octet
+        }
+    }
 
     private fun longToIp(ip: Long): String =
         "${(ip ushr 24) and 0xFF}.${(ip ushr 16) and 0xFF}.${(ip ushr 8) and 0xFF}.${ip and 0xFF}"

--- a/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/portscan/BannerSanitizer.kt
+++ b/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/portscan/BannerSanitizer.kt
@@ -1,0 +1,15 @@
+package net.aieat.netswissknife.core.network.portscan
+
+/**
+ * Sanitizes raw port banner text to safe, ASCII-printable characters only.
+ *
+ * Restricts output to the printable ASCII range (0x20–0x7E), trims surrounding
+ * whitespace, and caps length at 200 characters to prevent log injection and
+ * avoid leaking arbitrary Unicode data from untrusted remote services.
+ */
+internal object BannerSanitizer {
+    private const val MAX_LEN = 200
+
+    fun sanitize(raw: String): String =
+        raw.trim().take(MAX_LEN).filter { it.code in 0x20..0x7E }
+}

--- a/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/portscan/PortScanRepositoryImpl.kt
+++ b/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/portscan/PortScanRepositoryImpl.kt
@@ -56,10 +56,7 @@ class PortScanRepositoryImpl(
                     val inputStream = socket.getInputStream()
                     val bytes = ByteArray(256)
                     val read = inputStream.read(bytes)
-                    if (read > 0) {
-                        String(bytes, 0, read).trim().take(200)
-                            .filter { it.isLetterOrDigit() || it.isWhitespace() || it in "-./()@:_+" }
-                    } else null
+                    if (read > 0) BannerSanitizer.sanitize(String(bytes, 0, read)) else null
                 } catch (_: Exception) { null }
 
                 PortConnectResult(PortStatus.OPEN, responseTime, banner)

--- a/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/traceroute/GeoIpRepositoryImpl.kt
+++ b/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/traceroute/GeoIpRepositoryImpl.kt
@@ -28,23 +28,21 @@ class GeoIpRepositoryImpl : GeoIpRepository {
     // ── Network ───────────────────────────────────────────────────────────────
 
     private suspend fun fetchGeoIp(ip: String): HopGeoLocation? = withContext(Dispatchers.IO) {
+        val conn = URI("https://ipinfo.io/$ip/json").toURL().openConnection() as HttpURLConnection
         try {
-            val conn = URI("https://ipinfo.io/$ip/json").toURL().openConnection() as HttpURLConnection
             conn.connectTimeout = 5_000
             conn.readTimeout    = 5_000
             conn.requestMethod  = "GET"
             conn.setRequestProperty("Accept", "application/json")
 
-            if (conn.responseCode != 200) {
-                conn.disconnect()
-                return@withContext null
-            }
+            if (conn.responseCode != 200) return@withContext null
 
             val body = conn.inputStream.use { it.bufferedReader().readText() }
-            conn.disconnect()
             parseIpInfoResponse(ip, body)
         } catch (_: Exception) {
             null
+        } finally {
+            conn.disconnect()
         }
     }
 

--- a/core-network/src/test/kotlin/net/aieat/netswissknife/core/network/HostValidatorTest.kt
+++ b/core-network/src/test/kotlin/net/aieat/netswissknife/core/network/HostValidatorTest.kt
@@ -55,5 +55,34 @@ class HostValidatorTest {
         fun `blank string is rejected`() {
             assertFalse(HostValidator.isValidHostname("   "))
         }
+
+        @ParameterizedTest(name = "{0} is a valid IPv6 host")
+        @ValueSource(strings = ["::1", "fe80::1", "2001:db8::1", "2001:0db8:85a3:0000:0000:8a2e:0370:7334"])
+        fun `valid IPv6 addresses are accepted as hostnames`(host: String) {
+            assertTrue(HostValidator.isValidHostname(host))
+        }
+
+        @ParameterizedTest(name = "{0} is NOT a valid IPv6 address")
+        @ValueSource(strings = [":::1", "gggg::1", "2001:db8::xyz"])
+        fun `invalid IPv6 addresses are rejected`(host: String) {
+            assertFalse(HostValidator.isValidHostname(host))
+        }
+    }
+
+    @Nested
+    @DisplayName("isValidIpv6")
+    inner class IsValidIpv6 {
+
+        @ParameterizedTest(name = "{0} is a valid IPv6 address")
+        @ValueSource(strings = ["::1", "fe80::1", "2001:db8::1", "::"])
+        fun `valid IPv6 addresses are accepted`(address: String) {
+            assertTrue(HostValidator.isValidIpv6(address))
+        }
+
+        @ParameterizedTest(name = "{0} is NOT a valid IPv6 address")
+        @ValueSource(strings = ["192.168.1.1", "localhost", "", "gggg::1"])
+        fun `non-IPv6 strings are rejected`(address: String) {
+            assertFalse(HostValidator.isValidIpv6(address))
+        }
     }
 }

--- a/core-network/src/test/kotlin/net/aieat/netswissknife/core/network/lan/SubnetUtilsTest.kt
+++ b/core-network/src/test/kotlin/net/aieat/netswissknife/core/network/lan/SubnetUtilsTest.kt
@@ -90,5 +90,50 @@ class SubnetUtilsTest {
         fun `invalid prefix throws exception`() {
             assertThrows<Exception> { SubnetUtils.parseSubnet("192.168.1.0/33") }
         }
+
+        @Test
+        fun `octet above 255 throws IllegalArgumentException`() {
+            assertThrows<IllegalArgumentException> { SubnetUtils.parseSubnet("999.0.0.0/24") }
+        }
+
+        @Test
+        fun `octet above 255 in second position throws IllegalArgumentException`() {
+            assertThrows<IllegalArgumentException> { SubnetUtils.parseSubnet("192.300.0.0/24") }
+        }
+
+        @Test
+        fun `non-numeric octet throws IllegalArgumentException`() {
+            assertThrows<IllegalArgumentException> { SubnetUtils.parseSubnet("abc.0.0.0/24") }
+        }
+
+        @Test
+        fun `too few octets throws IllegalArgumentException`() {
+            assertThrows<IllegalArgumentException> { SubnetUtils.parseSubnet("192.168.1/24") }
+        }
+    }
+
+    @Nested
+    @DisplayName("parseIpToLong")
+    inner class ParseIpToLong {
+
+        @Test
+        fun `valid ip converts correctly`() {
+            assertEquals(0xC0A80101L, SubnetUtils.parseIpToLong("192.168.1.1"))
+        }
+
+        @Test
+        fun `octet above 255 throws IllegalArgumentException`() {
+            assertThrows<IllegalArgumentException> { SubnetUtils.parseIpToLong("256.0.0.1") }
+        }
+
+        @Test
+        fun `non-numeric octet throws IllegalArgumentException`() {
+            assertThrows<IllegalArgumentException> { SubnetUtils.parseIpToLong("192.168.x.1") }
+        }
+
+        @Test
+        fun `wrong number of octets throws IllegalArgumentException`() {
+            assertThrows<IllegalArgumentException> { SubnetUtils.parseIpToLong("192.168.1") }
+        }
     }
 }

--- a/core-network/src/test/kotlin/net/aieat/netswissknife/core/network/portscan/BannerSanitizerTest.kt
+++ b/core-network/src/test/kotlin/net/aieat/netswissknife/core/network/portscan/BannerSanitizerTest.kt
@@ -1,0 +1,91 @@
+package net.aieat.netswissknife.core.network.portscan
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("BannerSanitizer")
+class BannerSanitizerTest {
+
+    @Nested
+    @DisplayName("sanitizeBanner")
+    inner class SanitizeBanner {
+
+        @Test
+        fun `ASCII-only banner passes through unchanged`() {
+            val banner = "SSH-2.0-OpenSSH_9.0"
+            assertEquals(banner, BannerSanitizer.sanitize(banner))
+        }
+
+        @Test
+        fun `leading and trailing whitespace is trimmed`() {
+            assertEquals("hello", BannerSanitizer.sanitize("  hello  "))
+        }
+
+        @Test
+        fun `unicode letters are stripped`() {
+            val banner = "caf\u00e9"         // café
+            assertFalse(BannerSanitizer.sanitize(banner).contains('\u00e9'))
+        }
+
+        @Test
+        fun `control characters are stripped`() {
+            val banner = "hello\u0000world"   // embedded NUL
+            assertFalse(BannerSanitizer.sanitize(banner).contains('\u0000'))
+            assertEquals("helloworld", BannerSanitizer.sanitize(banner))
+        }
+
+        @Test
+        fun `newline characters are stripped`() {
+            val banner = "line1\nline2"
+            assertFalse(BannerSanitizer.sanitize(banner).contains('\n'))
+        }
+
+        @Test
+        fun `carriage return characters are stripped`() {
+            val banner = "line1\r\nline2"
+            assertFalse(BannerSanitizer.sanitize(banner).contains('\r'))
+        }
+
+        @Test
+        fun `tab characters are stripped`() {
+            val banner = "col1\tcol2"
+            assertFalse(BannerSanitizer.sanitize(banner).contains('\t'))
+        }
+
+        @Test
+        fun `banner is truncated to 200 characters`() {
+            val longBanner = "A".repeat(300)
+            assertTrue(BannerSanitizer.sanitize(longBanner).length <= 200)
+        }
+
+        @Test
+        fun `common service banner characters are preserved`() {
+            val banner = "SSH-2.0 (Ubuntu) / OpenSSH_9.0p1 @ host:22"
+            val result = BannerSanitizer.sanitize(banner)
+            assertTrue(result.contains("SSH-2.0"))
+            assertTrue(result.contains("/"))
+            assertTrue(result.contains(":"))
+            assertTrue(result.contains("@"))
+        }
+
+        @Test
+        fun `empty string returns empty string`() {
+            assertEquals("", BannerSanitizer.sanitize(""))
+        }
+
+        @Test
+        fun `whitespace-only string returns empty string after trim`() {
+            assertEquals("", BannerSanitizer.sanitize("   "))
+        }
+
+        @Test
+        fun `DEL character is stripped`() {
+            val banner = "hello\u007Fworld"  // DEL (0x7F)
+            assertFalse(BannerSanitizer.sanitize(banner).contains('\u007F'))
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **`SubnetUtils.parseIpToLong`**: Invalid IP octets (e.g. `999`) were silently accepted and produced wrong network addresses. Now validates each octet is in `0..255` and throws `IllegalArgumentException` on bad input.
- **`HostValidator`**: IPv6 addresses (e.g. `::1`, `fe80::1`) were incorrectly rejected. Added `isValidIpv6()` backed by `java.net.InetAddress` and routed colon-containing hosts through it in `isValidHostname()`.
- **`PortScanRepositoryImpl`**: Banner grab filtering used `isLetterOrDigit()` (passes Unicode) and `isWhitespace()` (passes `\n`, `\r`, `\t`). Extracted to a new `BannerSanitizer` object that restricts output to printable ASCII (`0x20–0x7E`), preventing log injection from untrusted remote services.
- **`GeoIpRepositoryImpl`**: `disconnect()` was not in a `finally` block — if body reading threw, the HTTP connection leaked. Restructured to always disconnect in `finally`.
- **`TopologyDiscoveryUseCase`**: `invoke()` was missing the `operator` keyword, inconsistent with every other use case. Callers could not use `useCase(params)` syntax.

## Test plan

- [ ] All existing tests still pass: `./gradlew :core-network:test :core-domain:test`
- [ ] 31 new tests added across `SubnetUtilsTest`, `HostValidatorTest`, `BannerSanitizerTest`, and `TopologyDiscoveryUseCaseTest`
- [ ] `BannerSanitizerTest` — 12 cases: ASCII passthrough, Unicode stripped, control chars stripped (`\0`, `\n`, `\r`, `\t`, DEL), length capped at 200, common service banner characters preserved
- [ ] `SubnetUtilsTest` — 7 new cases: octet > 255, non-numeric octet, wrong octet count (both in `parseSubnet` and `parseIpToLong` directly)
- [ ] `HostValidatorTest` — 12 new cases: valid/invalid IPv6 addresses via `isValidIpv6` and `isValidHostname`
- [ ] `TopologyDiscoveryUseCaseTest` — 1 new case: operator call syntax `useCase(params)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)