### PR TITLE
fix: strip subdomains to registrable domain before WHOIS queries

### DIFF
--- a/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/whois/WhoisRepositoryImpl.kt
+++ b/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/whois/WhoisRepositoryImpl.kt
@@ -41,11 +41,13 @@ class WhoisRepositoryImpl : WhoisRepository {
         timeoutMs: Int,
         overallStart: Long
     ): NetworkResult<WhoisResult> {
+        // Strip subdomains — WHOIS registries only know about the registrable domain (eTLD+1)
+        val registrableDomain = extractRegistrableDomain(domain)
         val hops = mutableListOf<WhoisHop>()
 
         // Hop 1 — IANA
         val ianaHop = try {
-            queryServer(IANA_SERVER, domain, timeoutMs)
+            queryServer(IANA_SERVER, registrableDomain, timeoutMs)
         } catch (e: Exception) {
             return NetworkResult.Error("IANA lookup failed: ${e.message}", e)
         }
@@ -61,11 +63,11 @@ class WhoisRepositoryImpl : WhoisRepository {
 
         // Hop 2 — TLD Registry
         val registryHost = ianaReferral
-            ?: getTldFallback(domain)
+            ?: getTldFallback(registrableDomain)
             ?: return buildDomainResult(domain, WhoisQueryType.DOMAIN, hops, overallStart)
 
         val registryHop = try {
-            queryServer(registryHost, domain, timeoutMs)
+            queryServer(registryHost, registrableDomain, timeoutMs)
         } catch (e: Exception) {
             return buildDomainResult(domain, WhoisQueryType.DOMAIN, hops, overallStart)
         }
@@ -82,7 +84,7 @@ class WhoisRepositoryImpl : WhoisRepository {
         // Hop 3 — Registrar
         if (registrarWhoisServer != null) {
             val registrarHop = try {
-                queryServer(registrarWhoisServer, domain, timeoutMs)
+                queryServer(registrarWhoisServer, registrableDomain, timeoutMs)
             } catch (e: Exception) {
                 return buildDomainResult(domain, WhoisQueryType.DOMAIN, hops, overallStart)
             }
@@ -224,6 +226,23 @@ class WhoisRepositoryImpl : WhoisRepository {
         )
     }
 
+    /**
+     * Strips subdomains to return the registrable domain (eTLD+1).
+     * e.g. "sub.example.co.uk" → "example.co.uk", "sub.example.com" → "example.com"
+     */
+    internal fun extractRegistrableDomain(domain: String): String {
+        val parts = domain.lowercase(java.util.Locale.ROOT).split('.')
+        if (parts.size <= 2) return domain
+        val lastTwo = "${parts[parts.size - 2]}.${parts.last()}"
+        return if (COMPOUND_TLDS.contains(lastTwo)) {
+            // e.g. co.uk → take 3 labels: example.co.uk
+            if (parts.size >= 3) parts.takeLast(3).joinToString(".") else domain
+        } else {
+            // Standard TLD → take 2 labels: example.com
+            parts.takeLast(2).joinToString(".")
+        }
+    }
+
     private fun getTldFallback(domain: String): String? {
         val parts = domain.lowercase(java.util.Locale.ROOT).split('.')
         if (parts.size < 2) return null
@@ -240,6 +259,17 @@ class WhoisRepositoryImpl : WhoisRepository {
         private const val WHOIS_PORT = 43
         private const val IANA_SERVER = "whois.iana.org"
         private const val ARIN_SERVER = "whois.arin.net"
+
+        private val COMPOUND_TLDS = setOf(
+            "co.uk", "org.uk", "me.uk", "net.uk", "ltd.uk", "plc.uk",
+            "co.nz", "net.nz", "org.nz", "gov.nz",
+            "com.au", "net.au", "org.au", "gov.au",
+            "co.jp", "or.jp", "ne.jp",
+            "co.in", "net.in", "org.in",
+            "com.br", "net.br", "org.br",
+            "com.cn", "net.cn", "org.cn",
+            "com.mx", "com.ar", "com.sg", "com.hk"
+        )
 
         private val TLD_FALLBACK = mapOf(
             "com"   to "whois.verisign-grs.com",

--- a/core-network/src/test/kotlin/net/aieat/netswissknife/core/network/whois/WhoisRepositoryImplTest.kt
+++ b/core-network/src/test/kotlin/net/aieat/netswissknife/core/network/whois/WhoisRepositoryImplTest.kt
@@ -35,3 +35,39 @@ class WhoisRepositoryImplTest {
         assertTrue(result is NetworkResult.Error)
     }
 }
+
+@DisplayName("WhoisRepositoryImpl – subdomain normalisation")
+class WhoisRegistrableDomainTest {
+
+    private val repo = WhoisRepositoryImpl()
+
+    @Test
+    @DisplayName("simple subdomain strips to eTLD+1")
+    fun `simple subdomain strips to eTLD+1`() {
+        assertEquals("example.com", repo.extractRegistrableDomain("sub.example.com"))
+    }
+
+    @Test
+    @DisplayName("deep subdomain strips to eTLD+1")
+    fun `deep subdomain strips to eTLD+1`() {
+        assertEquals("example.net", repo.extractRegistrableDomain("a.b.example.net"))
+    }
+
+    @Test
+    @DisplayName("compound TLD keeps three labels")
+    fun `compound TLD keeps three labels`() {
+        assertEquals("example.co.uk", repo.extractRegistrableDomain("sub.example.co.uk"))
+    }
+
+    @Test
+    @DisplayName("bare domain is returned unchanged")
+    fun `bare domain is returned unchanged`() {
+        assertEquals("example.com", repo.extractRegistrableDomain("example.com"))
+    }
+
+    @Test
+    @DisplayName("two-label compound TLD domain is returned unchanged")
+    fun `two-label compound TLD domain is returned unchanged`() {
+        assertEquals("example.co.uk", repo.extractRegistrableDomain("example.co.uk"))
+    }
+}


### PR DESCRIPTION
## Summary

- Fixes WHOIS lookup returning no data when a subdomain (e.g. `sub.example.net`) is entered
- WHOIS registries only hold records for the second-level domain — querying with a subdomain returns nothing useful

## Root cause

All three hops sent the full user input (including leading labels) to each server. Verisign, MarkMonitor, etc. only index `example.net`, not `sub.example.net`, so the `Registrar WHOIS Server:` line was never found and parsed fields came back null.

## Fix

`WhoisRepositoryImpl` now calls `extractRegistrableDomain()` before starting the hop chain, reducing `sub.example.net` → `example.net` and `sub.example.co.uk` → `example.co.uk`. Compound TLDs (co.uk, com.au, co.jp, etc.) are handled via an explicit set so the correct three-label form is preserved. The original query string is still stored in `WhoisResult.query` for display.

## Test plan

- [x] `./gradlew :core-network:test` — new `WhoisRegistrableDomainTest` (5 cases) + all prior WHOIS tests green
- [x] Manual: `sub.example.com` now resolves registrar, expiry, and name servers correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)