### PR TITLE
feat: subnet calculator alignment warning, IP range mode & tooltips

### DIFF
--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/subnet/SubnetCalculatorScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/subnet/SubnetCalculatorScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.Button
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -45,8 +46,15 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.PlainTooltip
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TooltipBox
+import androidx.compose.material3.TooltipDefaults
+import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -109,55 +117,184 @@ fun SubnetCalculatorScreen(viewModel: SubnetCalculatorViewModel = hiltViewModel(
                         }
                     }
 
-                    OutlinedTextField(
-                        value = uiState.input,
-                        onValueChange = viewModel::onInputChange,
-                        modifier = Modifier.fillMaxWidth(),
-                        label = { Text(stringResource(R.string.subnet_input_label)) },
-                        placeholder = { Text(stringResource(R.string.subnet_input_placeholder)) },
-                        leadingIcon = { Icon(Icons.Default.NetworkCheck, contentDescription = null) },
-                        trailingIcon = {
-                            if (uiState.input.isNotEmpty()) {
-                                IconButton(onClick = { viewModel.onInputChange("") }) {
-                                    Icon(Icons.Default.Close, contentDescription = stringResource(R.string.clear))
-                                }
-                            }
-                        },
-                        singleLine = true,
-                        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-                        keyboardActions = KeyboardActions(onDone = { viewModel.calculate() })
+                    // Mode toggle
+                    SubnetModeToggle(
+                        isRangeMode = uiState.isRangeMode,
+                        onToggle = viewModel::toggleMode
                     )
 
-                    Button(
-                        onClick = viewModel::calculate,
-                        modifier = Modifier.fillMaxWidth(),
-                        enabled = uiState.input.isNotBlank()
-                    ) {
-                        Icon(Icons.Default.Calculate, contentDescription = null, modifier = Modifier.size(18.dp))
-                        Spacer(modifier = Modifier.width(8.dp))
-                        Text(stringResource(R.string.subnet_calculate_button))
+                    // Animated switch between input modes
+                    AnimatedContent(
+                        targetState = uiState.isRangeMode,
+                        transitionSpec = { fadeIn(tween(200)) togetherWith fadeOut(tween(150)) },
+                        label = "input-mode"
+                    ) { rangeMode ->
+                        if (rangeMode) {
+                            SubnetRangeInputs(
+                                minIp = uiState.minIpInput,
+                                maxIp = uiState.maxIpInput,
+                                onMinIpChange = viewModel::onMinIpChange,
+                                onMaxIpChange = viewModel::onMaxIpChange,
+                                onCalculate = viewModel::calculateRange,
+                                canCalculate = uiState.minIpInput.isNotBlank() && uiState.maxIpInput.isNotBlank()
+                            )
+                        } else {
+                            SubnetCidrInputs(
+                                input = uiState.input,
+                                onInputChange = viewModel::onInputChange,
+                                onCalculate = viewModel::calculate,
+                                onExampleSelected = viewModel::setExample,
+                                canCalculate = uiState.input.isNotBlank()
+                            )
+                        }
                     }
-
-                    // Quick example chips
-                    SubnetExampleChips(onExampleSelected = viewModel::setExample)
                 }
             }
 
             // ── Result / error area ─────────────────────────────────────────────
             AnimatedContent(
-                targetState = Pair(uiState.result, uiState.error),
+                targetState = Triple(uiState.result, uiState.error, uiState.isRangeMode),
                 transitionSpec = {
                     fadeIn(tween(300)) + slideInVertically(tween(300)) { it / 8 } togetherWith
                             fadeOut(tween(200))
                 },
                 label = "subnet-state"
-            ) { (result, error) ->
+            ) { (result, error, rangeMode) ->
                 when {
                     result != null -> SubnetResultContent(result)
-                    error != null  -> SubnetErrorCard(message = error, onRetry = viewModel::calculate)
-                    else           -> SubnetIdleCard()
+                    error != null  -> SubnetErrorCard(
+                        message = error,
+                        onRetry = if (rangeMode) viewModel::calculateRange else viewModel::calculate
+                    )
+                    else           -> SubnetIdleCard(isRangeMode = rangeMode)
                 }
             }
+        }
+    }
+}
+
+// ── Mode toggle ───────────────────────────────────────────────────────────────
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SubnetModeToggle(isRangeMode: Boolean, onToggle: () -> Unit) {
+    SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+        SegmentedButton(
+            selected = !isRangeMode,
+            onClick = { if (isRangeMode) onToggle() },
+            shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2),
+            label = { Text(stringResource(R.string.subnet_mode_cidr)) }
+        )
+        SegmentedButton(
+            selected = isRangeMode,
+            onClick = { if (!isRangeMode) onToggle() },
+            shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2),
+            label = { Text(stringResource(R.string.subnet_mode_range)) }
+        )
+    }
+}
+
+// ── CIDR input panel ──────────────────────────────────────────────────────────
+
+@Composable
+private fun SubnetCidrInputs(
+    input: String,
+    onInputChange: (String) -> Unit,
+    onCalculate: () -> Unit,
+    onExampleSelected: (String) -> Unit,
+    canCalculate: Boolean
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        OutlinedTextField(
+            value = input,
+            onValueChange = onInputChange,
+            modifier = Modifier.fillMaxWidth(),
+            label = { Text(stringResource(R.string.subnet_input_label)) },
+            placeholder = { Text(stringResource(R.string.subnet_input_placeholder)) },
+            leadingIcon = { Icon(Icons.Default.NetworkCheck, contentDescription = null) },
+            trailingIcon = {
+                if (input.isNotEmpty()) {
+                    IconButton(onClick = { onInputChange("") }) {
+                        Icon(Icons.Default.Close, contentDescription = stringResource(R.string.clear))
+                    }
+                }
+            },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+            keyboardActions = KeyboardActions(onDone = { onCalculate() })
+        )
+
+        Button(
+            onClick = onCalculate,
+            modifier = Modifier.fillMaxWidth(),
+            enabled = canCalculate
+        ) {
+            Icon(Icons.Default.Calculate, contentDescription = null, modifier = Modifier.size(18.dp))
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(stringResource(R.string.subnet_calculate_button))
+        }
+
+        SubnetExampleChips(onExampleSelected = onExampleSelected)
+    }
+}
+
+// ── Range input panel ─────────────────────────────────────────────────────────
+
+@Composable
+private fun SubnetRangeInputs(
+    minIp: String,
+    maxIp: String,
+    onMinIpChange: (String) -> Unit,
+    onMaxIpChange: (String) -> Unit,
+    onCalculate: () -> Unit,
+    canCalculate: Boolean
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        OutlinedTextField(
+            value = minIp,
+            onValueChange = onMinIpChange,
+            modifier = Modifier.fillMaxWidth(),
+            label = { Text(stringResource(R.string.subnet_min_ip_label)) },
+            placeholder = { Text(stringResource(R.string.subnet_min_ip_placeholder)) },
+            leadingIcon = { Icon(Icons.Default.NetworkCheck, contentDescription = null) },
+            trailingIcon = {
+                if (minIp.isNotEmpty()) {
+                    IconButton(onClick = { onMinIpChange("") }) {
+                        Icon(Icons.Default.Close, contentDescription = stringResource(R.string.clear))
+                    }
+                }
+            },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next)
+        )
+
+        OutlinedTextField(
+            value = maxIp,
+            onValueChange = onMaxIpChange,
+            modifier = Modifier.fillMaxWidth(),
+            label = { Text(stringResource(R.string.subnet_max_ip_label)) },
+            placeholder = { Text(stringResource(R.string.subnet_max_ip_placeholder)) },
+            leadingIcon = { Icon(Icons.Default.NetworkCheck, contentDescription = null) },
+            trailingIcon = {
+                if (maxIp.isNotEmpty()) {
+                    IconButton(onClick = { onMaxIpChange("") }) {
+                        Icon(Icons.Default.Close, contentDescription = stringResource(R.string.clear))
+                    }
+                }
+            },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+            keyboardActions = KeyboardActions(onDone = { onCalculate() })
+        )
+
+        Button(
+            onClick = onCalculate,
+            modifier = Modifier.fillMaxWidth(),
+            enabled = canCalculate
+        ) {
+            Icon(Icons.Default.Calculate, contentDescription = null, modifier = Modifier.size(18.dp))
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(stringResource(R.string.subnet_range_calculate_button))
         }
     }
 }
@@ -185,7 +322,7 @@ private fun SubnetExampleChips(onExampleSelected: (String) -> Unit) {
 // ── Idle card ─────────────────────────────────────────────────────────────────
 
 @Composable
-private fun SubnetIdleCard() {
+private fun SubnetIdleCard(isRangeMode: Boolean) {
     ElevatedCard(modifier = Modifier.fillMaxWidth()) {
         Column(
             modifier = Modifier
@@ -201,12 +338,16 @@ private fun SubnetIdleCard() {
                 tint = MaterialTheme.colorScheme.primary
             )
             Text(
-                text = stringResource(R.string.subnet_idle_title),
+                text = stringResource(
+                    if (isRangeMode) R.string.subnet_range_idle_title else R.string.subnet_idle_title
+                ),
                 style = MaterialTheme.typography.titleMedium,
                 textAlign = TextAlign.Center
             )
             Text(
-                text = stringResource(R.string.subnet_idle_body),
+                text = stringResource(
+                    if (isRangeMode) R.string.subnet_range_idle_body else R.string.subnet_idle_body
+                ),
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 textAlign = TextAlign.Center
@@ -259,10 +400,56 @@ private fun SubnetErrorCard(message: String, onRetry: () -> Unit) {
 @Composable
 private fun SubnetResultContent(info: SubnetInfo) {
     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        if (!info.inputIsAligned) {
+            SubnetAlignmentWarning(info)
+        }
         SubnetOverviewCard(info)
         SubnetBinaryVisualizerCard(info)
         SubnetNotationsCard(info)
         SubnetPropertiesCard(info)
+    }
+}
+
+// ── Alignment warning card ────────────────────────────────────────────────────
+
+@Composable
+private fun SubnetAlignmentWarning(info: SubnetInfo) {
+    OutlinedCard(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.outlinedCardColors(
+            containerColor = MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.6f)
+        )
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.Top
+        ) {
+            Icon(
+                Icons.Default.Warning,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.error,
+                modifier = Modifier.size(20.dp)
+            )
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Text(
+                    text = stringResource(R.string.subnet_alignment_warning_title),
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onErrorContainer,
+                    fontWeight = FontWeight.SemiBold
+                )
+                Text(
+                    text = stringResource(
+                        R.string.subnet_alignment_warning_body,
+                        info.inputIp,
+                        info.prefixLength,
+                        info.networkAddress
+                    ),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onErrorContainer
+                )
+            }
+        }
     }
 }
 
@@ -310,19 +497,23 @@ private fun SubnetOverviewCard(info: SubnetInfo) {
             Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
                 SubnetInfoRow(
                     label = stringResource(R.string.subnet_network_address),
-                    value = info.networkAddress
+                    value = info.networkAddress,
+                    tooltip = stringResource(R.string.tooltip_network_address)
                 )
                 SubnetInfoRow(
                     label = stringResource(R.string.subnet_broadcast),
-                    value = info.broadcastAddress
+                    value = info.broadcastAddress,
+                    tooltip = stringResource(R.string.tooltip_broadcast)
                 )
                 SubnetInfoRow(
                     label = stringResource(R.string.subnet_first_host),
-                    value = info.firstHost
+                    value = info.firstHost,
+                    tooltip = stringResource(R.string.tooltip_first_host)
                 )
                 SubnetInfoRow(
                     label = stringResource(R.string.subnet_last_host),
-                    value = info.lastHost
+                    value = info.lastHost,
+                    tooltip = stringResource(R.string.tooltip_last_host)
                 )
                 SubnetInfoRow(
                     label = stringResource(R.string.subnet_total_hosts),
@@ -330,7 +521,8 @@ private fun SubnetOverviewCard(info: SubnetInfo) {
                 )
                 SubnetInfoRow(
                     label = stringResource(R.string.subnet_usable_hosts),
-                    value = formatHostCount(info.usableHosts)
+                    value = formatHostCount(info.usableHosts),
+                    tooltip = stringResource(R.string.tooltip_usable_hosts)
                 )
             }
         }
@@ -483,7 +675,8 @@ private fun SubnetNotationsCard(info: SubnetInfo) {
             SubnetInfoRow(
                 label = stringResource(R.string.subnet_notation_cidr),
                 value = info.cidrNotation,
-                monospace = true
+                monospace = true,
+                tooltip = stringResource(R.string.tooltip_cidr)
             )
             SubnetInfoRow(
                 label = stringResource(R.string.subnet_notation_mask),
@@ -493,7 +686,8 @@ private fun SubnetNotationsCard(info: SubnetInfo) {
             SubnetInfoRow(
                 label = stringResource(R.string.subnet_notation_wildcard),
                 value = info.wildcardMask,
-                monospace = true
+                monospace = true,
+                tooltip = stringResource(R.string.tooltip_wildcard)
             )
             SubnetInfoRow(
                 label = stringResource(R.string.subnet_notation_hex),
@@ -522,21 +716,13 @@ private fun SubnetPropertiesCard(info: SubnetInfo) {
             HorizontalDivider()
 
             // IP Class badge
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
+            SubnetInfoRow(
+                label = stringResource(R.string.subnet_ip_class),
+                tooltip = stringResource(R.string.tooltip_ip_class)
             ) {
-                Text(
-                    text = stringResource(R.string.subnet_ip_class),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.weight(0.5f)
-                )
                 Surface(
                     shape = RoundedCornerShape(8.dp),
-                    color = MaterialTheme.colorScheme.primaryContainer,
-                    modifier = Modifier.weight(0.5f)
+                    color = MaterialTheme.colorScheme.primaryContainer
                 ) {
                     Text(
                         text = stringResource(R.string.subnet_class_label, info.ipClass),
@@ -550,56 +736,43 @@ private fun SubnetPropertiesCard(info: SubnetInfo) {
             }
 
             // Private / Public badge
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
+            SubnetInfoRow(
+                label = stringResource(R.string.subnet_scope),
+                tooltip = stringResource(R.string.tooltip_scope)
             ) {
-                Text(
-                    text = stringResource(R.string.subnet_scope),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.weight(0.5f)
-                )
-                Row(
-                    modifier = Modifier.weight(0.5f),
-                    horizontalArrangement = Arrangement.End,
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    val (scopeIcon, scopeLabel, scopeColor, scopeContainerColor) = if (info.isPrivate) {
-                        Quad(
-                            Icons.Default.Lock,
-                            stringResource(R.string.subnet_scope_private),
-                            MaterialTheme.colorScheme.onSecondaryContainer,
-                            MaterialTheme.colorScheme.secondaryContainer
+                val (scopeIcon, scopeLabel, scopeColor, scopeContainerColor) = if (info.isPrivate) {
+                    Quad(
+                        Icons.Default.Lock,
+                        stringResource(R.string.subnet_scope_private),
+                        MaterialTheme.colorScheme.onSecondaryContainer,
+                        MaterialTheme.colorScheme.secondaryContainer
+                    )
+                } else {
+                    Quad(
+                        Icons.Default.Public,
+                        stringResource(R.string.subnet_scope_public),
+                        MaterialTheme.colorScheme.onTertiaryContainer,
+                        MaterialTheme.colorScheme.tertiaryContainer
+                    )
+                }
+                Surface(shape = RoundedCornerShape(8.dp), color = scopeContainerColor) {
+                    Row(
+                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(4.dp)
+                    ) {
+                        Icon(
+                            scopeIcon,
+                            contentDescription = null,
+                            modifier = Modifier.size(14.dp),
+                            tint = scopeColor
                         )
-                    } else {
-                        Quad(
-                            Icons.Default.Public,
-                            stringResource(R.string.subnet_scope_public),
-                            MaterialTheme.colorScheme.onTertiaryContainer,
-                            MaterialTheme.colorScheme.tertiaryContainer
+                        Text(
+                            text = scopeLabel,
+                            style = MaterialTheme.typography.labelLarge,
+                            color = scopeColor,
+                            fontWeight = FontWeight.SemiBold
                         )
-                    }
-                    Surface(shape = RoundedCornerShape(8.dp), color = scopeContainerColor) {
-                        Row(
-                            modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.spacedBy(4.dp)
-                        ) {
-                            Icon(
-                                scopeIcon,
-                                contentDescription = null,
-                                modifier = Modifier.size(14.dp),
-                                tint = scopeColor
-                            )
-                            Text(
-                                text = scopeLabel,
-                                style = MaterialTheme.typography.labelLarge,
-                                color = scopeColor,
-                                fontWeight = FontWeight.SemiBold
-                            )
-                        }
                     }
                 }
             }
@@ -618,26 +791,76 @@ private fun SubnetPropertiesCard(info: SubnetInfo) {
 
 // ── Small helpers ─────────────────────────────────────────────────────────────
 
+/**
+ * Row with label on the left, arbitrary content on the right, and an optional tooltip
+ * info icon next to the label. Long-press the (i) icon to see the tooltip.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun SubnetInfoRow(label: String, value: String, monospace: Boolean = false) {
+private fun SubnetInfoRow(
+    label: String,
+    tooltip: String? = null,
+    content: @Composable () -> Unit
+) {
     Row(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.Top
+        verticalAlignment = Alignment.CenterVertically
     ) {
-        Text(
-            text = label,
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.weight(0.45f)
-        )
+        Row(
+            modifier = Modifier.weight(0.5f),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(2.dp)
+        ) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            if (tooltip != null) {
+                val tooltipState = rememberTooltipState(isPersistent = true)
+                TooltipBox(
+                    positionProvider = TooltipDefaults.rememberRichTooltipPositionProvider(),
+                    tooltip = {
+                        PlainTooltip {
+                            Text(
+                                text = tooltip,
+                                style = MaterialTheme.typography.bodySmall
+                            )
+                        }
+                    },
+                    state = tooltipState
+                ) {
+                    Icon(
+                        Icons.Default.Info,
+                        contentDescription = "Info",
+                        modifier = Modifier.size(14.dp),
+                        tint = MaterialTheme.colorScheme.primary.copy(alpha = 0.7f)
+                    )
+                }
+            }
+        }
+        Box(modifier = Modifier.weight(0.5f), contentAlignment = Alignment.CenterEnd) {
+            content()
+        }
+    }
+}
+
+/** Convenience overload for rows with a plain text value. */
+@Composable
+private fun SubnetInfoRow(
+    label: String,
+    value: String,
+    monospace: Boolean = false,
+    tooltip: String? = null
+) {
+    SubnetInfoRow(label = label, tooltip = tooltip) {
         Text(
             text = value,
             style = if (monospace)
                 MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Monospace)
             else
                 MaterialTheme.typography.bodyMedium,
-            modifier = Modifier.weight(0.55f),
             textAlign = TextAlign.End,
             fontWeight = FontWeight.Medium
         )

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/subnet/SubnetCalculatorViewModel.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/subnet/SubnetCalculatorViewModel.kt
@@ -16,6 +16,9 @@ data class SubnetCalculatorUiState(
     val input: String = "",
     val result: SubnetInfo? = null,
     val error: String? = null,
+    val isRangeMode: Boolean = false,
+    val minIpInput: String = "",
+    val maxIpInput: String = "",
 )
 
 @HiltViewModel
@@ -45,5 +48,34 @@ class SubnetCalculatorViewModel @Inject constructor(
     fun setExample(example: String) {
         _uiState.value = SubnetCalculatorUiState(input = example)
         calculate()
+    }
+
+    fun toggleMode() {
+        _uiState.value = _uiState.value.copy(
+            isRangeMode = !_uiState.value.isRangeMode,
+            result = null,
+            error = null
+        )
+    }
+
+    fun onMinIpChange(value: String) {
+        _uiState.value = _uiState.value.copy(minIpInput = value, error = null)
+    }
+
+    fun onMaxIpChange(value: String) {
+        _uiState.value = _uiState.value.copy(maxIpInput = value, error = null)
+    }
+
+    fun calculateRange() {
+        val min = _uiState.value.minIpInput.trim()
+        val max = _uiState.value.maxIpInput.trim()
+        if (min.isBlank() || max.isBlank()) return
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(result = null, error = null)
+            when (val res = useCase.invokeRange(min, max)) {
+                is NetworkResult.Success -> _uiState.value = _uiState.value.copy(result = res.data)
+                is NetworkResult.Error   -> _uiState.value = _uiState.value.copy(error = res.message)
+            }
+        }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -534,5 +534,29 @@
     <string name="subnet_prefix_of_32">%1$d / 32</string>
     <string name="subnet_host_bit_count">Host bits</string>
     <string name="subnet_bits_count">%1$d bits</string>
+    <!-- Mode toggle -->
+    <string name="subnet_mode_cidr">CIDR / Mask</string>
+    <string name="subnet_mode_range">IP Range</string>
+    <!-- Range mode inputs -->
+    <string name="subnet_range_idle_title">Enter an IP range</string>
+    <string name="subnet_range_idle_body">Enter the smallest and largest IP addresses you need. The calculator finds the tightest subnet that covers both.</string>
+    <string name="subnet_min_ip_label">Minimum IP</string>
+    <string name="subnet_min_ip_placeholder">e.g. 10.0.70.1</string>
+    <string name="subnet_max_ip_label">Maximum IP</string>
+    <string name="subnet_max_ip_placeholder">e.g. 10.0.71.254</string>
+    <string name="subnet_range_calculate_button">Find Subnet</string>
+    <!-- Alignment warning -->
+    <string name="subnet_alignment_warning_title">IP Not on Network Boundary</string>
+    <string name="subnet_alignment_warning_body">%1$s is not a valid network address for /%2$d. The actual network starts at %3$s. Cloud providers like Azure require the exact network address in subnet definitions.</string>
+    <!-- Tooltips -->
+    <string name="tooltip_network_address">The network address is the first address in a subnet, with all host bits set to 0. It identifies the subnet itself and cannot be assigned to any device. Example: in 192.168.1.0/24 the network address is 192.168.1.0.</string>
+    <string name="tooltip_broadcast">The broadcast address is the last address in a subnet, with all host bits set to 1. Packets sent here are delivered to every device in the subnet. Example: in 192.168.1.0/24 the broadcast is 192.168.1.255.</string>
+    <string name="tooltip_first_host">The first usable IP address — one above the network address. This is the lowest address you can assign to a device.</string>
+    <string name="tooltip_last_host">The last usable IP address — one below the broadcast address. This is the highest address you can assign to a device.</string>
+    <string name="tooltip_usable_hosts">The count of addresses that can be assigned to devices. Always (2^host_bits − 2) because the network and broadcast addresses are reserved.</string>
+    <string name="tooltip_wildcard">The wildcard mask is the bitwise inverse of the subnet mask. Bits set to 1 are "don\'t care" bits. Used in ACLs and OSPF configurations.</string>
+    <string name="tooltip_cidr">Classless Inter-Domain Routing notation combines an IP address with a prefix length (the number of network bits). Example: 192.168.1.0/24 means 24 network bits and 8 host bits.</string>
+    <string name="tooltip_ip_class">A legacy classification of IPv4 ranges before CIDR replaced it. Class A covers 0–127, B covers 128–191, C covers 192–223. Class D is multicast, E is reserved.</string>
+    <string name="tooltip_scope">Whether the address falls within RFC 1918 private ranges (10.x, 172.16–31.x, 192.168.x) or is publicly routable on the internet.</string>
 
 </resources>

--- a/core-domain/src/main/kotlin/net/aieat/netswissknife/core/domain/SubnetCalculatorUseCase.kt
+++ b/core-domain/src/main/kotlin/net/aieat/netswissknife/core/domain/SubnetCalculatorUseCase.kt
@@ -9,4 +9,7 @@ class SubnetCalculatorUseCase(
 ) {
     suspend operator fun invoke(params: String): NetworkResult<SubnetInfo> =
         repository.calculate(params)
+
+    suspend fun invokeRange(minIp: String, maxIp: String): NetworkResult<SubnetInfo> =
+        repository.calculateRange(minIp, maxIp)
 }

--- a/core-domain/src/test/kotlin/net/aieat/netswissknife/core/domain/SubnetCalculatorUseCaseTest.kt
+++ b/core-domain/src/test/kotlin/net/aieat/netswissknife/core/domain/SubnetCalculatorUseCaseTest.kt
@@ -36,6 +36,7 @@ class SubnetCalculatorUseCaseTest {
             ipClass = "C",
             isPrivate = true,
             cidrNotation = "192.168.1.0/24",
+            inputIsAligned = false,
         )
         coEvery { repository.calculate("192.168.1.100/24") } returns NetworkResult.Success(expectedInfo)
 

--- a/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/subnet/SubnetCalculatorRepository.kt
+++ b/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/subnet/SubnetCalculatorRepository.kt
@@ -13,4 +13,10 @@ import net.aieat.netswissknife.core.network.NetworkResult
  */
 interface SubnetCalculatorRepository {
     fun calculate(input: String): NetworkResult<SubnetInfo>
+
+    /**
+     * Finds the smallest subnet that contains both [minIp] and [maxIp].
+     * Both arguments should be bare IPv4 addresses (no prefix).
+     */
+    fun calculateRange(minIp: String, maxIp: String): NetworkResult<SubnetInfo>
 }

--- a/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/subnet/SubnetCalculatorRepositoryImpl.kt
+++ b/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/subnet/SubnetCalculatorRepositoryImpl.kt
@@ -42,12 +42,31 @@ class SubnetCalculatorRepositoryImpl : SubnetCalculatorRepository {
                 ipClass = classOf(ipLong),
                 isPrivate = isPrivate(ipLong),
                 cidrNotation = "$networkAddress/$prefix",
+                inputIsAligned = (ipLong == networkLong),
             )
         )
     } catch (e: IllegalArgumentException) {
         NetworkResult.Error(e.message ?: "Invalid input")
     } catch (e: Exception) {
         NetworkResult.Error("Invalid input: ${e.message}")
+    }
+
+    override fun calculateRange(minIp: String, maxIp: String): NetworkResult<SubnetInfo> = try {
+        val minLong = parseIpToLong(minIp.trim())
+        val maxLong = parseIpToLong(maxIp.trim())
+        require(minLong <= maxLong) { "Minimum IP must be ≤ maximum IP" }
+        val diff = minLong xor maxLong
+        // Number of bits needed to represent the difference determines host bit count
+        val hostBitsNeeded = Long.SIZE_BITS - diff.countLeadingZeroBits()
+        require(hostBitsNeeded <= 32) { "IP range too large for a valid IPv4 subnet" }
+        val prefix = 32 - hostBitsNeeded
+        // Use the masked minLong so the result is always on the network boundary
+        val networkIp = longToIp(minLong and prefixToMask(prefix))
+        calculate("$networkIp/$prefix")
+    } catch (e: IllegalArgumentException) {
+        NetworkResult.Error(e.message ?: "Invalid IP range")
+    } catch (e: Exception) {
+        NetworkResult.Error("Invalid IP range: ${e.message}")
     }
 
     // ── Parsing ────────────────────────────────────────────────────────────────

--- a/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/subnet/SubnetModels.kt
+++ b/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/subnet/SubnetModels.kt
@@ -40,4 +40,10 @@ data class SubnetInfo(
     val isPrivate: Boolean,
     /** Canonical CIDR notation of the network, e.g. "192.168.1.0/24". */
     val cidrNotation: String,
+    /**
+     * True if the original input IP is already on the network boundary (host bits all zero).
+     * False when the user typed e.g. "10.0.71.0/23" but the real network is "10.0.70.0/23".
+     * Cloud providers like Azure require subnet addresses to be on the network boundary.
+     */
+    val inputIsAligned: Boolean,
 )

--- a/core-network/src/test/kotlin/net/aieat/netswissknife/core/network/subnet/SubnetCalculatorRepositoryTest.kt
+++ b/core-network/src/test/kotlin/net/aieat/netswissknife/core/network/subnet/SubnetCalculatorRepositoryTest.kt
@@ -184,4 +184,79 @@ class SubnetCalculatorRepositoryTest {
         val info = (result as NetworkResult.Success).data
         assertEquals("0xFFFFFF00", info.hexMask)
     }
+
+    // ── Alignment detection ────────────────────────────────────────────────────
+
+    @Test
+    fun `calculate marks aligned when input IP is already on network boundary`() {
+        val result = repo.calculate("192.168.1.0/24")
+        assertTrue(result is NetworkResult.Success)
+        val info = (result as NetworkResult.Success).data
+        assertTrue(info.inputIsAligned)
+    }
+
+    @Test
+    fun `calculate marks misaligned when input IP is not on network boundary`() {
+        val result = repo.calculate("10.0.71.0/23")
+        assertTrue(result is NetworkResult.Success)
+        val info = (result as NetworkResult.Success).data
+        assertEquals("10.0.70.0", info.networkAddress)
+        assertTrue(!info.inputIsAligned)
+    }
+
+    @Test
+    fun `calculate marks bare IP as aligned for slash 32`() {
+        val result = repo.calculate("192.168.1.1")
+        assertTrue(result is NetworkResult.Success)
+        val info = (result as NetworkResult.Success).data
+        assertTrue(info.inputIsAligned)
+    }
+
+    // ── Range calculation ──────────────────────────────────────────────────────
+
+    @Test
+    fun `calculateRange returns smallest subnet containing both IPs in same slash 24`() {
+        val result = repo.calculateRange("192.168.1.10", "192.168.1.200")
+        assertTrue(result is NetworkResult.Success)
+        val info = (result as NetworkResult.Success).data
+        assertEquals("192.168.1.0", info.networkAddress)
+        assertEquals(24, info.prefixLength)
+    }
+
+    @Test
+    fun `calculateRange returns slash 23 for IPs spanning two class C networks`() {
+        val result = repo.calculateRange("10.0.70.1", "10.0.71.254")
+        assertTrue(result is NetworkResult.Success)
+        val info = (result as NetworkResult.Success).data
+        assertEquals("10.0.70.0", info.networkAddress)
+        assertEquals(23, info.prefixLength)
+    }
+
+    @Test
+    fun `calculateRange returns slash 32 for identical IPs`() {
+        val result = repo.calculateRange("192.168.1.5", "192.168.1.5")
+        assertTrue(result is NetworkResult.Success)
+        val info = (result as NetworkResult.Success).data
+        assertEquals(32, info.prefixLength)
+    }
+
+    @Test
+    fun `calculateRange returns error when min IP is greater than max IP`() {
+        val result = repo.calculateRange("192.168.1.100", "192.168.1.1")
+        assertTrue(result is NetworkResult.Error)
+    }
+
+    @Test
+    fun `calculateRange returns error for invalid IP`() {
+        val result = repo.calculateRange("999.0.0.1", "192.168.1.1")
+        assertTrue(result is NetworkResult.Error)
+    }
+
+    @Test
+    fun `calculateRange result always has inputIsAligned true`() {
+        val result = repo.calculateRange("10.0.70.1", "10.0.71.254")
+        assertTrue(result is NetworkResult.Success)
+        val info = (result as NetworkResult.Success).data
+        assertTrue(info.inputIsAligned)
+    }
 }


### PR DESCRIPTION
## Summary

- **Alignment validation** — detects when the input IP is not on the network boundary (e.g. `10.0.71.0/23` where the real boundary is `10.0.70.0/23`) and shows a clear warning card. Cloud providers like Azure reject non-aligned subnet addresses, so the calculator now surfaces this immediately instead of silently accepting it.
- **IP Range → Subnet mode** — new segmented toggle switches the input card to "IP Range" mode where you enter a minimum and maximum IP and the calculator finds the smallest subnet that covers both (e.g. `10.0.70.1`–`10.0.71.254` → `10.0.70.0/23`).
- **Tooltips** — a small ⓘ icon appears next to key fields; long-pressing it shows a plain-English explanation of: network address vs. IP address, broadcast address, first/last host, usable host count, CIDR notation, wildcard mask, IP class, and scope.

## Technical changes

- `SubnetInfo` — new `inputIsAligned: Boolean` field
- `SubnetCalculatorRepository` — new `calculateRange(minIp, maxIp)` method
- `SubnetCalculatorRepositoryImpl` — implements `calculateRange` using XOR-based host-bit counting; sets `inputIsAligned`
- `SubnetCalculatorUseCase` — new `invokeRange(minIp, maxIp)` suspend fun
- `SubnetCalculatorViewModel` — range mode state (`isRangeMode`, `minIpInput`, `maxIpInput`) + `toggleMode`, `onMinIpChange`, `onMaxIpChange`, `calculateRange`
- `SubnetCalculatorScreen` — segmented mode toggle, range input panel, alignment warning card, tooltip-aware `SubnetInfoRow` overloads using Material3 `TooltipBox`/`PlainTooltip`

## Test plan

- [ ] Enter `10.0.71.0/23` in CIDR mode → warning banner appears showing boundary is `10.0.70.0`
- [ ] Enter `192.168.1.0/24` → no warning (already aligned)
- [ ] Switch to IP Range mode → two IP fields appear
- [ ] Enter `10.0.70.1` / `10.0.71.254` → result shows `10.0.70.0/23`
- [ ] Enter same IP in both range fields → `/32` result
- [ ] Enter max IP smaller than min IP → error card shown
- [ ] Long-press ⓘ next to "Network address" → tooltip explains difference from regular IP
- [ ] All existing subnet calculator features unchanged
- [ ] `./gradlew :core-network:test :core-domain:test` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)