### PR TITLE
fix: bug fixes and code quality improvements from codebase audit

### DIFF
--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/whois/WhoisViewModel.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/whois/WhoisViewModel.kt
@@ -81,8 +81,8 @@ class WhoisViewModel @Inject constructor(
         }
 
         viewModelScope.launch {
-            // Brief delay to let progress subscription attach
-            kotlinx.coroutines.delay(10)
+            // Yield so the progress-collection coroutine above can reach collect() first
+            kotlinx.coroutines.yield()
             val result = whoisLookupUseCase(WhoisParams(query = query))
             progressJob?.cancel()
             progressJob = null

--- a/core-domain/src/main/kotlin/net/aieat/netswissknife/core/domain/SubnetCalculatorUseCase.kt
+++ b/core-domain/src/main/kotlin/net/aieat/netswissknife/core/domain/SubnetCalculatorUseCase.kt
@@ -6,7 +6,7 @@ import net.aieat.netswissknife.core.network.subnet.SubnetInfo
 
 class SubnetCalculatorUseCase(
     private val repository: SubnetCalculatorRepository
-) : UseCase<String, NetworkResult<SubnetInfo>> {
-    override suspend fun invoke(params: String): NetworkResult<SubnetInfo> =
+) {
+    suspend operator fun invoke(params: String): NetworkResult<SubnetInfo> =
         repository.calculate(params)
 }

--- a/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/ping/PingStats.kt
+++ b/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/ping/PingStats.kt
@@ -36,7 +36,7 @@ data class PingStats(
             val avgMs = if (successRtts.isEmpty()) 0.0 else successRtts.average()
 
             val jitterMs = if (successRtts.size < 2) 0.0 else {
-                val diffs = successRtts.zipWithNext { a, b -> Math.abs(b - a).toDouble() }
+                val diffs = successRtts.zipWithNext { a, b -> kotlin.math.abs(b - a).toDouble() }
                 diffs.average()
             }
 

--- a/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/tls/TlsInspectorRepositoryImpl.kt
+++ b/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/tls/TlsInspectorRepositoryImpl.kt
@@ -2,6 +2,7 @@ package net.aieat.netswissknife.core.network.tls
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import net.aieat.netswissknife.core.network.HostValidator
 import net.aieat.netswissknife.core.network.NetworkResult
 import java.net.InetSocketAddress
 import java.security.KeyStore
@@ -34,7 +35,7 @@ class TlsInspectorRepositoryImpl : TlsInspectorRepository {
                 val sslSocket = (trustAllCtx.socketFactory.createSocket() as SSLSocket).apply {
                     soTimeout = timeoutMs
                     // Set SNI for hostname-based hosts (not bare IPs)
-                    if (!host.contains(':') && !host.matches(Regex("""^\d+\.\d+\.\d+\.\d+$"""))) {
+                    if (!host.contains(':') && !HostValidator.isValidIpv4(host)) {
                         try {
                             val params = sslParameters
                             params.serverNames = listOf(javax.net.ssl.SNIHostName(host))

--- a/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/traceroute/GeoIpRepositoryImpl.kt
+++ b/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/traceroute/GeoIpRepositoryImpl.kt
@@ -99,57 +99,27 @@ class GeoIpRepositoryImpl : GeoIpRepository {
 
     // ── Country code → full name (ISO 3166-1 alpha-2 for common countries) ───
 
-    @Suppress("CyclomaticComplexMethod")
-    private fun countryName(code: String): String = when (code.uppercase()) {
-        "US" -> "United States"
-        "GB" -> "United Kingdom"
-        "DE" -> "Germany"
-        "FR" -> "France"
-        "JP" -> "Japan"
-        "CN" -> "China"
-        "CA" -> "Canada"
-        "AU" -> "Australia"
-        "BR" -> "Brazil"
-        "IN" -> "India"
-        "RU" -> "Russia"
-        "NL" -> "Netherlands"
-        "SE" -> "Sweden"
-        "SG" -> "Singapore"
-        "HK" -> "Hong Kong"
-        "KR" -> "South Korea"
-        "IT" -> "Italy"
-        "ES" -> "Spain"
-        "CH" -> "Switzerland"
-        "NO" -> "Norway"
-        "DK" -> "Denmark"
-        "FI" -> "Finland"
-        "PL" -> "Poland"
-        "ZA" -> "South Africa"
-        "MX" -> "Mexico"
-        "AR" -> "Argentina"
-        "TR" -> "Turkey"
-        "ID" -> "Indonesia"
-        "TH" -> "Thailand"
-        "PH" -> "Philippines"
-        "MY" -> "Malaysia"
-        "UA" -> "Ukraine"
-        "IE" -> "Ireland"
-        "NZ" -> "New Zealand"
-        "PT" -> "Portugal"
-        "AT" -> "Austria"
-        "BE" -> "Belgium"
-        "CZ" -> "Czech Republic"
-        "HU" -> "Hungary"
-        "RO" -> "Romania"
-        "GR" -> "Greece"
-        "TW" -> "Taiwan"
-        "VN" -> "Vietnam"
-        "EG" -> "Egypt"
-        "SA" -> "Saudi Arabia"
-        "AE" -> "UAE"
-        "IL" -> "Israel"
-        "PK" -> "Pakistan"
-        "NG" -> "Nigeria"
-        else -> code
+    private fun countryName(code: String): String = COUNTRY_NAMES[code.uppercase()] ?: code
+
+    companion object {
+        private val COUNTRY_NAMES = mapOf(
+            "US" to "United States",  "GB" to "United Kingdom", "DE" to "Germany",
+            "FR" to "France",         "JP" to "Japan",          "CN" to "China",
+            "CA" to "Canada",         "AU" to "Australia",      "BR" to "Brazil",
+            "IN" to "India",          "RU" to "Russia",         "NL" to "Netherlands",
+            "SE" to "Sweden",         "SG" to "Singapore",      "HK" to "Hong Kong",
+            "KR" to "South Korea",    "IT" to "Italy",          "ES" to "Spain",
+            "CH" to "Switzerland",    "NO" to "Norway",         "DK" to "Denmark",
+            "FI" to "Finland",        "PL" to "Poland",         "ZA" to "South Africa",
+            "MX" to "Mexico",         "AR" to "Argentina",      "TR" to "Turkey",
+            "ID" to "Indonesia",      "TH" to "Thailand",       "PH" to "Philippines",
+            "MY" to "Malaysia",       "UA" to "Ukraine",        "IE" to "Ireland",
+            "NZ" to "New Zealand",    "PT" to "Portugal",       "AT" to "Austria",
+            "BE" to "Belgium",        "CZ" to "Czech Republic", "HU" to "Hungary",
+            "RO" to "Romania",        "GR" to "Greece",         "TW" to "Taiwan",
+            "VN" to "Vietnam",        "EG" to "Egypt",          "SA" to "Saudi Arabia",
+            "AE" to "UAE",            "IL" to "Israel",         "PK" to "Pakistan",
+            "NG" to "Nigeria",
+        )
     }
 }


### PR DESCRIPTION
## Summary

Post-merge codebase audit across all modules. Five targeted fixes — no scope creep.

- **`PingStats`** – `Math.abs` → `kotlin.math.abs` (idiomatic Kotlin; avoids unnecessary Java interop)
- **`WhoisViewModel`** – replaced `delay(10)` hack with `yield()`. The delay was used to give the hop-progress coroutine time to subscribe before the lookup started emitting, but an arbitrary 10 ms sleep is fragile. `yield()` correctly suspends the lookup coroutine for exactly one scheduling round, guaranteeing the subscriber is active.
- **`SubnetCalculatorUseCase`** – removed `UseCase<P,R>` interface implementation. Every other use case in the codebase (`PingUseCase`, `LanScanUseCase`, `PortScanUseCase`, `WhoisLookupUseCase`, `HttpProbeUseCase`, …) defines `operator fun invoke()` directly without implementing the interface. This use case was the odd one out.
- **`TlsInspectorRepositoryImpl`** – removed duplicate inline IPv4 regex `^\d+\.\d+\.\d+\.\d+$` and replaced with `HostValidator.isValidIpv4()`, which already exists in `:core-network`, validates octet ranges, and is tested.
- **`GeoIpRepositoryImpl`** – converted the 50-arm `when` block (with `@Suppress("CyclomaticComplexMethod")`) to a `companion object` Map. Adding a new country is now a single line, and the suppression annotation is gone.

## Confirmed non-issues (false positives from audit)
- 172.16.0.0/12 private-range check: `ip shr 20 == (172L shl 4) + 1` evaluates to `2753`, which equals `0xAC100000 shr 20` — mathematically correct.
- `GeoIpRepositoryImpl` resource leak: `finally { conn.disconnect() }` always runs, including through early returns.

## Test plan
- [x] `./gradlew test` — all tests pass
- [x] `./gradlew :app:assembleDebug` — clean build, no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)