### PR TITLE
fix: show failed registrar hop in WHOIS query chain

### DIFF
--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/whois/WhoisViewModel.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/whois/WhoisViewModel.kt
@@ -71,7 +71,7 @@ class WhoisViewModel @Inject constructor(
                         if (h.status == HopStatus.QUERYING) h.copy(status = HopStatus.DONE) else h
                     } + HopUiState(
                         server = hop.server,
-                        status = HopStatus.DONE,
+                        status = if (hop.error != null) HopStatus.FAILED else HopStatus.DONE,
                         queryTimeMs = hop.queryTimeMs,
                         referral = hop.referral
                     )
@@ -94,7 +94,7 @@ class WhoisViewModel @Inject constructor(
                         hopStates = result.data.hops.map { hop ->
                             HopUiState(
                                 server = hop.server,
-                                status = HopStatus.DONE,
+                                status = if (hop.error != null) HopStatus.FAILED else HopStatus.DONE,
                                 queryTimeMs = hop.queryTimeMs,
                                 referral = hop.referral
                             )

--- a/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/whois/WhoisModels.kt
+++ b/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/whois/WhoisModels.kt
@@ -13,7 +13,8 @@ data class WhoisHop(
     val server: WhoisServer,
     val rawResponse: String,
     val queryTimeMs: Long,
-    val referral: String?
+    val referral: String?,
+    val error: String? = null
 )
 
 data class WhoisResult(

--- a/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/whois/WhoisRepositoryImpl.kt
+++ b/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/whois/WhoisRepositoryImpl.kt
@@ -86,6 +86,15 @@ class WhoisRepositoryImpl : WhoisRepository {
             val registrarHop = try {
                 queryServer(registrarWhoisServer, registrableDomain, timeoutMs)
             } catch (e: Exception) {
+                val failedHop = WhoisHop(
+                    server = WhoisServer(registrarWhoisServer, WhoisServerRole.REGISTRAR),
+                    rawResponse = "",
+                    queryTimeMs = 0L,
+                    referral = null,
+                    error = e.message ?: "Connection failed"
+                )
+                hops.add(failedHop)
+                _hopProgress.emit(failedHop)
                 return buildDomainResult(domain, WhoisQueryType.DOMAIN, hops, overallStart)
             }
             val hop3 = WhoisHop(
@@ -166,7 +175,7 @@ class WhoisRepositoryImpl : WhoisRepository {
         hops: List<WhoisHop>,
         overallStart: Long
     ): NetworkResult<WhoisResult> {
-        val lastResponse = hops.lastOrNull()?.rawResponse ?: ""
+        val lastResponse = hops.lastOrNull { it.error == null }?.rawResponse ?: ""
         val p = WhoisResponseParser
         return NetworkResult.Success(
             WhoisResult(


### PR DESCRIPTION
## Summary

- Added `error: String?` field to `WhoisHop` to represent unreachable servers
- When registrar WHOIS server (hop 3) connection fails, emit a failed hop instead of silently dropping it — the UI already has `HopStatus.FAILED` rendering (red X node) but was never given the data
- Use last *successful* hop's raw response for result field parsing, so fields like registrar/dates still populate correctly when hop 3 fails
- Map `hop.error != null` → `HopStatus.FAILED` in both ViewModel hop-progress collector and final state rebuild

## Test plan

- [ ] Query `epicor.com` — should show 3 nodes in query chain: IANA ✓, Verisign ✓, whois.corporatedomains.com ✗ (red X)
- [ ] Query `example.com` — should show 3 successful nodes when registrar server responds
- [ ] Query `8.8.8.8` — IP lookup unaffected, still shows RIR chain
- [ ] All existing unit tests pass (`./gradlew test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)