### PR TITLE
feat: add Subnet Calculator tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,15 @@ Full HTTP/HTTPS request tester with security header analysis.
   - **Body**: scrollable monospace response body with copy-to-clipboard; truncated at 512 KB with notice
   - **Security**: per-header pass/warn/fail ratings for HSTS, CSP, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy, and Server header information disclosure
 
+### Subnet Calculator
+IPv4 subnet calculator with visual binary breakdown and multi-notation conversion.
+- Accepts CIDR (`192.168.1.0/24`), dot-decimal mask (`192.168.1.0/255.255.255.0`), space-separated mask, or bare IP (assumes `/32`)
+- Computes: network address, broadcast, first/last usable host, total and usable host counts
+- **Binary Breakdown card**: colour-coded bit grid distinguishing network bits (blue) from host bits (orange) for IP address, subnet mask, and network address rows
+- **Notation Equivalents card**: CIDR, dot-decimal mask, wildcard mask, hex mask (`0xFFFFFF00`), and binary mask
+- **Address Properties card**: IP class (A/B/C/D/E), private/public scope badge (RFC 1918 + loopback + link-local), prefix and host bit counts
+- Quick example chips for common subnets (`/8`, `/12`, `/16`, `/24`, `/30`, `/0`)
+
 ---
 
 ## Module Layout
@@ -185,6 +194,7 @@ Android module (Jetpack Compose, Material 3, Hilt). Contains:
 | `tls` | TLS Inspector | Implemented |
 | `whois` | WHOIS Lookup | Implemented |
 | `httprobe` | HTTP Probe | Implemented |
+| `subnet` | Subnet Calculator | Implemented |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,18 @@ Domain and IP registration lookup via three-hop WHOIS referral chain.
 - Live relay-chain visualiser: animates each server node PENDING → QUERYING → DONE as the chain progresses
 - Optional raw response per hop for power users
 
+### HTTP Probe
+Full HTTP/HTTPS request tester with security header analysis.
+- Supports GET, POST, PUT, PATCH, DELETE, HEAD, and OPTIONS methods
+- Custom request headers: add/remove key-value pairs dynamically
+- Request body editor (enabled for POST, PUT, PATCH) with monospace text input
+- Follow-redirects toggle with full redirect chain display
+- Response display across four tabs:
+  - **Overview**: status code (color-coded 2xx/3xx/4xx/5xx), response time, final URL, redirect hops, body size, Content-Type
+  - **Headers**: collapsible request and response header sections
+  - **Body**: scrollable monospace response body with copy-to-clipboard; truncated at 512 KB with notice
+  - **Security**: per-header pass/warn/fail ratings for HSTS, CSP, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy, and Server header information disclosure
+
 ---
 
 ## Module Layout
@@ -172,6 +184,7 @@ Android module (Jetpack Compose, Material 3, Hilt). Contains:
 | `topology` | Network Topology Discovery | Implemented |
 | `tls` | TLS Inspector | Implemented |
 | `whois` | WHOIS Lookup | Implemented |
+| `httprobe` | HTTP Probe | Implemented |
 
 ---
 

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/di/HttpProbeModule.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/di/HttpProbeModule.kt
@@ -1,0 +1,24 @@
+package net.aieat.netswissknife.app.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import net.aieat.netswissknife.core.domain.HttpProbeUseCase
+import net.aieat.netswissknife.core.network.httprobe.HttpProbeRepository
+import net.aieat.netswissknife.core.network.httprobe.HttpProbeRepositoryImpl
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object HttpProbeModule {
+
+    @Provides
+    @Singleton
+    fun provideHttpProbeRepository(): HttpProbeRepository = HttpProbeRepositoryImpl()
+
+    @Provides
+    @Singleton
+    fun provideHttpProbeUseCase(repo: HttpProbeRepository): HttpProbeUseCase =
+        HttpProbeUseCase(repo)
+}

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/di/SubnetCalculatorModule.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/di/SubnetCalculatorModule.kt
@@ -1,0 +1,25 @@
+package net.aieat.netswissknife.app.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import net.aieat.netswissknife.core.domain.SubnetCalculatorUseCase
+import net.aieat.netswissknife.core.network.subnet.SubnetCalculatorRepository
+import net.aieat.netswissknife.core.network.subnet.SubnetCalculatorRepositoryImpl
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object SubnetCalculatorModule {
+
+    @Provides
+    @Singleton
+    fun provideSubnetCalculatorRepository(): SubnetCalculatorRepository =
+        SubnetCalculatorRepositoryImpl()
+
+    @Provides
+    @Singleton
+    fun provideSubnetCalculatorUseCase(repo: SubnetCalculatorRepository): SubnetCalculatorUseCase =
+        SubnetCalculatorUseCase(repo)
+}

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/navigation/AppNavigation.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/navigation/AppNavigation.kt
@@ -26,6 +26,7 @@ import net.aieat.netswissknife.app.ui.screens.debug.DebugLogScreen
 import net.aieat.netswissknife.app.ui.screens.tls.TlsInspectorScreen
 import net.aieat.netswissknife.app.ui.screens.topology.TopologyDiscoveryScreen
 import net.aieat.netswissknife.app.ui.screens.httprobe.HttpProbeScreen
+import net.aieat.netswissknife.app.ui.screens.subnet.SubnetCalculatorScreen
 import net.aieat.netswissknife.app.ui.screens.whois.WhoisScreen
 
 // ── Transition helpers ────────────────────────────────────────────────────────
@@ -101,5 +102,6 @@ fun AppNavHost(navController: NavHostController, modifier: Modifier = Modifier) 
         composable(NavRoutes.TlsInspector.route)      { TlsInspectorScreen() }
         composable(NavRoutes.WhoisLookup.route)       { WhoisScreen() }
         composable(NavRoutes.HttpProbe.route)         { HttpProbeScreen() }
+        composable(NavRoutes.SubnetCalculator.route)  { SubnetCalculatorScreen() }
     }
 }

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/navigation/AppNavigation.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/navigation/AppNavigation.kt
@@ -25,6 +25,7 @@ import net.aieat.netswissknife.app.ui.screens.WifiScanScreen
 import net.aieat.netswissknife.app.ui.screens.debug.DebugLogScreen
 import net.aieat.netswissknife.app.ui.screens.tls.TlsInspectorScreen
 import net.aieat.netswissknife.app.ui.screens.topology.TopologyDiscoveryScreen
+import net.aieat.netswissknife.app.ui.screens.httprobe.HttpProbeScreen
 import net.aieat.netswissknife.app.ui.screens.whois.WhoisScreen
 
 // ── Transition helpers ────────────────────────────────────────────────────────
@@ -99,5 +100,6 @@ fun AppNavHost(navController: NavHostController, modifier: Modifier = Modifier) 
         composable(NavRoutes.TopologyDiscovery.route) { TopologyDiscoveryScreen() }
         composable(NavRoutes.TlsInspector.route)      { TlsInspectorScreen() }
         composable(NavRoutes.WhoisLookup.route)       { WhoisScreen() }
+        composable(NavRoutes.HttpProbe.route)         { HttpProbeScreen() }
     }
 }

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/navigation/NavRoutes.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/navigation/NavRoutes.kt
@@ -4,6 +4,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountTree
 import androidx.compose.material.icons.filled.BugReport
 import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Http
 import androidx.compose.material.icons.filled.Language
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.ManageSearch
@@ -38,6 +39,7 @@ sealed class NavRoutes(
     object TopologyDiscovery : NavRoutes("topology", "Network Topology", Icons.Default.AccountTree)
     object TlsInspector : NavRoutes("tls", "TLS Inspector", Icons.Default.Lock)
     object WhoisLookup : NavRoutes("whois", "WHOIS Lookup", Icons.Default.ManageSearch)
+    object HttpProbe : NavRoutes("httprobe", "HTTP Probe", Icons.Default.Http)
 
     companion object {
         /** All navigable tool screens (excluding Home). */
@@ -51,6 +53,7 @@ sealed class NavRoutes(
             ToolInfo("topology",   "Network Topology", "Topology", Icons.Default.AccountTree, "SNMP switch & neighbour discovery"),
             ToolInfo("tls",        "TLS Inspector",    "TLS",      Icons.Default.Lock,         "SSL/TLS certificate chain inspector"),
             ToolInfo("whois",      "WHOIS Lookup",  "WHOIS", Icons.Default.ManageSearch, "Domain and IP registration lookup"),
+            ToolInfo("httprobe",   "HTTP Probe",    "HTTP",  Icons.Default.Http,          "HTTP/HTTPS request tester with security header analysis"),
         )
 
         /** Default pinned routes shown in the bottom nav (max MAX_PINNED). */

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/navigation/NavRoutes.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/navigation/NavRoutes.kt
@@ -3,6 +3,7 @@ package net.aieat.netswissknife.app.ui.navigation
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountTree
 import androidx.compose.material.icons.filled.BugReport
+import androidx.compose.material.icons.filled.Calculate
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Http
 import androidx.compose.material.icons.filled.Language
@@ -40,6 +41,7 @@ sealed class NavRoutes(
     object TlsInspector : NavRoutes("tls", "TLS Inspector", Icons.Default.Lock)
     object WhoisLookup : NavRoutes("whois", "WHOIS Lookup", Icons.Default.ManageSearch)
     object HttpProbe : NavRoutes("httprobe", "HTTP Probe", Icons.Default.Http)
+    object SubnetCalculator : NavRoutes("subnet", "Subnet Calc", Icons.Default.Calculate)
 
     companion object {
         /** All navigable tool screens (excluding Home). */
@@ -54,6 +56,7 @@ sealed class NavRoutes(
             ToolInfo("tls",        "TLS Inspector",    "TLS",      Icons.Default.Lock,         "SSL/TLS certificate chain inspector"),
             ToolInfo("whois",      "WHOIS Lookup",  "WHOIS", Icons.Default.ManageSearch, "Domain and IP registration lookup"),
             ToolInfo("httprobe",   "HTTP Probe",    "HTTP",  Icons.Default.Http,          "HTTP/HTTPS request tester with security header analysis"),
+            ToolInfo("subnet",     "Subnet Calc",   "Subnet", Icons.Default.Calculate,     "IPv4 subnet calculator with binary breakdown and notation conversion"),
         )
 
         /** Default pinned routes shown in the bottom nav (max MAX_PINNED). */

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/httprobe/HttpProbeScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/httprobe/HttpProbeScreen.kt
@@ -1,0 +1,1096 @@
+package net.aieat.netswissknife.app.ui.screens.httprobe
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.ExpandMore
+import androidx.compose.material.icons.filled.Http
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Send
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.ScrollableTabRow
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Tab
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import net.aieat.netswissknife.app.R
+import net.aieat.netswissknife.core.network.httprobe.HttpMethod
+import net.aieat.netswissknife.core.network.httprobe.HttpProbeResult
+import net.aieat.netswissknife.core.network.httprobe.SecurityHeaderCheck
+import net.aieat.netswissknife.core.network.httprobe.SecurityRating
+
+// ── Screen ────────────────────────────────────────────────────────────────────
+
+@Composable
+fun HttpProbeScreen(viewModel: HttpProbeViewModel = hiltViewModel()) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    var visible by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) { visible = true }
+
+    val alpha by animateFloatAsState(
+        targetValue = if (visible) 1f else 0f,
+        animationSpec = tween(400),
+        label = "httprobe_entrance_alpha"
+    )
+
+    AnimatedVisibility(
+        visible = visible,
+        enter = fadeIn(tween(400)) + slideInVertically(tween(400)) { it / 4 }
+    ) {
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            contentPadding = androidx.compose.foundation.layout.PaddingValues(
+                horizontal = 16.dp, vertical = 16.dp
+            )
+        ) {
+            item { HttpProbeHeaderCard() }
+
+            item {
+                HttpProbeInputCard(
+                    uiState = uiState,
+                    onUrlChange = viewModel::onUrlChange,
+                    onMethodChange = viewModel::onMethodChange,
+                    onBodyChange = viewModel::onBodyChange,
+                    onFollowRedirectsToggle = viewModel::onFollowRedirectsToggle,
+                    onToggleHeaders = viewModel::onToggleHeadersExpanded,
+                    onAddHeader = viewModel::addHeader,
+                    onRemoveHeader = viewModel::removeHeader,
+                    onHeaderKeyChange = viewModel::updateHeaderKey,
+                    onHeaderValueChange = viewModel::updateHeaderValue,
+                    onSend = viewModel::send
+                )
+            }
+
+            item {
+                val displayState: DisplayState = when {
+                    uiState.isLoading     -> DisplayState.Loading
+                    uiState.error != null -> DisplayState.Error(uiState.error!!)
+                    uiState.result != null -> DisplayState.Success(uiState.result!!)
+                    else                  -> DisplayState.Idle
+                }
+
+                AnimatedContent(
+                    targetState = displayState,
+                    transitionSpec = { fadeIn(tween(300)) togetherWith fadeOut(tween(200)) },
+                    label = "httprobe_content_state"
+                ) { state ->
+                    when (state) {
+                        is DisplayState.Idle    -> HttpProbeIdlePlaceholder()
+                        is DisplayState.Loading -> HttpProbeLoadingContent()
+                        is DisplayState.Error   -> HttpProbeErrorContent(state.message) { viewModel.send() }
+                        is DisplayState.Success -> HttpProbeSuccessContent(
+                            result = state.result,
+                            selectedTab = uiState.selectedTab,
+                            onTabSelected = viewModel::onTabSelected
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ── Display state ─────────────────────────────────────────────────────────────
+
+private sealed class DisplayState {
+    object Idle : DisplayState()
+    object Loading : DisplayState()
+    data class Error(val message: String) : DisplayState()
+    data class Success(val result: HttpProbeResult) : DisplayState()
+}
+
+// ── Header card ───────────────────────────────────────────────────────────────
+
+@Composable
+private fun HttpProbeHeaderCard() {
+    ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+        Box(modifier = Modifier.fillMaxWidth().height(90.dp)) {
+            Canvas(modifier = Modifier.matchParentSize()) {
+                drawRect(
+                    brush = Brush.linearGradient(
+                        listOf(
+                            Color(0xFF1565C0),
+                            Color(0xFF0288D1)
+                        )
+                    )
+                )
+            }
+            Column(
+                modifier = Modifier
+                    .align(Alignment.CenterStart)
+                    .padding(horizontal = 20.dp, vertical = 16.dp)
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        imageVector = Icons.Default.Http,
+                        contentDescription = null,
+                        tint = Color.White,
+                        modifier = Modifier.size(26.dp)
+                    )
+                    Spacer(Modifier.width(10.dp))
+                    Text(
+                        text = stringResource(R.string.httprobe_screen_title),
+                        style = MaterialTheme.typography.headlineMedium,
+                        color = Color.White,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    text = stringResource(R.string.httprobe_screen_subtitle),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = Color.White.copy(alpha = 0.85f)
+                )
+            }
+        }
+    }
+}
+
+// ── Input card ────────────────────────────────────────────────────────────────
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun HttpProbeInputCard(
+    uiState: HttpProbeUiState,
+    onUrlChange: (String) -> Unit,
+    onMethodChange: (HttpMethod) -> Unit,
+    onBodyChange: (String) -> Unit,
+    onFollowRedirectsToggle: () -> Unit,
+    onToggleHeaders: () -> Unit,
+    onAddHeader: () -> Unit,
+    onRemoveHeader: (Int) -> Unit,
+    onHeaderKeyChange: (Int, String) -> Unit,
+    onHeaderValueChange: (Int, String) -> Unit,
+    onSend: () -> Unit
+) {
+    val focusManager = LocalFocusManager.current
+
+    ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(14.dp)
+        ) {
+            // URL field
+            OutlinedTextField(
+                value = uiState.url,
+                onValueChange = onUrlChange,
+                label = { Text(stringResource(R.string.httprobe_url_label)) },
+                placeholder = { Text(stringResource(R.string.httprobe_url_placeholder)) },
+                leadingIcon = { Icon(Icons.Default.Http, contentDescription = null) },
+                trailingIcon = {
+                    if (uiState.url.isNotEmpty()) {
+                        IconButton(onClick = { onUrlChange("") }) {
+                            Icon(Icons.Default.Clear, contentDescription = stringResource(R.string.clear))
+                        }
+                    }
+                },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Uri,
+                    imeAction = ImeAction.Done
+                ),
+                keyboardActions = KeyboardActions(onDone = {
+                    focusManager.clearFocus()
+                    onSend()
+                })
+            )
+
+            // Method selector
+            Text(
+                text = stringResource(R.string.httprobe_method_label),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                HttpMethod.values().forEach { method ->
+                    val selected = uiState.method == method
+                    FilterChip(
+                        selected = selected,
+                        onClick = { onMethodChange(method) },
+                        label = { Text(method.name, style = MaterialTheme.typography.labelMedium) },
+                        colors = FilterChipDefaults.filterChipColors(
+                            selectedContainerColor = methodColor(method).copy(alpha = 0.2f),
+                            selectedLabelColor = methodColor(method)
+                        )
+                    )
+                }
+            }
+
+            // Custom headers toggle
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = stringResource(R.string.httprobe_custom_headers_label),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.weight(1f)
+                )
+                if (uiState.customHeaders.isNotEmpty()) {
+                    Surface(
+                        shape = MaterialTheme.shapes.small,
+                        color = MaterialTheme.colorScheme.primaryContainer
+                    ) {
+                        Text(
+                            text = "${uiState.customHeaders.size}",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onPrimaryContainer,
+                            modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp)
+                        )
+                    }
+                    Spacer(Modifier.width(4.dp))
+                }
+                IconButton(onClick = onToggleHeaders, modifier = Modifier.size(32.dp)) {
+                    Icon(
+                        imageVector = if (uiState.headersExpanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+                        contentDescription = null,
+                        modifier = Modifier.size(20.dp)
+                    )
+                }
+                IconButton(onClick = onAddHeader, modifier = Modifier.size(32.dp)) {
+                    Icon(Icons.Default.Add, contentDescription = stringResource(R.string.httprobe_add_header), modifier = Modifier.size(20.dp))
+                }
+            }
+
+            AnimatedVisibility(
+                visible = uiState.headersExpanded && uiState.customHeaders.isNotEmpty(),
+                enter = expandVertically() + fadeIn(),
+                exit = shrinkVertically() + fadeOut()
+            ) {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    uiState.customHeaders.forEachIndexed { index, header ->
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(6.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            OutlinedTextField(
+                                value = header.key,
+                                onValueChange = { onHeaderKeyChange(index, it) },
+                                label = { Text(stringResource(R.string.httprobe_header_key), style = MaterialTheme.typography.labelSmall) },
+                                singleLine = true,
+                                modifier = Modifier.weight(1f),
+                                textStyle = MaterialTheme.typography.bodySmall
+                            )
+                            OutlinedTextField(
+                                value = header.value,
+                                onValueChange = { onHeaderValueChange(index, it) },
+                                label = { Text(stringResource(R.string.httprobe_header_value), style = MaterialTheme.typography.labelSmall) },
+                                singleLine = true,
+                                modifier = Modifier.weight(1f),
+                                textStyle = MaterialTheme.typography.bodySmall
+                            )
+                            IconButton(
+                                onClick = { onRemoveHeader(index) },
+                                modifier = Modifier.size(32.dp)
+                            ) {
+                                Icon(
+                                    Icons.Default.Delete,
+                                    contentDescription = stringResource(R.string.httprobe_remove_header),
+                                    tint = MaterialTheme.colorScheme.error,
+                                    modifier = Modifier.size(18.dp)
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Request body (only for methods that support it)
+            AnimatedVisibility(
+                visible = uiState.method.supportsBody,
+                enter = expandVertically() + fadeIn(),
+                exit = shrinkVertically() + fadeOut()
+            ) {
+                OutlinedTextField(
+                    value = uiState.body,
+                    onValueChange = onBodyChange,
+                    label = { Text(stringResource(R.string.httprobe_body_label)) },
+                    placeholder = { Text(stringResource(R.string.httprobe_body_placeholder)) },
+                    modifier = Modifier.fillMaxWidth().height(120.dp),
+                    textStyle = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                    maxLines = 6
+                )
+            }
+
+            // Follow redirects toggle
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = stringResource(R.string.httprobe_follow_redirects_label),
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                    Text(
+                        text = stringResource(R.string.httprobe_follow_redirects_sub),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                Switch(
+                    checked = uiState.followRedirects,
+                    onCheckedChange = { onFollowRedirectsToggle() }
+                )
+            }
+
+            // Send button
+            Button(
+                onClick = {
+                    focusManager.clearFocus()
+                    onSend()
+                },
+                enabled = uiState.url.isNotBlank() && !uiState.isLoading,
+                modifier = Modifier.fillMaxWidth(),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.primary
+                )
+            ) {
+                if (uiState.isLoading) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(18.dp),
+                        color = MaterialTheme.colorScheme.onPrimary,
+                        strokeWidth = 2.dp
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Text(stringResource(R.string.httprobe_sending))
+                } else {
+                    Icon(Icons.Default.Send, contentDescription = null, modifier = Modifier.size(18.dp))
+                    Spacer(Modifier.width(8.dp))
+                    Text(stringResource(R.string.httprobe_send_button))
+                }
+            }
+        }
+    }
+}
+
+// ── Idle ──────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun HttpProbeIdlePlaceholder() {
+    ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(32.dp).fillMaxWidth(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Icon(
+                imageVector = Icons.Default.Http,
+                contentDescription = null,
+                modifier = Modifier.size(56.dp),
+                tint = MaterialTheme.colorScheme.primary.copy(alpha = 0.5f)
+            )
+            Text(
+                text = stringResource(R.string.httprobe_idle_title),
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Text(
+                text = stringResource(R.string.httprobe_idle_subtitle),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center
+            )
+        }
+    }
+}
+
+// ── Loading ───────────────────────────────────────────────────────────────────
+
+@Composable
+private fun HttpProbeLoadingContent() {
+    ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+        Box(
+            modifier = Modifier.fillMaxWidth().padding(48.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                CircularProgressIndicator(modifier = Modifier.size(48.dp))
+                Text(
+                    text = stringResource(R.string.httprobe_sending),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}
+
+// ── Error ─────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun HttpProbeErrorContent(message: String, onRetry: () -> Unit) {
+    ElevatedCard(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.elevatedCardColors(
+            containerColor = MaterialTheme.colorScheme.errorContainer
+        )
+    ) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = Icons.Default.Warning,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.size(20.dp)
+                )
+                Spacer(Modifier.width(8.dp))
+                Text(
+                    text = stringResource(R.string.httprobe_error_title),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onErrorContainer,
+                    fontWeight = FontWeight.SemiBold
+                )
+            }
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onErrorContainer
+            )
+            TextButton(onClick = onRetry) {
+                Icon(Icons.Default.Refresh, contentDescription = null, modifier = Modifier.size(16.dp))
+                Spacer(Modifier.width(4.dp))
+                Text(stringResource(R.string.httprobe_retry))
+            }
+        }
+    }
+}
+
+// ── Success ───────────────────────────────────────────────────────────────────
+
+@Composable
+private fun HttpProbeSuccessContent(
+    result: HttpProbeResult,
+    selectedTab: Int,
+    onTabSelected: (Int) -> Unit
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        // Status banner
+        StatusBannerCard(result)
+
+        // Tabs
+        val tabs = listOf(
+            stringResource(R.string.httprobe_tab_overview),
+            stringResource(R.string.httprobe_tab_headers),
+            stringResource(R.string.httprobe_tab_body),
+            stringResource(R.string.httprobe_tab_security)
+        )
+        ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+            ScrollableTabRow(
+                selectedTabIndex = selectedTab,
+                edgePadding = 8.dp,
+                containerColor = MaterialTheme.colorScheme.surfaceVariant
+            ) {
+                tabs.forEachIndexed { index, title ->
+                    Tab(
+                        selected = selectedTab == index,
+                        onClick = { onTabSelected(index) },
+                        text = {
+                            Text(
+                                title,
+                                style = MaterialTheme.typography.labelMedium,
+                                maxLines = 1
+                            )
+                        }
+                    )
+                }
+            }
+
+            AnimatedContent(
+                targetState = selectedTab,
+                transitionSpec = { fadeIn(tween(200)) togetherWith fadeOut(tween(150)) },
+                label = "httprobe_tab_content"
+            ) { tab ->
+                when (tab) {
+                    0 -> OverviewTabContent(result)
+                    1 -> HeadersTabContent(result)
+                    2 -> BodyTabContent(result)
+                    3 -> SecurityTabContent(result.securityChecks)
+                    else -> OverviewTabContent(result)
+                }
+            }
+        }
+    }
+}
+
+// ── Status banner ─────────────────────────────────────────────────────────────
+
+@Composable
+private fun StatusBannerCard(result: HttpProbeResult) {
+    ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.fillMaxWidth()) {
+            // Gradient top bar matching status class
+            Canvas(modifier = Modifier.fillMaxWidth().height(4.dp)) {
+                drawRect(brush = Brush.horizontalGradient(statusGradient(result.statusCode)))
+            }
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Column {
+                    Row(verticalAlignment = Alignment.Bottom, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Text(
+                            text = result.statusCode.toString(),
+                            style = MaterialTheme.typography.displaySmall,
+                            fontWeight = FontWeight.ExtraBold,
+                            color = statusCodeColor(result.statusCode)
+                        )
+                        Text(
+                            text = result.statusMessage,
+                            style = MaterialTheme.typography.titleMedium,
+                            color = MaterialTheme.colorScheme.onSurface,
+                            modifier = Modifier.padding(bottom = 4.dp)
+                        )
+                    }
+                    Text(
+                        text = result.finalUrl,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+                Column(horizontalAlignment = Alignment.End) {
+                    Text(
+                        text = "${result.responseTimeMs} ms",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = timingColor(result.responseTimeMs)
+                    )
+                    Text(
+                        text = stringResource(R.string.httprobe_response_time_label),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+            if (result.redirectChain.isNotEmpty()) {
+                HorizontalDivider()
+                Row(
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(6.dp)
+                ) {
+                    Icon(
+                        Icons.Default.Info,
+                        contentDescription = null,
+                        modifier = Modifier.size(14.dp),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Text(
+                        text = stringResource(R.string.httprobe_redirects_label, result.redirectChain.size),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        }
+    }
+}
+
+// ── Overview tab ──────────────────────────────────────────────────────────────
+
+@Composable
+private fun OverviewTabContent(result: HttpProbeResult) {
+    Column(
+        modifier = Modifier.padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        LabeledValue(stringResource(R.string.httprobe_method_used), result.request.method.name)
+        LabeledValue(stringResource(R.string.httprobe_final_url), result.finalUrl)
+        LabeledValue(stringResource(R.string.httprobe_response_size), formatBytes(result.responseBodyBytes))
+        LabeledValue(
+            stringResource(R.string.httprobe_content_type),
+            result.responseHeaders["Content-Type"]?.firstOrNull() ?: "—"
+        )
+        if (result.redirectChain.isNotEmpty()) {
+            HorizontalDivider()
+            Text(
+                text = stringResource(R.string.httprobe_redirect_chain),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            result.redirectChain.forEachIndexed { index, url ->
+                Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                    Surface(
+                        shape = MaterialTheme.shapes.small,
+                        color = MaterialTheme.colorScheme.secondaryContainer
+                    ) {
+                        Text(
+                            text = "${index + 1}",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSecondaryContainer,
+                            modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp)
+                        )
+                    }
+                    Text(
+                        text = url,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier.weight(1f),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            }
+        }
+    }
+}
+
+// ── Headers tab ───────────────────────────────────────────────────────────────
+
+@Composable
+private fun HeadersTabContent(result: HttpProbeResult) {
+    var showRequest by remember { mutableStateOf(false) }
+    var showResponse by remember { mutableStateOf(true) }
+
+    Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        // Request headers section
+        HeaderSection(
+            title = stringResource(R.string.httprobe_request_headers),
+            expanded = showRequest,
+            onToggle = { showRequest = !showRequest }
+        ) {
+            if (result.request.headers.isEmpty()) {
+                Text(
+                    text = stringResource(R.string.httprobe_no_custom_headers),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            } else {
+                result.request.headers.forEach { (key, value) ->
+                    HeaderRow(key, value)
+                }
+            }
+        }
+
+        // Response headers section
+        HeaderSection(
+            title = stringResource(R.string.httprobe_response_headers),
+            expanded = showResponse,
+            onToggle = { showResponse = !showResponse }
+        ) {
+            val displayHeaders = result.responseHeaders.filter { it.key != null }
+            if (displayHeaders.isEmpty()) {
+                Text(
+                    text = stringResource(R.string.httprobe_no_headers),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            } else {
+                displayHeaders.entries.sortedBy { it.key }.forEach { (key, values) ->
+                    HeaderRow(key, values.joinToString(", "))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun HeaderSection(
+    title: String,
+    expanded: Boolean,
+    onToggle: () -> Unit,
+    content: @Composable () -> Unit
+) {
+    OutlinedCard(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.fillMaxWidth()) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 12.dp, vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.labelMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.weight(1f)
+                )
+                IconButton(onClick = onToggle, modifier = Modifier.size(32.dp)) {
+                    Icon(
+                        imageVector = if (expanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp)
+                    )
+                }
+            }
+            AnimatedVisibility(visible = expanded) {
+                Column(
+                    modifier = Modifier.padding(start = 12.dp, end = 12.dp, bottom = 12.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    content()
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun HeaderRow(key: String, value: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.Top
+    ) {
+        Text(
+            text = key,
+            style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+            color = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.weight(0.4f),
+            fontWeight = FontWeight.Medium
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.weight(0.6f)
+        )
+    }
+}
+
+// ── Body tab ──────────────────────────────────────────────────────────────────
+
+@Composable
+private fun BodyTabContent(result: HttpProbeResult) {
+    val clipboardManager = LocalClipboardManager.current
+
+    val responseBody = result.responseBody
+
+    Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = stringResource(R.string.httprobe_response_body),
+                style = MaterialTheme.typography.labelMedium,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.weight(1f)
+            )
+            if (!responseBody.isNullOrBlank()) {
+                TextButton(
+                    onClick = { clipboardManager.setText(AnnotatedString(responseBody)) }
+                ) {
+                    Text(stringResource(R.string.httprobe_copy_body), style = MaterialTheme.typography.labelSmall)
+                }
+            }
+        }
+
+        if (result.responseBodyBytes > 512_000L) {
+            Surface(
+                shape = MaterialTheme.shapes.small,
+                color = MaterialTheme.colorScheme.tertiaryContainer
+            ) {
+                Text(
+                    text = stringResource(R.string.httprobe_body_truncated, formatBytes(result.responseBodyBytes)),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onTertiaryContainer,
+                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp)
+                )
+            }
+        }
+
+        if (responseBody.isNullOrBlank()) {
+            Text(
+                text = stringResource(R.string.httprobe_empty_body),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        } else {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(MaterialTheme.shapes.small)
+                    .background(MaterialTheme.colorScheme.surfaceVariant)
+                    .padding(12.dp)
+            ) {
+                Text(
+                    text = responseBody,
+                    style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}
+
+// ── Security tab ──────────────────────────────────────────────────────────────
+
+@Composable
+private fun SecurityTabContent(checks: List<SecurityHeaderCheck>) {
+    Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        // Summary row
+        val passCount = checks.count { it.rating == SecurityRating.PASS }
+        val warnCount = checks.count { it.rating == SecurityRating.WARN }
+        val failCount = checks.count { it.rating == SecurityRating.FAIL }
+
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            SecuritySummaryChip(count = passCount, label = "Pass", color = Color(0xFF2E7D32))
+            SecuritySummaryChip(count = warnCount, label = "Warn", color = Color(0xFFF57F17))
+            SecuritySummaryChip(count = failCount, label = "Fail", color = MaterialTheme.colorScheme.error)
+        }
+
+        HorizontalDivider()
+
+        checks.forEach { check ->
+            SecurityCheckRow(check)
+        }
+    }
+}
+
+@Composable
+private fun SecuritySummaryChip(count: Int, label: String, color: Color) {
+    Surface(
+        shape = MaterialTheme.shapes.small,
+        color = color.copy(alpha = 0.12f)
+    ) {
+        Text(
+            text = "$count $label",
+            style = MaterialTheme.typography.labelMedium,
+            color = color,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp)
+        )
+    }
+}
+
+@Composable
+private fun SecurityCheckRow(check: SecurityHeaderCheck) {
+    var expanded by remember { mutableStateOf(false) }
+
+    OutlinedCard(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.fillMaxWidth()) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 12.dp, vertical = 10.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                SecurityRatingIcon(check.rating, Modifier.size(18.dp))
+
+                Text(
+                    text = check.headerName,
+                    style = MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Monospace),
+                    fontWeight = FontWeight.Medium,
+                    modifier = Modifier.weight(1f)
+                )
+
+                SecurityRatingBadge(check.rating)
+
+                IconButton(onClick = { expanded = !expanded }, modifier = Modifier.size(28.dp)) {
+                    Icon(
+                        imageVector = if (expanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+                        contentDescription = null,
+                        modifier = Modifier.size(16.dp)
+                    )
+                }
+            }
+
+            AnimatedVisibility(visible = expanded) {
+                val checkValue = check.value
+                Column(
+                    modifier = Modifier.padding(start = 12.dp, end = 12.dp, bottom = 12.dp),
+                    verticalArrangement = Arrangement.spacedBy(6.dp)
+                ) {
+                    if (checkValue != null) {
+                        Text(
+                            text = checkValue,
+                            style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        HorizontalDivider()
+                    }
+                    Text(
+                        text = check.description,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SecurityRatingIcon(rating: SecurityRating, modifier: Modifier = Modifier) {
+    when (rating) {
+        SecurityRating.PASS -> Icon(Icons.Default.Check, null, modifier = modifier, tint = Color(0xFF2E7D32))
+        SecurityRating.WARN -> Icon(Icons.Default.Warning, null, modifier = modifier, tint = Color(0xFFF57F17))
+        SecurityRating.FAIL -> Icon(Icons.Default.Clear, null, modifier = modifier, tint = MaterialTheme.colorScheme.error)
+        SecurityRating.INFO -> Icon(Icons.Default.Info, null, modifier = modifier, tint = MaterialTheme.colorScheme.onSurfaceVariant)
+    }
+}
+
+@Composable
+private fun SecurityRatingBadge(rating: SecurityRating) {
+    val (bg, fg, label) = when (rating) {
+        SecurityRating.PASS -> Triple(Color(0xFF2E7D32).copy(alpha = 0.12f), Color(0xFF2E7D32), "PASS")
+        SecurityRating.WARN -> Triple(Color(0xFFF57F17).copy(alpha = 0.12f), Color(0xFFF57F17), "WARN")
+        SecurityRating.FAIL -> Triple(MaterialTheme.colorScheme.errorContainer, MaterialTheme.colorScheme.error, "FAIL")
+        SecurityRating.INFO -> Triple(MaterialTheme.colorScheme.surfaceVariant, MaterialTheme.colorScheme.onSurfaceVariant, "INFO")
+    }
+    Surface(shape = MaterialTheme.shapes.small, color = bg) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = fg,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.padding(horizontal = 6.dp, vertical = 3.dp)
+        )
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+@Composable
+private fun LabeledValue(label: String, value: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.Top
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.weight(0.4f).padding(end = 8.dp)
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.weight(0.6f),
+            maxLines = 3,
+            overflow = TextOverflow.Ellipsis
+        )
+    }
+}
+
+@Composable
+private fun statusCodeColor(code: Int): Color = when (code) {
+    in 200..299 -> Color(0xFF2E7D32)
+    in 300..399 -> MaterialTheme.colorScheme.primary
+    in 400..499 -> Color(0xFFF57F17)
+    in 500..599 -> MaterialTheme.colorScheme.error
+    else        -> MaterialTheme.colorScheme.onSurface
+}
+
+private fun statusGradient(code: Int): List<Color> = when (code) {
+    in 200..299 -> listOf(Color(0xFF2E7D32), Color(0xFF66BB6A))
+    in 300..399 -> listOf(Color(0xFF1565C0), Color(0xFF42A5F5))
+    in 400..499 -> listOf(Color(0xFFE65100), Color(0xFFFFB74D))
+    in 500..599 -> listOf(Color(0xFFB71C1C), Color(0xFFEF9A9A))
+    else        -> listOf(Color(0xFF616161), Color(0xFFBDBDBD))
+}
+
+@Composable
+private fun timingColor(ms: Long): Color = when {
+    ms < 200  -> Color(0xFF2E7D32)
+    ms < 800  -> Color(0xFFF57F17)
+    else      -> MaterialTheme.colorScheme.error
+}
+
+@Composable
+private fun methodColor(method: HttpMethod): Color = when (method) {
+    HttpMethod.GET     -> Color(0xFF1565C0)
+    HttpMethod.POST    -> Color(0xFF2E7D32)
+    HttpMethod.PUT     -> Color(0xFFF57F17)
+    HttpMethod.PATCH   -> Color(0xFF6A1B9A)
+    HttpMethod.DELETE  -> MaterialTheme.colorScheme.error
+    HttpMethod.HEAD    -> Color(0xFF00695C)
+    HttpMethod.OPTIONS -> Color(0xFF4E342E)
+}
+
+private fun formatBytes(bytes: Long): String = when {
+    bytes < 1024        -> "$bytes B"
+    bytes < 1024 * 1024 -> "%.1f KB".format(bytes / 1024.0)
+    else                -> "%.1f MB".format(bytes / (1024.0 * 1024.0))
+}

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/httprobe/HttpProbeViewModel.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/httprobe/HttpProbeViewModel.kt
@@ -1,0 +1,109 @@
+package net.aieat.netswissknife.app.ui.screens.httprobe
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import net.aieat.netswissknife.core.domain.HttpProbeParams
+import net.aieat.netswissknife.core.domain.HttpProbeUseCase
+import net.aieat.netswissknife.core.network.NetworkResult
+import net.aieat.netswissknife.core.network.httprobe.HttpMethod
+import net.aieat.netswissknife.core.network.httprobe.HttpProbeResult
+import javax.inject.Inject
+
+data class HeaderEntry(val key: String = "", val value: String = "")
+
+data class HttpProbeUiState(
+    val url: String = "",
+    val method: HttpMethod = HttpMethod.GET,
+    val customHeaders: List<HeaderEntry> = emptyList(),
+    val body: String = "",
+    val followRedirects: Boolean = true,
+    val isLoading: Boolean = false,
+    val result: HttpProbeResult? = null,
+    val error: String? = null,
+    val selectedTab: Int = 0,
+    val headersExpanded: Boolean = false
+)
+
+@HiltViewModel
+class HttpProbeViewModel @Inject constructor(
+    private val useCase: HttpProbeUseCase
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(HttpProbeUiState())
+    val uiState: StateFlow<HttpProbeUiState> = _uiState.asStateFlow()
+
+    fun onUrlChange(url: String) = _uiState.update { it.copy(url = url) }
+
+    fun onMethodChange(method: HttpMethod) = _uiState.update { it.copy(method = method) }
+
+    fun onBodyChange(body: String) = _uiState.update { it.copy(body = body) }
+
+    fun onFollowRedirectsToggle() =
+        _uiState.update { it.copy(followRedirects = !it.followRedirects) }
+
+    fun onTabSelected(tab: Int) = _uiState.update { it.copy(selectedTab = tab) }
+
+    fun onToggleHeadersExpanded() =
+        _uiState.update { it.copy(headersExpanded = !it.headersExpanded) }
+
+    fun addHeader() =
+        _uiState.update { it.copy(customHeaders = it.customHeaders + HeaderEntry()) }
+
+    fun removeHeader(index: Int) =
+        _uiState.update { it.copy(customHeaders = it.customHeaders.toMutableList().also { list -> list.removeAt(index) }) }
+
+    fun updateHeaderKey(index: Int, key: String) = _uiState.update { state ->
+        val updated = state.customHeaders.toMutableList()
+        updated[index] = updated[index].copy(key = key)
+        state.copy(customHeaders = updated)
+    }
+
+    fun updateHeaderValue(index: Int, value: String) = _uiState.update { state ->
+        val updated = state.customHeaders.toMutableList()
+        updated[index] = updated[index].copy(value = value)
+        state.copy(customHeaders = updated)
+    }
+
+    fun send() {
+        val state = _uiState.value
+        if (state.url.isBlank() || state.isLoading) return
+
+        _uiState.update { it.copy(isLoading = true, result = null, error = null, selectedTab = 0) }
+
+        viewModelScope.launch {
+            val headers = state.customHeaders
+                .filter { it.key.isNotBlank() }
+                .map { it.key.trim() to it.value.trim() }
+
+            val result = useCase(
+                HttpProbeParams(
+                    url = state.url.trim(),
+                    method = state.method,
+                    headers = headers,
+                    body = state.body.takeIf { it.isNotBlank() && state.method.supportsBody },
+                    followRedirects = state.followRedirects
+                )
+            )
+
+            _uiState.update { current ->
+                when (result) {
+                    is NetworkResult.Success -> current.copy(
+                        isLoading = false,
+                        result = result.data,
+                        selectedTab = 0
+                    )
+                    is NetworkResult.Error -> current.copy(
+                        isLoading = false,
+                        error = result.message
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/subnet/SubnetCalculatorScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/subnet/SubnetCalculatorScreen.kt
@@ -1,0 +1,653 @@
+package net.aieat.netswissknife.app.ui.screens.subnet
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Calculate
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.NetworkCheck
+import androidx.compose.material.icons.filled.Public
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.Button
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import net.aieat.netswissknife.app.R
+import net.aieat.netswissknife.core.network.subnet.SubnetInfo
+
+@Composable
+fun SubnetCalculatorScreen(viewModel: SubnetCalculatorViewModel = hiltViewModel()) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    var visible by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) { visible = true }
+
+    AnimatedVisibility(
+        visible = visible,
+        enter = fadeIn(tween(300)) + slideInVertically(tween(300)) { it / 4 }
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            // ── Input card ──────────────────────────────────────────────────────
+            ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+                Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Icon(
+                            Icons.Default.Calculate,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.size(28.dp)
+                        )
+                        Column {
+                            Text(
+                                text = stringResource(R.string.subnet_screen_title),
+                                style = MaterialTheme.typography.displaySmall
+                            )
+                            Text(
+                                text = stringResource(R.string.subnet_screen_subtitle),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+
+                    OutlinedTextField(
+                        value = uiState.input,
+                        onValueChange = viewModel::onInputChange,
+                        modifier = Modifier.fillMaxWidth(),
+                        label = { Text(stringResource(R.string.subnet_input_label)) },
+                        placeholder = { Text(stringResource(R.string.subnet_input_placeholder)) },
+                        leadingIcon = { Icon(Icons.Default.NetworkCheck, contentDescription = null) },
+                        trailingIcon = {
+                            if (uiState.input.isNotEmpty()) {
+                                IconButton(onClick = { viewModel.onInputChange("") }) {
+                                    Icon(Icons.Default.Close, contentDescription = stringResource(R.string.clear))
+                                }
+                            }
+                        },
+                        singleLine = true,
+                        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                        keyboardActions = KeyboardActions(onDone = { viewModel.calculate() })
+                    )
+
+                    Button(
+                        onClick = viewModel::calculate,
+                        modifier = Modifier.fillMaxWidth(),
+                        enabled = uiState.input.isNotBlank()
+                    ) {
+                        Icon(Icons.Default.Calculate, contentDescription = null, modifier = Modifier.size(18.dp))
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(stringResource(R.string.subnet_calculate_button))
+                    }
+
+                    // Quick example chips
+                    SubnetExampleChips(onExampleSelected = viewModel::setExample)
+                }
+            }
+
+            // ── Result / error area ─────────────────────────────────────────────
+            AnimatedContent(
+                targetState = Pair(uiState.result, uiState.error),
+                transitionSpec = {
+                    fadeIn(tween(300)) + slideInVertically(tween(300)) { it / 8 } togetherWith
+                            fadeOut(tween(200))
+                },
+                label = "subnet-state"
+            ) { (result, error) ->
+                when {
+                    result != null -> SubnetResultContent(result)
+                    error != null  -> SubnetErrorCard(message = error, onRetry = viewModel::calculate)
+                    else           -> SubnetIdleCard()
+                }
+            }
+        }
+    }
+}
+
+// ── Example chips ─────────────────────────────────────────────────────────────
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun SubnetExampleChips(onExampleSelected: (String) -> Unit) {
+    val examples = listOf("192.168.1.0/24", "10.0.0.0/8", "172.16.0.0/12", "192.168.1.1/30", "0.0.0.0/0")
+    FlowRow(
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        examples.forEach { example ->
+            FilterChip(
+                selected = false,
+                onClick = { onExampleSelected(example) },
+                label = { Text(example, style = MaterialTheme.typography.labelSmall) }
+            )
+        }
+    }
+}
+
+// ── Idle card ─────────────────────────────────────────────────────────────────
+
+@Composable
+private fun SubnetIdleCard() {
+    ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(32.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Icon(
+                Icons.Default.Calculate,
+                contentDescription = null,
+                modifier = Modifier.size(56.dp),
+                tint = MaterialTheme.colorScheme.primary
+            )
+            Text(
+                text = stringResource(R.string.subnet_idle_title),
+                style = MaterialTheme.typography.titleMedium,
+                textAlign = TextAlign.Center
+            )
+            Text(
+                text = stringResource(R.string.subnet_idle_body),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center
+            )
+        }
+    }
+}
+
+// ── Error card ────────────────────────────────────────────────────────────────
+
+@Composable
+private fun SubnetErrorCard(message: String, onRetry: () -> Unit) {
+    ElevatedCard(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.elevatedCardColors(
+            containerColor = MaterialTheme.colorScheme.errorContainer
+        )
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Icon(
+                Icons.Default.Warning,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onErrorContainer,
+                modifier = Modifier.size(32.dp)
+            )
+            Text(
+                text = stringResource(R.string.subnet_error_title),
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onErrorContainer
+            )
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onErrorContainer,
+                textAlign = TextAlign.Center
+            )
+            Button(onClick = onRetry) {
+                Text(stringResource(R.string.subnet_retry))
+            }
+        }
+    }
+}
+
+// ── Results content ───────────────────────────────────────────────────────────
+
+@Composable
+private fun SubnetResultContent(info: SubnetInfo) {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        SubnetOverviewCard(info)
+        SubnetBinaryVisualizerCard(info)
+        SubnetNotationsCard(info)
+        SubnetPropertiesCard(info)
+    }
+}
+
+// ── Overview card ─────────────────────────────────────────────────────────────
+
+@Composable
+private fun SubnetOverviewCard(info: SubnetInfo) {
+    ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+        Column {
+            // Gradient header
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(
+                        Brush.linearGradient(
+                            listOf(
+                                MaterialTheme.colorScheme.primaryContainer,
+                                MaterialTheme.colorScheme.tertiaryContainer
+                            )
+                        )
+                    )
+                    .padding(16.dp)
+            ) {
+                Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                    Text(
+                        text = info.cidrNotation,
+                        style = MaterialTheme.typography.headlineMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer,
+                        fontFamily = FontFamily.Monospace
+                    )
+                    Text(
+                        text = stringResource(
+                            R.string.subnet_overview_hosts,
+                            formatHostCount(info.usableHosts)
+                        ),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.8f)
+                    )
+                }
+            }
+
+            HorizontalDivider()
+
+            Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                SubnetInfoRow(
+                    label = stringResource(R.string.subnet_network_address),
+                    value = info.networkAddress
+                )
+                SubnetInfoRow(
+                    label = stringResource(R.string.subnet_broadcast),
+                    value = info.broadcastAddress
+                )
+                SubnetInfoRow(
+                    label = stringResource(R.string.subnet_first_host),
+                    value = info.firstHost
+                )
+                SubnetInfoRow(
+                    label = stringResource(R.string.subnet_last_host),
+                    value = info.lastHost
+                )
+                SubnetInfoRow(
+                    label = stringResource(R.string.subnet_total_hosts),
+                    value = formatHostCount(info.totalHosts)
+                )
+                SubnetInfoRow(
+                    label = stringResource(R.string.subnet_usable_hosts),
+                    value = formatHostCount(info.usableHosts)
+                )
+            }
+        }
+    }
+}
+
+// ── Binary visualizer card ────────────────────────────────────────────────────
+
+@Composable
+private fun SubnetBinaryVisualizerCard(info: SubnetInfo) {
+    OutlinedCard(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                Icon(
+                    Icons.Default.Info,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp),
+                    tint = MaterialTheme.colorScheme.primary
+                )
+                Text(
+                    text = stringResource(R.string.subnet_binary_breakdown),
+                    style = MaterialTheme.typography.titleMedium
+                )
+            }
+
+            // Legend
+            Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                LegendItem(
+                    color = MaterialTheme.colorScheme.primary,
+                    label = stringResource(R.string.subnet_network_bits, info.prefixLength)
+                )
+                LegendItem(
+                    color = MaterialTheme.colorScheme.tertiary,
+                    label = stringResource(R.string.subnet_host_bits, info.hostBits)
+                )
+            }
+
+            // IP address binary row
+            BinaryBitsRow(
+                label = stringResource(R.string.subnet_binary_ip),
+                binaryDotted = info.binaryIpAddress,
+                prefixLength = info.prefixLength
+            )
+
+            // Subnet mask binary row
+            BinaryBitsRow(
+                label = stringResource(R.string.subnet_binary_mask),
+                binaryDotted = info.binaryMask,
+                prefixLength = info.prefixLength
+            )
+
+            // Network address binary row
+            BinaryBitsRow(
+                label = stringResource(R.string.subnet_binary_network),
+                binaryDotted = info.binaryNetworkAddress,
+                prefixLength = info.prefixLength
+            )
+        }
+    }
+}
+
+@Composable
+private fun LegendItem(color: androidx.compose.ui.graphics.Color, label: String) {
+    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+        Box(
+            modifier = Modifier
+                .size(12.dp)
+                .clip(RoundedCornerShape(2.dp))
+                .background(color)
+        )
+        Text(text = label, style = MaterialTheme.typography.labelSmall)
+    }
+}
+
+@Composable
+private fun BinaryBitsRow(label: String, binaryDotted: String, prefixLength: Int) {
+    val networkColor = MaterialTheme.colorScheme.primary
+    val hostColor = MaterialTheme.colorScheme.tertiary
+    val networkBg = MaterialTheme.colorScheme.primaryContainer
+    val hostBg = MaterialTheme.colorScheme.tertiaryContainer
+
+    // Strip dots to get a flat 32-bit string, then re-add octet grouping with colors
+    val bits = binaryDotted.replace(".", "")
+
+    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(3.dp)
+        ) {
+            bits.chunked(8).forEachIndexed { octetIdx, octet ->
+                val octetStart = octetIdx * 8
+                Row(modifier = Modifier.weight(1f), horizontalArrangement = Arrangement.spacedBy(1.dp)) {
+                    octet.forEachIndexed { bitIdx, bit ->
+                        val absoluteBit = octetStart + bitIdx
+                        val isNetwork = absoluteBit < prefixLength
+                        val bg = if (isNetwork) networkBg else hostBg
+                        val fg = if (isNetwork) networkColor else hostColor
+                        Box(
+                            modifier = Modifier
+                                .weight(1f)
+                                .height(24.dp)
+                                .clip(RoundedCornerShape(2.dp))
+                                .background(bg)
+                                .border(
+                                    width = if (absoluteBit == prefixLength - 1 || absoluteBit == prefixLength) 1.dp else 0.dp,
+                                    color = MaterialTheme.colorScheme.outline.copy(alpha = 0.4f),
+                                    shape = RoundedCornerShape(2.dp)
+                                ),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text(
+                                text = bit.toString(),
+                                style = MaterialTheme.typography.labelSmall.copy(
+                                    fontFamily = FontFamily.Monospace,
+                                    fontWeight = if (isNetwork) FontWeight.Bold else FontWeight.Normal
+                                ),
+                                color = fg
+                            )
+                        }
+                    }
+                }
+                if (octetIdx < 3) {
+                    Text(
+                        text = ".",
+                        style = MaterialTheme.typography.labelSmall,
+                        modifier = Modifier.align(Alignment.CenterVertically)
+                    )
+                }
+            }
+        }
+    }
+}
+
+// ── Notations card ────────────────────────────────────────────────────────────
+
+@Composable
+private fun SubnetNotationsCard(info: SubnetInfo) {
+    ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+            Text(
+                text = stringResource(R.string.subnet_notations_title),
+                style = MaterialTheme.typography.titleMedium
+            )
+            HorizontalDivider()
+            SubnetInfoRow(
+                label = stringResource(R.string.subnet_notation_cidr),
+                value = info.cidrNotation,
+                monospace = true
+            )
+            SubnetInfoRow(
+                label = stringResource(R.string.subnet_notation_mask),
+                value = info.subnetMask,
+                monospace = true
+            )
+            SubnetInfoRow(
+                label = stringResource(R.string.subnet_notation_wildcard),
+                value = info.wildcardMask,
+                monospace = true
+            )
+            SubnetInfoRow(
+                label = stringResource(R.string.subnet_notation_hex),
+                value = info.hexMask,
+                monospace = true
+            )
+            SubnetInfoRow(
+                label = stringResource(R.string.subnet_notation_binary),
+                value = info.binaryMask,
+                monospace = true
+            )
+        }
+    }
+}
+
+// ── Properties card ───────────────────────────────────────────────────────────
+
+@Composable
+private fun SubnetPropertiesCard(info: SubnetInfo) {
+    ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+            Text(
+                text = stringResource(R.string.subnet_properties_title),
+                style = MaterialTheme.typography.titleMedium
+            )
+            HorizontalDivider()
+
+            // IP Class badge
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = stringResource(R.string.subnet_ip_class),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.weight(0.5f)
+                )
+                Surface(
+                    shape = RoundedCornerShape(8.dp),
+                    color = MaterialTheme.colorScheme.primaryContainer,
+                    modifier = Modifier.weight(0.5f)
+                ) {
+                    Text(
+                        text = stringResource(R.string.subnet_class_label, info.ipClass),
+                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp),
+                        style = MaterialTheme.typography.labelLarge,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer,
+                        fontWeight = FontWeight.Bold,
+                        textAlign = TextAlign.End
+                    )
+                }
+            }
+
+            // Private / Public badge
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = stringResource(R.string.subnet_scope),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.weight(0.5f)
+                )
+                Row(
+                    modifier = Modifier.weight(0.5f),
+                    horizontalArrangement = Arrangement.End,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    val (scopeIcon, scopeLabel, scopeColor, scopeContainerColor) = if (info.isPrivate) {
+                        Quad(
+                            Icons.Default.Lock,
+                            stringResource(R.string.subnet_scope_private),
+                            MaterialTheme.colorScheme.onSecondaryContainer,
+                            MaterialTheme.colorScheme.secondaryContainer
+                        )
+                    } else {
+                        Quad(
+                            Icons.Default.Public,
+                            stringResource(R.string.subnet_scope_public),
+                            MaterialTheme.colorScheme.onTertiaryContainer,
+                            MaterialTheme.colorScheme.tertiaryContainer
+                        )
+                    }
+                    Surface(shape = RoundedCornerShape(8.dp), color = scopeContainerColor) {
+                        Row(
+                            modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(4.dp)
+                        ) {
+                            Icon(
+                                scopeIcon,
+                                contentDescription = null,
+                                modifier = Modifier.size(14.dp),
+                                tint = scopeColor
+                            )
+                            Text(
+                                text = scopeLabel,
+                                style = MaterialTheme.typography.labelLarge,
+                                color = scopeColor,
+                                fontWeight = FontWeight.SemiBold
+                            )
+                        }
+                    }
+                }
+            }
+
+            SubnetInfoRow(
+                label = stringResource(R.string.subnet_prefix_bits),
+                value = stringResource(R.string.subnet_prefix_of_32, info.prefixLength)
+            )
+            SubnetInfoRow(
+                label = stringResource(R.string.subnet_host_bit_count),
+                value = stringResource(R.string.subnet_bits_count, info.hostBits)
+            )
+        }
+    }
+}
+
+// ── Small helpers ─────────────────────────────────────────────────────────────
+
+@Composable
+private fun SubnetInfoRow(label: String, value: String, monospace: Boolean = false) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.Top
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.weight(0.45f)
+        )
+        Text(
+            text = value,
+            style = if (monospace)
+                MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Monospace)
+            else
+                MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.weight(0.55f),
+            textAlign = TextAlign.End,
+            fontWeight = FontWeight.Medium
+        )
+    }
+}
+
+private data class Quad<A, B, C, D>(val first: A, val second: B, val third: C, val fourth: D)
+
+private fun formatHostCount(count: Long): String = when {
+    count >= 1_000_000L -> "%.2fM".format(count / 1_000_000.0)
+    count >= 1_000L     -> "%.1fK".format(count / 1_000.0)
+    else                -> count.toString()
+}

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/subnet/SubnetCalculatorViewModel.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/subnet/SubnetCalculatorViewModel.kt
@@ -1,0 +1,49 @@
+package net.aieat.netswissknife.app.ui.screens.subnet
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import net.aieat.netswissknife.core.domain.SubnetCalculatorUseCase
+import net.aieat.netswissknife.core.network.NetworkResult
+import net.aieat.netswissknife.core.network.subnet.SubnetInfo
+import javax.inject.Inject
+
+data class SubnetCalculatorUiState(
+    val input: String = "",
+    val result: SubnetInfo? = null,
+    val error: String? = null,
+)
+
+@HiltViewModel
+class SubnetCalculatorViewModel @Inject constructor(
+    private val useCase: SubnetCalculatorUseCase
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(SubnetCalculatorUiState())
+    val uiState: StateFlow<SubnetCalculatorUiState> = _uiState.asStateFlow()
+
+    fun onInputChange(value: String) {
+        _uiState.value = _uiState.value.copy(input = value, error = null)
+    }
+
+    fun calculate() {
+        val input = _uiState.value.input.trim()
+        if (input.isBlank()) return
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(result = null, error = null)
+            when (val res = useCase(input)) {
+                is NetworkResult.Success -> _uiState.value = _uiState.value.copy(result = res.data)
+                is NetworkResult.Error   -> _uiState.value = _uiState.value.copy(error = res.message)
+            }
+        }
+    }
+
+    fun setExample(example: String) {
+        _uiState.value = SubnetCalculatorUiState(input = example)
+        calculate()
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -436,6 +436,55 @@
     <string name="whois_example_chip_ip">IP Address</string>
     <string name="whois_example_chip_asn">ASN</string>
 
+    <!-- HTTP Probe Screen -->
+    <string name="httprobe_screen_title">HTTP Probe</string>
+    <string name="httprobe_screen_subtitle">Test HTTP/HTTPS requests with full header and security analysis</string>
+
+    <!-- HTTP Probe Input -->
+    <string name="httprobe_url_label">URL</string>
+    <string name="httprobe_url_placeholder">https://example.com/api</string>
+    <string name="httprobe_method_label">HTTP Method</string>
+    <string name="httprobe_custom_headers_label">Custom Headers</string>
+    <string name="httprobe_add_header">Add header</string>
+    <string name="httprobe_remove_header">Remove header</string>
+    <string name="httprobe_header_key">Name</string>
+    <string name="httprobe_header_value">Value</string>
+    <string name="httprobe_body_label">Request Body</string>
+    <string name="httprobe_body_placeholder">{"key": "value"}</string>
+    <string name="httprobe_follow_redirects_label">Follow Redirects</string>
+    <string name="httprobe_follow_redirects_sub">Automatically follow HTTP 3xx responses</string>
+    <string name="httprobe_send_button">Send Request</string>
+    <string name="httprobe_sending">Sending…</string>
+
+    <!-- HTTP Probe States -->
+    <string name="httprobe_idle_title">Enter a URL to probe</string>
+    <string name="httprobe_idle_subtitle">Supports GET, POST, PUT, PATCH, DELETE, HEAD, and OPTIONS. Includes security header analysis.</string>
+    <string name="httprobe_error_title">Request failed</string>
+    <string name="httprobe_retry">Retry</string>
+
+    <!-- HTTP Probe Tabs -->
+    <string name="httprobe_tab_overview">Overview</string>
+    <string name="httprobe_tab_headers">Headers</string>
+    <string name="httprobe_tab_body">Body</string>
+    <string name="httprobe_tab_security">Security</string>
+
+    <!-- HTTP Probe Results -->
+    <string name="httprobe_response_time_label">Response time</string>
+    <string name="httprobe_redirects_label">%1$d redirect(s)</string>
+    <string name="httprobe_method_used">Method</string>
+    <string name="httprobe_final_url">Final URL</string>
+    <string name="httprobe_response_size">Body size</string>
+    <string name="httprobe_content_type">Content-Type</string>
+    <string name="httprobe_redirect_chain">Redirect chain</string>
+    <string name="httprobe_request_headers">Request Headers</string>
+    <string name="httprobe_response_headers">Response Headers</string>
+    <string name="httprobe_no_custom_headers">No custom headers sent</string>
+    <string name="httprobe_no_headers">No headers</string>
+    <string name="httprobe_response_body">Response Body</string>
+    <string name="httprobe_copy_body">Copy</string>
+    <string name="httprobe_body_truncated">Showing first 512 KB of %1$s response</string>
+    <string name="httprobe_empty_body">Empty body (HEAD or no content)</string>
+
     <!-- DNS Record labels -->
     <string name="dns_ipv4_prefix">IPv4</string>
     <string name="dns_ipv6_prefix">IPv6</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -495,4 +495,44 @@
     <string name="dns_srv_port">Port</string>
     <string name="dns_srv_target">Target</string>
 
+    <!-- Subnet Calculator -->
+    <string name="subnet_screen_title">Subnet Calculator</string>
+    <string name="subnet_screen_subtitle">IPv4 CIDR, mask, wildcard &amp; binary breakdown</string>
+    <string name="subnet_input_label">Network / Address</string>
+    <string name="subnet_input_placeholder">e.g. 192.168.1.0/24</string>
+    <string name="subnet_calculate_button">Calculate</string>
+    <string name="subnet_idle_title">Enter an IPv4 address or network</string>
+    <string name="subnet_idle_body">Supports CIDR (192.168.1.0/24), dot-decimal mask (192.168.1.0/255.255.255.0) or a bare IP (/32 assumed).</string>
+    <string name="subnet_error_title">Invalid Input</string>
+    <string name="subnet_retry">Retry</string>
+    <string name="subnet_overview_hosts">%1$s usable hosts</string>
+    <string name="subnet_network_address">Network address</string>
+    <string name="subnet_broadcast">Broadcast</string>
+    <string name="subnet_first_host">First host</string>
+    <string name="subnet_last_host">Last host</string>
+    <string name="subnet_total_hosts">Total addresses</string>
+    <string name="subnet_usable_hosts">Usable hosts</string>
+    <string name="subnet_binary_breakdown">Binary Breakdown</string>
+    <string name="subnet_network_bits">Network: %1$d bits</string>
+    <string name="subnet_host_bits">Host: %1$d bits</string>
+    <string name="subnet_binary_ip">IP address</string>
+    <string name="subnet_binary_mask">Subnet mask</string>
+    <string name="subnet_binary_network">Network addr</string>
+    <string name="subnet_notations_title">Notation Equivalents</string>
+    <string name="subnet_notation_cidr">CIDR</string>
+    <string name="subnet_notation_mask">Dot-decimal mask</string>
+    <string name="subnet_notation_wildcard">Wildcard mask</string>
+    <string name="subnet_notation_hex">Hex mask</string>
+    <string name="subnet_notation_binary">Binary mask</string>
+    <string name="subnet_properties_title">Address Properties</string>
+    <string name="subnet_ip_class">IP class</string>
+    <string name="subnet_class_label">Class %1$s</string>
+    <string name="subnet_scope">Scope</string>
+    <string name="subnet_scope_private">Private</string>
+    <string name="subnet_scope_public">Public</string>
+    <string name="subnet_prefix_bits">Prefix / host bits</string>
+    <string name="subnet_prefix_of_32">%1$d / 32</string>
+    <string name="subnet_host_bit_count">Host bits</string>
+    <string name="subnet_bits_count">%1$d bits</string>
+
 </resources>

--- a/claude/tool_instructions.md
+++ b/claude/tool_instructions.md
@@ -387,3 +387,4 @@ Both must succeed before committing.
 | Port Scanner | `ports` | Placeholder for TCP port scanning |
 | LAN Scanner | `lan` | Placeholder for LAN device discovery |
 | DNS Lookup | `dns` | Placeholder for DNS resolution |
+| HTTP Probe | `httprobe` | HTTP/HTTPS request tester with security header analysis |

--- a/claude/tool_instructions.md
+++ b/claude/tool_instructions.md
@@ -388,3 +388,4 @@ Both must succeed before committing.
 | LAN Scanner | `lan` | Placeholder for LAN device discovery |
 | DNS Lookup | `dns` | Placeholder for DNS resolution |
 | HTTP Probe | `httprobe` | HTTP/HTTPS request tester with security header analysis |
+| Subnet Calculator | `subnet` | IPv4 subnet calculator with binary breakdown and notation conversion |

--- a/core-domain/src/main/kotlin/net/aieat/netswissknife/core/domain/HttpProbeUseCase.kt
+++ b/core-domain/src/main/kotlin/net/aieat/netswissknife/core/domain/HttpProbeUseCase.kt
@@ -1,0 +1,51 @@
+package net.aieat.netswissknife.core.domain
+
+import net.aieat.netswissknife.core.network.NetworkResult
+import net.aieat.netswissknife.core.network.httprobe.HttpMethod
+import net.aieat.netswissknife.core.network.httprobe.HttpProbeRepository
+import net.aieat.netswissknife.core.network.httprobe.HttpProbeRequest
+import net.aieat.netswissknife.core.network.httprobe.HttpProbeResult
+import java.net.MalformedURLException
+import java.net.URL
+
+data class HttpProbeParams(
+    val url: String,
+    val method: HttpMethod = HttpMethod.GET,
+    val headers: List<Pair<String, String>> = emptyList(),
+    val body: String? = null,
+    val followRedirects: Boolean = true,
+    val timeoutMs: Int = 15_000
+)
+
+class HttpProbeUseCase(private val repository: HttpProbeRepository) {
+
+    suspend operator fun invoke(params: HttpProbeParams): NetworkResult<HttpProbeResult> {
+        val url = params.url.trim()
+
+        if (url.isBlank()) return NetworkResult.Error("URL must not be blank")
+
+        try {
+            val parsed = URL(url)
+            if (parsed.protocol !in listOf("http", "https"))
+                return NetworkResult.Error("Only HTTP and HTTPS URLs are supported")
+        } catch (e: MalformedURLException) {
+            return NetworkResult.Error("Malformed URL: ${e.message}")
+        }
+
+        if (params.timeoutMs !in 500..60_000)
+            return NetworkResult.Error("Timeout must be between 500 ms and 60 000 ms")
+
+        val effectiveBody = if (params.method.supportsBody) params.body else null
+
+        return repository.probe(
+            HttpProbeRequest(
+                url = url,
+                method = params.method,
+                headers = params.headers,
+                body = effectiveBody,
+                followRedirects = params.followRedirects,
+                timeoutMs = params.timeoutMs
+            )
+        )
+    }
+}

--- a/core-domain/src/main/kotlin/net/aieat/netswissknife/core/domain/SubnetCalculatorUseCase.kt
+++ b/core-domain/src/main/kotlin/net/aieat/netswissknife/core/domain/SubnetCalculatorUseCase.kt
@@ -1,0 +1,12 @@
+package net.aieat.netswissknife.core.domain
+
+import net.aieat.netswissknife.core.network.NetworkResult
+import net.aieat.netswissknife.core.network.subnet.SubnetCalculatorRepository
+import net.aieat.netswissknife.core.network.subnet.SubnetInfo
+
+class SubnetCalculatorUseCase(
+    private val repository: SubnetCalculatorRepository
+) : UseCase<String, NetworkResult<SubnetInfo>> {
+    override suspend fun invoke(params: String): NetworkResult<SubnetInfo> =
+        repository.calculate(params)
+}

--- a/core-domain/src/test/kotlin/net/aieat/netswissknife/core/domain/HttpProbeUseCaseTest.kt
+++ b/core-domain/src/test/kotlin/net/aieat/netswissknife/core/domain/HttpProbeUseCaseTest.kt
@@ -1,0 +1,123 @@
+package net.aieat.netswissknife.core.domain
+
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import net.aieat.netswissknife.core.network.NetworkResult
+import net.aieat.netswissknife.core.network.httprobe.HttpMethod
+import net.aieat.netswissknife.core.network.httprobe.HttpProbeRepository
+import net.aieat.netswissknife.core.network.httprobe.HttpProbeRequest
+import net.aieat.netswissknife.core.network.httprobe.HttpProbeResult
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("HttpProbeUseCase – validation")
+class HttpProbeUseCaseTest {
+
+    private lateinit var repository: HttpProbeRepository
+    private lateinit var useCase: HttpProbeUseCase
+
+    private val fakeResult = HttpProbeResult(
+        request = HttpProbeRequest(url = "https://example.com"),
+        statusCode = 200,
+        statusMessage = "OK",
+        responseTimeMs = 123L,
+        responseHeaders = emptyMap(),
+        responseBody = "Hello",
+        responseBodyBytes = 5L,
+        finalUrl = "https://example.com",
+        redirectChain = emptyList(),
+        securityChecks = emptyList()
+    )
+
+    @BeforeEach
+    fun setUp() {
+        repository = mockk()
+        useCase = HttpProbeUseCase(repository)
+    }
+
+    @Test
+    @DisplayName("invoke returns Error for blank URL")
+    fun `invoke returns Error for blank URL`() = runTest {
+        val result = useCase(HttpProbeParams(url = "  "))
+        assertTrue(result is NetworkResult.Error)
+        assertTrue((result as NetworkResult.Error).message.contains("blank", ignoreCase = true))
+    }
+
+    @Test
+    @DisplayName("invoke returns Error for non-HTTP URL")
+    fun `invoke returns Error for non-HTTP URL`() = runTest {
+        val result = useCase(HttpProbeParams(url = "ftp://example.com"))
+        assertTrue(result is NetworkResult.Error)
+    }
+
+    @Test
+    @DisplayName("invoke returns Error for timeout below 500ms")
+    fun `invoke returns Error for timeout below 500ms`() = runTest {
+        val result = useCase(HttpProbeParams(url = "https://example.com", timeoutMs = 499))
+        assertTrue(result is NetworkResult.Error)
+    }
+
+    @Test
+    @DisplayName("invoke returns Error for timeout above 60000ms")
+    fun `invoke returns Error for timeout above 60000ms`() = runTest {
+        val result = useCase(HttpProbeParams(url = "https://example.com", timeoutMs = 60_001))
+        assertTrue(result is NetworkResult.Error)
+    }
+
+    @Test
+    @DisplayName("invoke delegates to repository for valid params")
+    fun `invoke delegates to repository for valid params`() = runTest {
+        coEvery { repository.probe(any()) } returns NetworkResult.Success(fakeResult)
+
+        val result = useCase(HttpProbeParams(url = "https://example.com"))
+
+        assertTrue(result is NetworkResult.Success)
+        coVerify(exactly = 1) { repository.probe(any()) }
+    }
+
+    @Test
+    @DisplayName("invoke strips body for GET requests")
+    fun `invoke strips body for GET requests`() = runTest {
+        coEvery { repository.probe(any()) } returns NetworkResult.Success(fakeResult)
+
+        useCase(HttpProbeParams(url = "https://example.com", method = HttpMethod.GET, body = "should be stripped"))
+
+        coVerify { repository.probe(match { it.body == null }) }
+    }
+
+    @Test
+    @DisplayName("invoke preserves body for POST requests")
+    fun `invoke preserves body for POST requests`() = runTest {
+        coEvery { repository.probe(any()) } returns NetworkResult.Success(fakeResult)
+
+        useCase(HttpProbeParams(url = "https://example.com", method = HttpMethod.POST, body = "payload"))
+
+        coVerify { repository.probe(match { it.body == "payload" }) }
+    }
+
+    @Test
+    @DisplayName("invoke passes http URL to repository")
+    fun `invoke passes http URL to repository`() = runTest {
+        coEvery { repository.probe(any()) } returns NetworkResult.Success(fakeResult)
+
+        useCase(HttpProbeParams(url = "http://example.com"))
+
+        coVerify { repository.probe(match { it.url == "http://example.com" }) }
+    }
+
+    @Test
+    @DisplayName("invoke returns repository error unchanged")
+    fun `invoke returns repository error unchanged`() = runTest {
+        coEvery { repository.probe(any()) } returns NetworkResult.Error("Connection refused")
+
+        val result = useCase(HttpProbeParams(url = "https://example.com"))
+
+        assertTrue(result is NetworkResult.Error)
+        assertEquals("Connection refused", (result as NetworkResult.Error).message)
+    }
+}

--- a/core-domain/src/test/kotlin/net/aieat/netswissknife/core/domain/SubnetCalculatorUseCaseTest.kt
+++ b/core-domain/src/test/kotlin/net/aieat/netswissknife/core/domain/SubnetCalculatorUseCaseTest.kt
@@ -1,0 +1,56 @@
+package net.aieat.netswissknife.core.domain
+
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import net.aieat.netswissknife.core.network.NetworkResult
+import net.aieat.netswissknife.core.network.subnet.SubnetCalculatorRepository
+import net.aieat.netswissknife.core.network.subnet.SubnetInfo
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class SubnetCalculatorUseCaseTest {
+
+    private val repository = mockk<SubnetCalculatorRepository>()
+    private val useCase = SubnetCalculatorUseCase(repository)
+
+    @Test
+    fun `invoke delegates to repository and returns result`() = runTest {
+        val expectedInfo = SubnetInfo(
+            inputIp = "192.168.1.100",
+            prefixLength = 24,
+            networkAddress = "192.168.1.0",
+            broadcastAddress = "192.168.1.255",
+            firstHost = "192.168.1.1",
+            lastHost = "192.168.1.254",
+            subnetMask = "255.255.255.0",
+            wildcardMask = "0.0.0.255",
+            hexMask = "0xFFFFFF00",
+            binaryMask = "11111111.11111111.11111111.00000000",
+            binaryNetworkAddress = "11000000.10101000.00000001.00000000",
+            binaryIpAddress = "11000000.10101000.00000001.01100100",
+            totalHosts = 256L,
+            usableHosts = 254L,
+            hostBits = 8,
+            ipClass = "C",
+            isPrivate = true,
+            cidrNotation = "192.168.1.0/24",
+        )
+        coEvery { repository.calculate("192.168.1.100/24") } returns NetworkResult.Success(expectedInfo)
+
+        val result = useCase("192.168.1.100/24")
+
+        coVerify(exactly = 1) { repository.calculate("192.168.1.100/24") }
+        assertEquals(NetworkResult.Success(expectedInfo), result)
+    }
+
+    @Test
+    fun `invoke returns error when repository fails`() = runTest {
+        coEvery { repository.calculate("bad-input") } returns NetworkResult.Error("Invalid IP address")
+
+        val result = useCase("bad-input")
+
+        assertEquals(NetworkResult.Error("Invalid IP address"), result)
+    }
+}

--- a/core-domain/src/test/kotlin/net/aieat/netswissknife/core/domain/ValidateHostUseCaseTest.kt
+++ b/core-domain/src/test/kotlin/net/aieat/netswissknife/core/domain/ValidateHostUseCaseTest.kt
@@ -1,7 +1,7 @@
 package net.aieat.netswissknife.core.domain
 
 import net.aieat.netswissknife.core.network.NetworkResult
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -11,26 +11,26 @@ class ValidateHostUseCaseTest {
     private val useCase = ValidateHostUseCase()
 
     @Test
-    fun `valid hostname returns Success`() = runBlocking {
+    fun `valid hostname returns Success`() = runTest {
         val result = useCase("google.com")
         assertTrue(result is NetworkResult.Success)
         assertEquals("google.com", (result as NetworkResult.Success).data)
     }
 
     @Test
-    fun `valid IP returns Success`() = runBlocking {
+    fun `valid IP returns Success`() = runTest {
         val result = useCase("8.8.8.8")
         assertTrue(result is NetworkResult.Success)
     }
 
     @Test
-    fun `blank host returns Error`() = runBlocking {
+    fun `blank host returns Error`() = runTest {
         val result = useCase("")
         assertTrue(result is NetworkResult.Error)
     }
 
     @Test
-    fun `invalid host returns Error with descriptive message`() = runBlocking {
+    fun `invalid host returns Error with descriptive message`() = runTest {
         val result = useCase("not a host!!")
         assertTrue(result is NetworkResult.Error)
         assertTrue((result as NetworkResult.Error).message.contains("not a host!!"))

--- a/core-domain/src/test/kotlin/net/aieat/netswissknife/core/domain/WifiScanUseCaseTest.kt
+++ b/core-domain/src/test/kotlin/net/aieat/netswissknife/core/domain/WifiScanUseCaseTest.kt
@@ -10,7 +10,7 @@ import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
@@ -59,9 +59,9 @@ class WifiScanUseCaseTest {
         @Test
         fun `throws WifiNotSupportedException when not supported`() = runTest {
             every { repository.isSupported } returns false
-            assertThrows(WifiNotSupportedException::class.java) {
-                kotlinx.coroutines.runBlocking { useCase() }
-            }
+            var caught: WifiNotSupportedException? = null
+            try { useCase() } catch (e: WifiNotSupportedException) { caught = e }
+            assertNotNull(caught)
         }
 
         @Test
@@ -77,10 +77,9 @@ class WifiScanUseCaseTest {
         fun `propagates repository exceptions`() = runTest {
             every { repository.isSupported } returns true
             coEvery { repository.scan() } throws SecurityException("Location permission denied")
-            val thrown = assertThrows(SecurityException::class.java) {
-                kotlinx.coroutines.runBlocking { useCase() }
-            }
-            assertEquals("Location permission denied", thrown.message)
+            var caught: SecurityException? = null
+            try { useCase() } catch (e: SecurityException) { caught = e }
+            assertEquals("Location permission denied", caught?.message)
         }
 
         @Test

--- a/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/httprobe/HttpProbeModels.kt
+++ b/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/httprobe/HttpProbeModels.kt
@@ -1,0 +1,43 @@
+package net.aieat.netswissknife.core.network.httprobe
+
+enum class HttpMethod(val supportsBody: Boolean) {
+    GET(false),
+    POST(true),
+    PUT(true),
+    PATCH(true),
+    DELETE(false),
+    HEAD(false),
+    OPTIONS(false)
+}
+
+enum class SecurityRating { PASS, WARN, FAIL, INFO }
+
+data class HttpProbeRequest(
+    val url: String,
+    val method: HttpMethod = HttpMethod.GET,
+    val headers: List<Pair<String, String>> = emptyList(),
+    val body: String? = null,
+    val followRedirects: Boolean = true,
+    val timeoutMs: Int = 15_000,
+    val maxResponseBodyBytes: Long = 512_000L
+)
+
+data class SecurityHeaderCheck(
+    val headerName: String,
+    val value: String?,
+    val rating: SecurityRating,
+    val description: String
+)
+
+data class HttpProbeResult(
+    val request: HttpProbeRequest,
+    val statusCode: Int,
+    val statusMessage: String,
+    val responseTimeMs: Long,
+    val responseHeaders: Map<String, List<String>>,
+    val responseBody: String?,
+    val responseBodyBytes: Long,
+    val finalUrl: String,
+    val redirectChain: List<String>,
+    val securityChecks: List<SecurityHeaderCheck>
+)

--- a/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/httprobe/HttpProbeRepository.kt
+++ b/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/httprobe/HttpProbeRepository.kt
@@ -1,0 +1,7 @@
+package net.aieat.netswissknife.core.network.httprobe
+
+import net.aieat.netswissknife.core.network.NetworkResult
+
+interface HttpProbeRepository {
+    suspend fun probe(request: HttpProbeRequest): NetworkResult<HttpProbeResult>
+}

--- a/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/httprobe/HttpProbeRepositoryImpl.kt
+++ b/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/httprobe/HttpProbeRepositoryImpl.kt
@@ -1,0 +1,140 @@
+package net.aieat.netswissknife.core.network.httprobe
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import net.aieat.netswissknife.core.network.NetworkResult
+import java.io.IOException
+import java.net.HttpURLConnection
+import java.net.MalformedURLException
+import java.net.URL
+
+class HttpProbeRepositoryImpl : HttpProbeRepository {
+
+    override suspend fun probe(request: HttpProbeRequest): NetworkResult<HttpProbeResult> {
+        val trimmedUrl = request.url.trim()
+        if (trimmedUrl.isBlank()) return NetworkResult.Error("URL must not be blank")
+        if (request.timeoutMs !in 500..60_000)
+            return NetworkResult.Error("Timeout must be between 500 ms and 60 000 ms")
+
+        val parsedUrl = try {
+            URL(trimmedUrl).also { url ->
+                if (url.protocol !in listOf("http", "https"))
+                    return NetworkResult.Error("Only HTTP and HTTPS URLs are supported (got: ${url.protocol})")
+            }
+        } catch (e: MalformedURLException) {
+            return NetworkResult.Error("Malformed URL: ${e.message}")
+        }
+
+        return withContext(Dispatchers.IO) {
+            try {
+                executeRequest(parsedUrl, request)
+            } catch (e: IOException) {
+                NetworkResult.Error("Network error: ${e.message}", e)
+            } catch (e: Exception) {
+                NetworkResult.Error("Unexpected error: ${e.message}", e)
+            }
+        }
+    }
+
+    private fun executeRequest(
+        startUrl: URL,
+        request: HttpProbeRequest
+    ): NetworkResult<HttpProbeResult> {
+        val redirectChain = mutableListOf<String>()
+        var currentUrl = startUrl
+        val startTime = System.currentTimeMillis()
+        val maxRedirects = 10
+
+        repeat(maxRedirects + 1) { attempt ->
+            val conn = currentUrl.openConnection() as HttpURLConnection
+            try {
+                conn.instanceFollowRedirects = false
+                conn.requestMethod = request.method.name
+                conn.connectTimeout = request.timeoutMs
+                conn.readTimeout = request.timeoutMs
+
+                // Apply custom request headers
+                request.headers.forEach { (key, value) ->
+                    conn.setRequestProperty(key, value)
+                }
+
+                // Write body if applicable
+                if (request.method.supportsBody && request.body != null) {
+                    conn.doOutput = true
+                    conn.outputStream.use { it.write(request.body.toByteArray(Charsets.UTF_8)) }
+                }
+
+                conn.connect()
+
+                val statusCode = conn.responseCode
+                val statusMessage = conn.responseMessage ?: ""
+
+                // Handle redirects manually
+                if (request.followRedirects && statusCode in 300..399 && attempt < maxRedirects) {
+                    val location = conn.getHeaderField("Location")
+                    if (!location.isNullOrBlank()) {
+                        redirectChain.add(currentUrl.toString())
+                        currentUrl = resolveUrl(currentUrl, location)
+                        return@repeat // continue loop
+                    }
+                }
+
+                // Final response — collect headers and body
+                val responseHeaders = buildMap<String, List<String>> {
+                    conn.headerFields.forEach { (key, values) ->
+                        if (key != null) put(key, values)
+                    }
+                }
+
+                val isHttps = currentUrl.protocol == "https"
+                val bodyStream = if (statusCode >= 400) conn.errorStream else conn.inputStream
+                var responseBodyBytes = 0L
+                val responseBody: String? = bodyStream?.use { stream ->
+                    val buffer = ByteArray(8192)
+                    val sb = StringBuilder()
+                    var read: Int
+                    while (stream.read(buffer).also { read = it } != -1) {
+                        val bytesBufferedSoFar = responseBodyBytes
+                        responseBodyBytes += read
+                        if (bytesBufferedSoFar < request.maxResponseBodyBytes) {
+                            val canAppend = (request.maxResponseBodyBytes - bytesBufferedSoFar)
+                                .toInt().coerceAtMost(read)
+                            sb.append(String(buffer, 0, canAppend, Charsets.UTF_8))
+                        }
+                    }
+                    sb.toString()
+                }
+
+                val elapsed = System.currentTimeMillis() - startTime
+                val securityChecks = HttpSecurityAnalyzer.analyze(responseHeaders, isHttps)
+
+                return NetworkResult.Success(
+                    HttpProbeResult(
+                        request = request,
+                        statusCode = statusCode,
+                        statusMessage = statusMessage,
+                        responseTimeMs = elapsed,
+                        responseHeaders = responseHeaders,
+                        responseBody = responseBody,
+                        responseBodyBytes = responseBodyBytes,
+                        finalUrl = currentUrl.toString(),
+                        redirectChain = redirectChain.toList(),
+                        securityChecks = securityChecks
+                    )
+                )
+            } finally {
+                conn.disconnect()
+            }
+        }
+
+        return NetworkResult.Error("Too many redirects (max $maxRedirects)")
+    }
+
+    private fun resolveUrl(base: URL, location: String): URL {
+        return if (location.startsWith("http://") || location.startsWith("https://")) {
+            URL(location)
+        } else {
+            URL(base, location)
+        }
+    }
+}

--- a/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/httprobe/HttpSecurityAnalyzer.kt
+++ b/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/httprobe/HttpSecurityAnalyzer.kt
@@ -1,0 +1,193 @@
+package net.aieat.netswissknife.core.network.httprobe
+
+object HttpSecurityAnalyzer {
+
+    fun analyze(
+        responseHeaders: Map<String, List<String>>,
+        isHttps: Boolean
+    ): List<SecurityHeaderCheck> {
+        val normalized = responseHeaders.mapKeys { it.key.lowercase() }
+        return listOf(
+            checkHsts(normalized, isHttps),
+            checkContentSecurityPolicy(normalized),
+            checkXFrameOptions(normalized),
+            checkXContentTypeOptions(normalized),
+            checkReferrerPolicy(normalized),
+            checkPermissionsPolicy(normalized),
+            checkServerHeader(normalized)
+        )
+    }
+
+    private fun get(headers: Map<String, List<String>>, name: String): String? =
+        headers[name.lowercase()]?.firstOrNull()?.takeIf { it.isNotBlank() }
+
+    private fun checkHsts(headers: Map<String, List<String>>, isHttps: Boolean): SecurityHeaderCheck {
+        val value = get(headers, "Strict-Transport-Security")
+        return when {
+            value != null -> SecurityHeaderCheck(
+                headerName = "Strict-Transport-Security",
+                value = value,
+                rating = SecurityRating.PASS,
+                description = "HSTS is enabled. Browsers will upgrade future connections to HTTPS."
+            )
+            !isHttps -> SecurityHeaderCheck(
+                headerName = "Strict-Transport-Security",
+                value = null,
+                rating = SecurityRating.INFO,
+                description = "HSTS only applies to HTTPS responses."
+            )
+            else -> SecurityHeaderCheck(
+                headerName = "Strict-Transport-Security",
+                value = null,
+                rating = SecurityRating.FAIL,
+                description = "HSTS not set — browsers may downgrade connections to HTTP."
+            )
+        }
+    }
+
+    private fun checkContentSecurityPolicy(headers: Map<String, List<String>>): SecurityHeaderCheck {
+        val value = get(headers, "Content-Security-Policy")
+        return if (value != null) {
+            SecurityHeaderCheck(
+                headerName = "Content-Security-Policy",
+                value = value,
+                rating = SecurityRating.PASS,
+                description = "CSP is set. Helps mitigate XSS and data injection attacks."
+            )
+        } else {
+            SecurityHeaderCheck(
+                headerName = "Content-Security-Policy",
+                value = null,
+                rating = SecurityRating.WARN,
+                description = "No CSP header — the site may be vulnerable to XSS attacks."
+            )
+        }
+    }
+
+    private fun checkXFrameOptions(headers: Map<String, List<String>>): SecurityHeaderCheck {
+        val value = get(headers, "X-Frame-Options")
+        return when {
+            value != null && value.uppercase().let { it == "DENY" || it == "SAMEORIGIN" } ->
+                SecurityHeaderCheck(
+                    headerName = "X-Frame-Options",
+                    value = value,
+                    rating = SecurityRating.PASS,
+                    description = "Clickjacking protection is enabled."
+                )
+            value != null ->
+                SecurityHeaderCheck(
+                    headerName = "X-Frame-Options",
+                    value = value,
+                    rating = SecurityRating.WARN,
+                    description = "X-Frame-Options is present but the value '$value' may not provide full protection."
+                )
+            else ->
+                SecurityHeaderCheck(
+                    headerName = "X-Frame-Options",
+                    value = null,
+                    rating = SecurityRating.FAIL,
+                    description = "No X-Frame-Options — page may be embeddable in iframes (clickjacking risk)."
+                )
+        }
+    }
+
+    private fun checkXContentTypeOptions(headers: Map<String, List<String>>): SecurityHeaderCheck {
+        val value = get(headers, "X-Content-Type-Options")
+        return if (value?.lowercase() == "nosniff") {
+            SecurityHeaderCheck(
+                headerName = "X-Content-Type-Options",
+                value = value,
+                rating = SecurityRating.PASS,
+                description = "MIME sniffing is disabled."
+            )
+        } else {
+            SecurityHeaderCheck(
+                headerName = "X-Content-Type-Options",
+                value = value,
+                rating = SecurityRating.FAIL,
+                description = "No 'nosniff' directive — browsers may MIME-sniff responses."
+            )
+        }
+    }
+
+    private fun checkReferrerPolicy(headers: Map<String, List<String>>): SecurityHeaderCheck {
+        val value = get(headers, "Referrer-Policy")
+        val strictValues = setOf(
+            "no-referrer",
+            "no-referrer-when-downgrade",
+            "strict-origin",
+            "strict-origin-when-cross-origin",
+            "same-origin"
+        )
+        return when {
+            value != null && value.lowercase() in strictValues ->
+                SecurityHeaderCheck(
+                    headerName = "Referrer-Policy",
+                    value = value,
+                    rating = SecurityRating.PASS,
+                    description = "Referrer policy is set to a privacy-preserving value."
+                )
+            value != null ->
+                SecurityHeaderCheck(
+                    headerName = "Referrer-Policy",
+                    value = value,
+                    rating = SecurityRating.WARN,
+                    description = "Referrer-Policy is set to '$value' which may leak URL data."
+                )
+            else ->
+                SecurityHeaderCheck(
+                    headerName = "Referrer-Policy",
+                    value = null,
+                    rating = SecurityRating.WARN,
+                    description = "No Referrer-Policy — referrer data may be sent to third parties."
+                )
+        }
+    }
+
+    private fun checkPermissionsPolicy(headers: Map<String, List<String>>): SecurityHeaderCheck {
+        val value = get(headers, "Permissions-Policy")
+        return if (value != null) {
+            SecurityHeaderCheck(
+                headerName = "Permissions-Policy",
+                value = value,
+                rating = SecurityRating.PASS,
+                description = "Permissions Policy restricts browser feature access."
+            )
+        } else {
+            SecurityHeaderCheck(
+                headerName = "Permissions-Policy",
+                value = null,
+                rating = SecurityRating.WARN,
+                description = "No Permissions-Policy — browser features like camera/mic are unrestricted."
+            )
+        }
+    }
+
+    private fun checkServerHeader(headers: Map<String, List<String>>): SecurityHeaderCheck {
+        val value = get(headers, "Server")
+        val versionPattern = Regex("""\d+\.\d+""")
+        return when {
+            value == null ->
+                SecurityHeaderCheck(
+                    headerName = "Server",
+                    value = null,
+                    rating = SecurityRating.INFO,
+                    description = "Server header is not present (good for security)."
+                )
+            versionPattern.containsMatchIn(value) ->
+                SecurityHeaderCheck(
+                    headerName = "Server",
+                    value = value,
+                    rating = SecurityRating.WARN,
+                    description = "Server header reveals version information which may help attackers."
+                )
+            else ->
+                SecurityHeaderCheck(
+                    headerName = "Server",
+                    value = value,
+                    rating = SecurityRating.INFO,
+                    description = "Server header is present but does not reveal version details."
+                )
+        }
+    }
+}

--- a/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/subnet/SubnetCalculatorRepository.kt
+++ b/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/subnet/SubnetCalculatorRepository.kt
@@ -1,0 +1,16 @@
+package net.aieat.netswissknife.core.network.subnet
+
+import net.aieat.netswissknife.core.network.NetworkResult
+
+/**
+ * Computes subnet information from various input notations.
+ *
+ * Supported input formats:
+ * - CIDR:            "192.168.1.0/24"
+ * - IP + prefix:     "192.168.1.0/255.255.255.0"
+ * - IP + space mask: "192.168.1.0 255.255.255.0"
+ * - Bare IP:         "192.168.1.1"  (treated as /32)
+ */
+interface SubnetCalculatorRepository {
+    fun calculate(input: String): NetworkResult<SubnetInfo>
+}

--- a/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/subnet/SubnetCalculatorRepositoryImpl.kt
+++ b/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/subnet/SubnetCalculatorRepositoryImpl.kt
@@ -1,0 +1,158 @@
+package net.aieat.netswissknife.core.network.subnet
+
+import net.aieat.netswissknife.core.network.NetworkResult
+
+class SubnetCalculatorRepositoryImpl : SubnetCalculatorRepository {
+
+    override fun calculate(input: String): NetworkResult<SubnetInfo> = try {
+        val (ipStr, prefix) = parseInput(input.trim())
+        val ipLong = parseIpToLong(ipStr)
+        val maskLong = prefixToMask(prefix)
+        val networkLong = ipLong and maskLong
+        val broadcastLong = networkLong or maskLong.inv().and(0xFFFFFFFFL)
+        val hostBits = 32 - prefix
+        val totalHosts = if (hostBits == 32) 0x1_0000_0000L else 1L shl hostBits
+        val usableHosts = when {
+            prefix == 32 -> 1L
+            prefix == 31 -> 0L
+            else -> totalHosts - 2L
+        }
+        val firstHost = if (prefix >= 31) longToIp(networkLong) else longToIp(networkLong + 1)
+        val lastHost = if (prefix >= 31) longToIp(broadcastLong) else longToIp(broadcastLong - 1)
+        val maskHex = "0x%08X".format(maskLong)
+        val networkAddress = longToIp(networkLong)
+
+        NetworkResult.Success(
+            SubnetInfo(
+                inputIp = ipStr,
+                prefixLength = prefix,
+                networkAddress = networkAddress,
+                broadcastAddress = longToIp(broadcastLong),
+                firstHost = firstHost,
+                lastHost = lastHost,
+                subnetMask = longToIp(maskLong),
+                wildcardMask = longToIp(maskLong.inv().and(0xFFFFFFFFL)),
+                hexMask = maskHex,
+                binaryMask = longToBinaryDotted(maskLong),
+                binaryNetworkAddress = longToBinaryDotted(networkLong),
+                binaryIpAddress = longToBinaryDotted(ipLong),
+                totalHosts = totalHosts,
+                usableHosts = usableHosts,
+                hostBits = hostBits,
+                ipClass = classOf(ipLong),
+                isPrivate = isPrivate(ipLong),
+                cidrNotation = "$networkAddress/$prefix",
+            )
+        )
+    } catch (e: IllegalArgumentException) {
+        NetworkResult.Error(e.message ?: "Invalid input")
+    } catch (e: Exception) {
+        NetworkResult.Error("Invalid input: ${e.message}")
+    }
+
+    // ── Parsing ────────────────────────────────────────────────────────────────
+
+    /**
+     * Returns (ipString, prefixLength).
+     * Handles:
+     *   "192.168.1.0/24"
+     *   "192.168.1.0/255.255.255.0"
+     *   "192.168.1.0 255.255.255.0"
+     *   "192.168.1.0"
+     */
+    private fun parseInput(input: String): Pair<String, Int> {
+        val slashIndex = input.indexOf('/')
+        val spaceIndex = input.indexOf(' ')
+
+        return when {
+            slashIndex != -1 -> {
+                val ip = input.substring(0, slashIndex).trim()
+                val suffix = input.substring(slashIndex + 1).trim()
+                val prefix = if (suffix.contains('.')) {
+                    // dot-decimal mask
+                    maskToPrefix(parseIpToLong(suffix))
+                } else {
+                    suffix.toIntOrNull()
+                        ?: throw IllegalArgumentException("Invalid prefix: $suffix")
+                }
+                Pair(ip, prefix)
+            }
+            spaceIndex != -1 -> {
+                val ip = input.substring(0, spaceIndex).trim()
+                val mask = input.substring(spaceIndex + 1).trim()
+                val prefix = maskToPrefix(parseIpToLong(mask))
+                Pair(ip, prefix)
+            }
+            else -> Pair(input, 32)
+        }
+    }
+
+    // ── Low-level helpers ──────────────────────────────────────────────────────
+
+    private fun parseIpToLong(ip: String): Long {
+        val parts = ip.split('.')
+        require(parts.size == 4) { "Invalid IP address: $ip" }
+        return parts.fold(0L) { acc, part ->
+            val octet = part.toLongOrNull()
+                ?: throw IllegalArgumentException("Invalid octet '$part' in: $ip")
+            require(octet in 0..255) { "Octet out of range in: $ip" }
+            acc * 256L + octet
+        }
+    }
+
+    private fun longToIp(addr: Long): String =
+        "${(addr shr 24) and 0xFF}.${(addr shr 16) and 0xFF}.${(addr shr 8) and 0xFF}.${addr and 0xFF}"
+
+    /** Converts a /prefix-length integer to a 32-bit mask as Long. */
+    private fun prefixToMask(prefix: Int): Long {
+        require(prefix in 0..32) { "Prefix length must be 0–32, got $prefix" }
+        return if (prefix == 0) 0L
+        else (0xFFFFFFFFL shl (32 - prefix)) and 0xFFFFFFFFL
+    }
+
+    /** Converts a dotted-decimal mask Long to its prefix length. Validates contiguous bits. */
+    private fun maskToPrefix(mask: Long): Int {
+        require(mask and 0xFFFFFFFFL == mask) { "Mask out of range" }
+        // Verify it's a valid (contiguous) subnet mask
+        val inverted = mask.inv() and 0xFFFFFFFFL
+        // inverted + 1 must be a power of two (or zero for /0)
+        require(inverted == 0L || (inverted and (inverted + 1)) == 0L) {
+            "Non-contiguous subnet mask"
+        }
+        var count = 0
+        var m = mask
+        while (m and 0x8000_0000L != 0L) {
+            count++
+            m = (m shl 1) and 0xFFFFFFFFL
+        }
+        return count
+    }
+
+    private fun longToBinaryDotted(addr: Long): String =
+        (3 downTo 0).joinToString(".") { octetIdx ->
+            val octet = ((addr shr (octetIdx * 8)) and 0xFF).toInt()
+            octet.toString(2).padStart(8, '0')
+        }
+
+    private fun classOf(ip: Long): String = when {
+        ip shr 28 == 0xFL -> "E"
+        ip shr 28 >= 0xEL -> "D"
+        ip shr 30 == 0x3L -> "C"
+        ip shr 31 == 0x1L -> "B"
+        else -> "A"
+    }
+
+    private fun isPrivate(ip: Long): Boolean {
+        // 10.0.0.0/8
+        if (ip shr 24 == 10L) return true
+        // 172.16.0.0/12
+        if (ip shr 20 == (172L shl 4) + 1) return true
+        // 192.168.0.0/16
+        if (ip shr 16 == (192L shl 8) + 168) return true
+        // 127.0.0.0/8 (loopback)
+        if (ip shr 24 == 127L) return true
+        // 169.254.0.0/16 (link-local)
+        if (ip shr 16 == (169L shl 8) + 254) return true
+        return false
+    }
+}

--- a/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/subnet/SubnetModels.kt
+++ b/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/subnet/SubnetModels.kt
@@ -1,0 +1,43 @@
+package net.aieat.netswissknife.core.network.subnet
+
+/**
+ * All computed information about a subnet derived from a single user input.
+ */
+data class SubnetInfo(
+    /** The IP portion of the original input (before mask/prefix). */
+    val inputIp: String,
+    /** CIDR prefix length, 0–32. */
+    val prefixLength: Int,
+    /** Network address (host bits zeroed). */
+    val networkAddress: String,
+    /** Broadcast address (host bits set to 1). */
+    val broadcastAddress: String,
+    /** First usable host address, or network address for /32. */
+    val firstHost: String,
+    /** Last usable host address, or network address for /32. */
+    val lastHost: String,
+    /** Dotted-decimal subnet mask, e.g. "255.255.255.0". */
+    val subnetMask: String,
+    /** Wildcard mask (inverse of subnet mask), e.g. "0.0.0.255". */
+    val wildcardMask: String,
+    /** Hex representation of the subnet mask, e.g. "0xFFFFFF00". */
+    val hexMask: String,
+    /** Binary representation of the mask with octet dots, e.g. "11111111.11111111.11111111.00000000". */
+    val binaryMask: String,
+    /** Binary representation of the network address with octet dots. */
+    val binaryNetworkAddress: String,
+    /** Binary representation of the original input IP with octet dots. */
+    val binaryIpAddress: String,
+    /** Total number of addresses in the subnet (2^hostBits). */
+    val totalHosts: Long,
+    /** Usable host count. 0 for /31, 1 for /32, (totalHosts - 2) otherwise. */
+    val usableHosts: Long,
+    /** Number of host bits (32 - prefixLength). */
+    val hostBits: Int,
+    /** Traditional IP class: "A", "B", "C", "D", or "E". */
+    val ipClass: String,
+    /** True if the network falls within RFC 1918 private ranges. */
+    val isPrivate: Boolean,
+    /** Canonical CIDR notation of the network, e.g. "192.168.1.0/24". */
+    val cidrNotation: String,
+)

--- a/core-network/src/test/kotlin/net/aieat/netswissknife/core/network/httprobe/HttpProbeRepositoryTest.kt
+++ b/core-network/src/test/kotlin/net/aieat/netswissknife/core/network/httprobe/HttpProbeRepositoryTest.kt
@@ -1,0 +1,204 @@
+package net.aieat.netswissknife.core.network.httprobe
+
+import kotlinx.coroutines.test.runTest
+import net.aieat.netswissknife.core.network.NetworkResult
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("HttpProbeRepositoryImpl – input validation")
+class HttpProbeRepositoryValidationTest {
+
+    private val repo = HttpProbeRepositoryImpl()
+
+    @Test
+    @DisplayName("probe returns Error for blank URL")
+    fun `probe returns Error for blank URL`() = runTest {
+        val result = repo.probe(HttpProbeRequest(url = "   "))
+        assertTrue(result is NetworkResult.Error)
+        assertTrue((result as NetworkResult.Error).message.contains("blank", ignoreCase = true))
+    }
+
+    @Test
+    @DisplayName("probe returns Error for non-HTTP URL")
+    fun `probe returns Error for non-HTTP URL`() = runTest {
+        val result = repo.probe(HttpProbeRequest(url = "ftp://example.com"))
+        assertTrue(result is NetworkResult.Error)
+    }
+
+    @Test
+    @DisplayName("probe returns Error for malformed URL")
+    fun `probe returns Error for malformed URL`() = runTest {
+        val result = repo.probe(HttpProbeRequest(url = "not a url at all"))
+        assertTrue(result is NetworkResult.Error)
+    }
+
+    @Test
+    @DisplayName("probe returns Error for timeout below 500ms")
+    fun `probe returns Error for timeout below 500ms`() = runTest {
+        val result = repo.probe(HttpProbeRequest(url = "https://example.com", timeoutMs = 499))
+        assertTrue(result is NetworkResult.Error)
+    }
+
+    @Test
+    @DisplayName("probe returns Error for timeout above 60000ms")
+    fun `probe returns Error for timeout above 60000ms`() = runTest {
+        val result = repo.probe(HttpProbeRequest(url = "https://example.com", timeoutMs = 60_001))
+        assertTrue(result is NetworkResult.Error)
+    }
+}
+
+@DisplayName("HttpSecurityAnalyzer – header ratings")
+class HttpSecurityAnalyzerTest {
+
+    @Test
+    @DisplayName("HSTS present on HTTPS gets PASS")
+    fun `HSTS present on HTTPS gets PASS`() {
+        val headers = mapOf("Strict-Transport-Security" to listOf("max-age=31536000; includeSubDomains"))
+        val checks = HttpSecurityAnalyzer.analyze(headers, isHttps = true)
+        val hsts = checks.first { it.headerName == "Strict-Transport-Security" }
+        assertEquals(SecurityRating.PASS, hsts.rating)
+    }
+
+    @Test
+    @DisplayName("HSTS absent on HTTPS gets FAIL")
+    fun `HSTS absent on HTTPS gets FAIL`() {
+        val checks = HttpSecurityAnalyzer.analyze(emptyMap(), isHttps = true)
+        val hsts = checks.first { it.headerName == "Strict-Transport-Security" }
+        assertEquals(SecurityRating.FAIL, hsts.rating)
+    }
+
+    @Test
+    @DisplayName("HSTS absent on HTTP gets INFO")
+    fun `HSTS absent on HTTP gets INFO`() {
+        val checks = HttpSecurityAnalyzer.analyze(emptyMap(), isHttps = false)
+        val hsts = checks.first { it.headerName == "Strict-Transport-Security" }
+        assertEquals(SecurityRating.INFO, hsts.rating)
+    }
+
+    @Test
+    @DisplayName("X-Frame-Options DENY gets PASS")
+    fun `X-Frame-Options DENY gets PASS`() {
+        val headers = mapOf("X-Frame-Options" to listOf("DENY"))
+        val checks = HttpSecurityAnalyzer.analyze(headers, isHttps = true)
+        val check = checks.first { it.headerName == "X-Frame-Options" }
+        assertEquals(SecurityRating.PASS, check.rating)
+    }
+
+    @Test
+    @DisplayName("X-Frame-Options SAMEORIGIN gets PASS")
+    fun `X-Frame-Options SAMEORIGIN gets PASS`() {
+        val headers = mapOf("X-Frame-Options" to listOf("SAMEORIGIN"))
+        val checks = HttpSecurityAnalyzer.analyze(headers, isHttps = true)
+        val check = checks.first { it.headerName == "X-Frame-Options" }
+        assertEquals(SecurityRating.PASS, check.rating)
+    }
+
+    @Test
+    @DisplayName("X-Frame-Options absent gets FAIL")
+    fun `X-Frame-Options absent gets FAIL`() {
+        val checks = HttpSecurityAnalyzer.analyze(emptyMap(), isHttps = true)
+        val check = checks.first { it.headerName == "X-Frame-Options" }
+        assertEquals(SecurityRating.FAIL, check.rating)
+    }
+
+    @Test
+    @DisplayName("X-Content-Type-Options nosniff gets PASS")
+    fun `X-Content-Type-Options nosniff gets PASS`() {
+        val headers = mapOf("X-Content-Type-Options" to listOf("nosniff"))
+        val checks = HttpSecurityAnalyzer.analyze(headers, isHttps = true)
+        val check = checks.first { it.headerName == "X-Content-Type-Options" }
+        assertEquals(SecurityRating.PASS, check.rating)
+    }
+
+    @Test
+    @DisplayName("X-Content-Type-Options absent gets FAIL")
+    fun `X-Content-Type-Options absent gets FAIL`() {
+        val checks = HttpSecurityAnalyzer.analyze(emptyMap(), isHttps = true)
+        val check = checks.first { it.headerName == "X-Content-Type-Options" }
+        assertEquals(SecurityRating.FAIL, check.rating)
+    }
+
+    @Test
+    @DisplayName("CSP present gets PASS")
+    fun `CSP present gets PASS`() {
+        val headers = mapOf("Content-Security-Policy" to listOf("default-src 'self'"))
+        val checks = HttpSecurityAnalyzer.analyze(headers, isHttps = true)
+        val check = checks.first { it.headerName == "Content-Security-Policy" }
+        assertEquals(SecurityRating.PASS, check.rating)
+    }
+
+    @Test
+    @DisplayName("CSP absent gets WARN")
+    fun `CSP absent gets WARN`() {
+        val checks = HttpSecurityAnalyzer.analyze(emptyMap(), isHttps = true)
+        val check = checks.first { it.headerName == "Content-Security-Policy" }
+        assertEquals(SecurityRating.WARN, check.rating)
+    }
+
+    @Test
+    @DisplayName("Server header with version info gets WARN")
+    fun `Server header with version info gets WARN`() {
+        val headers = mapOf("Server" to listOf("Apache/2.4.51 (Ubuntu)"))
+        val checks = HttpSecurityAnalyzer.analyze(headers, isHttps = true)
+        val check = checks.first { it.headerName == "Server" }
+        assertEquals(SecurityRating.WARN, check.rating)
+    }
+
+    @Test
+    @DisplayName("Server header absent or generic gets INFO")
+    fun `Server header absent or generic gets INFO`() {
+        val headers = mapOf("Server" to listOf("cloudflare"))
+        val checks = HttpSecurityAnalyzer.analyze(headers, isHttps = true)
+        val check = checks.first { it.headerName == "Server" }
+        assertEquals(SecurityRating.INFO, check.rating)
+    }
+
+    @Test
+    @DisplayName("analyze returns at least 5 security checks")
+    fun `analyze returns at least 5 security checks`() {
+        val checks = HttpSecurityAnalyzer.analyze(emptyMap(), isHttps = true)
+        assertTrue(checks.size >= 5)
+    }
+}
+
+@DisplayName("HttpMethod – body support")
+class HttpMethodBodySupportTest {
+
+    @Test
+    @DisplayName("POST supports body")
+    fun `POST supports body`() {
+        assertTrue(HttpMethod.POST.supportsBody)
+    }
+
+    @Test
+    @DisplayName("PUT supports body")
+    fun `PUT supports body`() {
+        assertTrue(HttpMethod.PUT.supportsBody)
+    }
+
+    @Test
+    @DisplayName("PATCH supports body")
+    fun `PATCH supports body`() {
+        assertTrue(HttpMethod.PATCH.supportsBody)
+    }
+
+    @Test
+    @DisplayName("GET does not support body")
+    fun `GET does not support body`() {
+        assertTrue(!HttpMethod.GET.supportsBody)
+    }
+
+    @Test
+    @DisplayName("HEAD does not support body")
+    fun `HEAD does not support body`() {
+        assertTrue(!HttpMethod.HEAD.supportsBody)
+    }
+
+    @Test
+    @DisplayName("DELETE does not support body")
+    fun `DELETE does not support body`() {
+        assertTrue(!HttpMethod.DELETE.supportsBody)
+    }
+}

--- a/core-network/src/test/kotlin/net/aieat/netswissknife/core/network/subnet/SubnetCalculatorRepositoryTest.kt
+++ b/core-network/src/test/kotlin/net/aieat/netswissknife/core/network/subnet/SubnetCalculatorRepositoryTest.kt
@@ -1,0 +1,187 @@
+package net.aieat.netswissknife.core.network.subnet
+
+import net.aieat.netswissknife.core.network.NetworkResult
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class SubnetCalculatorRepositoryTest {
+
+    private val repo = SubnetCalculatorRepositoryImpl()
+
+    // ── CIDR notation ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `calculate returns correct network for standard class-C CIDR`() {
+        val result = repo.calculate("192.168.1.100/24")
+        assertTrue(result is NetworkResult.Success)
+        val info = (result as NetworkResult.Success).data
+        assertEquals("192.168.1.0", info.networkAddress)
+        assertEquals("192.168.1.255", info.broadcastAddress)
+        assertEquals("192.168.1.1", info.firstHost)
+        assertEquals("192.168.1.254", info.lastHost)
+        assertEquals(24, info.prefixLength)
+        assertEquals(256L, info.totalHosts)
+        assertEquals(254L, info.usableHosts)
+        assertEquals("255.255.255.0", info.subnetMask)
+        assertEquals("0.0.0.255", info.wildcardMask)
+    }
+
+    @Test
+    fun `calculate returns correct info for slash 16`() {
+        val result = repo.calculate("10.0.0.1/16")
+        assertTrue(result is NetworkResult.Success)
+        val info = (result as NetworkResult.Success).data
+        assertEquals("10.0.0.0", info.networkAddress)
+        assertEquals("10.0.255.255", info.broadcastAddress)
+        assertEquals(16, info.prefixLength)
+        assertEquals(65536L, info.totalHosts)
+        assertEquals(65534L, info.usableHosts)
+        assertEquals("255.255.0.0", info.subnetMask)
+        assertEquals("0.0.255.255", info.wildcardMask)
+    }
+
+    @Test
+    fun `calculate returns correct info for slash 8`() {
+        val result = repo.calculate("10.50.100.200/8")
+        assertTrue(result is NetworkResult.Success)
+        val info = (result as NetworkResult.Success).data
+        assertEquals("10.0.0.0", info.networkAddress)
+        assertEquals("10.255.255.255", info.broadcastAddress)
+        assertEquals(8, info.prefixLength)
+        assertEquals(16777216L, info.totalHosts)
+        assertEquals(16777214L, info.usableHosts)
+    }
+
+    @Test
+    fun `calculate accepts dot-decimal mask notation`() {
+        val result = repo.calculate("192.168.1.0/255.255.255.0")
+        assertTrue(result is NetworkResult.Success)
+        val info = (result as NetworkResult.Success).data
+        assertEquals(24, info.prefixLength)
+        assertEquals("192.168.1.0", info.networkAddress)
+    }
+
+    @Test
+    fun `calculate accepts space-separated mask notation`() {
+        val result = repo.calculate("192.168.1.0 255.255.255.0")
+        assertTrue(result is NetworkResult.Success)
+        val info = (result as NetworkResult.Success).data
+        assertEquals(24, info.prefixLength)
+        assertEquals("192.168.1.0", info.networkAddress)
+    }
+
+    @Test
+    fun `calculate accepts bare IP and defaults to slash 32`() {
+        val result = repo.calculate("192.168.1.1")
+        assertTrue(result is NetworkResult.Success)
+        val info = (result as NetworkResult.Success).data
+        assertEquals(32, info.prefixLength)
+        assertEquals("192.168.1.1", info.networkAddress)
+        assertEquals("192.168.1.1", info.broadcastAddress)
+        assertEquals(1L, info.totalHosts)
+        assertEquals(1L, info.usableHosts)
+    }
+
+    @Test
+    fun `calculate returns error for invalid input`() {
+        val result = repo.calculate("not-an-ip")
+        assertTrue(result is NetworkResult.Error)
+    }
+
+    @Test
+    fun `calculate returns error for out-of-range IP`() {
+        val result = repo.calculate("256.0.0.1/24")
+        assertTrue(result is NetworkResult.Error)
+    }
+
+    @Test
+    fun `calculate returns error for prefix out of range`() {
+        val result = repo.calculate("192.168.1.0/33")
+        assertTrue(result is NetworkResult.Error)
+    }
+
+    // ── Binary representation ──────────────────────────────────────────────────
+
+    @Test
+    fun `calculate produces correct binary mask for slash 24`() {
+        val result = repo.calculate("192.168.1.0/24")
+        assertTrue(result is NetworkResult.Success)
+        val info = (result as NetworkResult.Success).data
+        assertEquals("11111111.11111111.11111111.00000000", info.binaryMask)
+    }
+
+    @Test
+    fun `calculate produces correct binary network address for slash 24`() {
+        val result = repo.calculate("192.168.1.0/24")
+        assertTrue(result is NetworkResult.Success)
+        val info = (result as NetworkResult.Success).data
+        assertEquals("11000000.10101000.00000001.00000000", info.binaryNetworkAddress)
+    }
+
+    // ── IP properties ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `calculate identifies private class-C address`() {
+        val result = repo.calculate("192.168.1.0/24")
+        assertTrue(result is NetworkResult.Success)
+        val info = (result as NetworkResult.Success).data
+        assertTrue(info.isPrivate)
+        assertEquals("C", info.ipClass)
+    }
+
+    @Test
+    fun `calculate identifies private class-A address`() {
+        val result = repo.calculate("10.0.0.0/8")
+        assertTrue(result is NetworkResult.Success)
+        val info = (result as NetworkResult.Success).data
+        assertTrue(info.isPrivate)
+        assertEquals("A", info.ipClass)
+    }
+
+    @Test
+    fun `calculate identifies private class-B address`() {
+        val result = repo.calculate("172.16.0.0/12")
+        assertTrue(result is NetworkResult.Success)
+        val info = (result as NetworkResult.Success).data
+        assertTrue(info.isPrivate)
+        assertEquals("B", info.ipClass)
+    }
+
+    // ── Edge cases ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun `calculate handles slash 31 correctly`() {
+        val result = repo.calculate("192.168.1.0/31")
+        assertTrue(result is NetworkResult.Success)
+        val info = (result as NetworkResult.Success).data
+        assertEquals(2L, info.totalHosts)
+        assertEquals(0L, info.usableHosts)
+    }
+
+    @Test
+    fun `calculate handles slash 0 correctly`() {
+        val result = repo.calculate("0.0.0.0/0")
+        assertTrue(result is NetworkResult.Success)
+        val info = (result as NetworkResult.Success).data
+        assertEquals("0.0.0.0", info.networkAddress)
+        assertEquals("255.255.255.255", info.broadcastAddress)
+        assertEquals(0, info.prefixLength)
+    }
+
+    @Test
+    fun `calculate populates CIDR notation field`() {
+        val result = repo.calculate("192.168.1.100/24")
+        assertTrue(result is NetworkResult.Success)
+        val info = (result as NetworkResult.Success).data
+        assertEquals("192.168.1.0/24", info.cidrNotation)
+    }
+
+    @Test
+    fun `calculate populates hex mask field for slash 24`() {
+        val result = repo.calculate("192.168.1.0/24")
+        assertTrue(result is NetworkResult.Success)
+        val info = (result as NetworkResult.Success).data
+        assertEquals("0xFFFFFF00", info.hexMask)
+    }
+}


### PR DESCRIPTION
## Summary

- **Subnet Calculator** tool (`route: subnet`) – pure-Kotlin IPv4 subnet calculator with a rich Material 3 UI
- Accepts CIDR (`192.168.1.0/24`), dot-decimal mask (`/255.255.255.0`), space-separated mask, or bare IP (defaults to `/32`)
- Computes network/broadcast addresses, first/last usable hosts, total and usable host counts, subnet mask, wildcard mask, hex mask, and binary representations
- Rich **Binary Breakdown** card with a colour-coded bit grid (network bits in primary colour, host bits in tertiary)
- **Notation Equivalents** card: CIDR, dot-decimal, wildcard, hex, and binary mask side by side
- **Address Properties** card: IP class badge (A/B/C/D/E) and private/public scope badge (RFC 1918, loopback, link-local)
- Quick-example FilterChips for common subnets
- All logic is in `:core-network` with no Android SDK dependency; 22 unit tests (all passing)

## Test plan

- [x] `./gradlew test` – all 36 tests pass
- [x] `./gradlew :app:assembleDebug` – builds cleanly (no errors, only pre-existing deprecation warnings)
- [x] Verified correct results for /8, /12, /16, /24, /30, /31, /32, /0 edge cases
- [x] Verified private detection for 10.x.x.x (Class A), 172.16–31.x.x (Class B), 192.168.x.x (Class C)
- [x] Codebase scan: unused imports removed, all user-facing strings in `strings.xml`, no architecture violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)