### PR TITLE
feat: LAN scanner search, filter, and layout improvements

### DIFF
--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/lan/LanScanScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/lan/LanScanScreen.kt
@@ -56,6 +56,7 @@ import androidx.compose.material.icons.filled.Lan
 import androidx.compose.material.icons.filled.NetworkCheck
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Router
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.SmartToy
 import androidx.compose.material.icons.filled.Stop
 import androidx.compose.material.icons.filled.Wifi
@@ -63,6 +64,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.FilledTonalIconButton
 import androidx.compose.material3.HorizontalDivider
@@ -109,6 +111,7 @@ fun LanScreen(viewModel: LanScanViewModel = hiltViewModel()) {
     val timeoutMs by viewModel.timeoutMs.collectAsState()
     val concurrency by viewModel.concurrency.collectAsState()
     val isSubnetLoading by viewModel.isSubnetLoading.collectAsState()
+    val searchQuery by viewModel.searchQuery.collectAsState()
 
     var visible by remember { mutableStateOf(false) }
     LaunchedEffect(Unit) { visible = true }
@@ -155,6 +158,8 @@ fun LanScreen(viewModel: LanScanViewModel = hiltViewModel()) {
                     is LanScanUiState.Finished -> LanFinishedContent(
                         summary = state.summary,
                         expandedHostIp = state.expandedHostIp,
+                        searchQuery = searchQuery,
+                        onSearchQueryChange = viewModel::onSearchQueryChange,
                         onToggleExpand = viewModel::onToggleHostExpanded,
                         onClear = viewModel::onClear,
                         onRescan = viewModel::startScan,
@@ -506,14 +511,53 @@ private fun PulsingIndicator() {
 
 // ── Finished ──────────────────────────────────────────────────────────────────
 
+private enum class HostFilter { All, Gateway, HasPorts }
+
+@Composable
+private fun HostFilterChips(activeFilter: HostFilter, onFilterChange: (HostFilter) -> Unit) {
+    val labels = mapOf(
+        HostFilter.All to R.string.lan_filter_all,
+        HostFilter.Gateway to R.string.lan_filter_gateway,
+        HostFilter.HasPorts to R.string.lan_filter_has_ports,
+    )
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        labels.forEach { (filter, labelRes) ->
+            FilterChip(
+                selected = activeFilter == filter,
+                onClick = { onFilterChange(filter) },
+                label = { Text(stringResource(labelRes)) },
+            )
+        }
+    }
+}
+
 @Composable
 private fun LanFinishedContent(
     summary: LanScanSummary,
     expandedHostIp: String?,
+    searchQuery: String,
+    onSearchQueryChange: (String) -> Unit,
     onToggleExpand: (String) -> Unit,
     onClear: () -> Unit,
     onRescan: () -> Unit,
 ) {
+    var activeFilter by remember { mutableStateOf(HostFilter.All) }
+
+    val filteredHosts = remember(summary.hosts, searchQuery, activeFilter) {
+        summary.hosts.filter { host ->
+            val passesFilter = when (activeFilter) {
+                HostFilter.All -> true
+                HostFilter.Gateway -> host.isGateway
+                HostFilter.HasPorts -> host.openPorts.isNotEmpty()
+            }
+            val passesSearch = searchQuery.isBlank() ||
+                host.ip.contains(searchQuery, ignoreCase = true) ||
+                host.hostname?.contains(searchQuery, ignoreCase = true) == true ||
+                host.vendor?.contains(searchQuery, ignoreCase = true) == true
+            passesFilter && passesSearch
+        }
+    }
+
     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
         // Summary stats card
         ElevatedCard(modifier = Modifier.fillMaxWidth()) {
@@ -546,7 +590,6 @@ private fun LanFinishedContent(
                     )
                 }
 
-                // Stats grid
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.SpaceEvenly,
@@ -570,7 +613,6 @@ private fun LanFinishedContent(
                     )
                 }
 
-                // Action buttons
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -595,7 +637,6 @@ private fun LanFinishedContent(
             }
         }
 
-        // Host list
         if (summary.hosts.isEmpty()) {
             OutlinedCard(modifier = Modifier.fillMaxWidth()) {
                 Box(
@@ -612,24 +653,61 @@ private fun LanFinishedContent(
                 }
             }
         } else {
+            NetworkTopologyCard(hosts = summary.hosts)
+
+            OutlinedTextField(
+                value = searchQuery,
+                onValueChange = onSearchQueryChange,
+                placeholder = { Text(stringResource(R.string.lan_search_placeholder)) },
+                leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
+                trailingIcon = {
+                    if (searchQuery.isNotEmpty()) {
+                        IconButton(onClick = { onSearchQueryChange("") }) {
+                            Icon(Icons.Default.Clear, contentDescription = stringResource(R.string.clear))
+                        }
+                    }
+                },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            HostFilterChips(activeFilter = activeFilter, onFilterChange = { activeFilter = it })
+
+            val headerText = if (searchQuery.isNotBlank() || activeFilter != HostFilter.All) {
+                stringResource(R.string.lan_hosts_filtered_header, filteredHosts.size, summary.hosts.size)
+            } else {
+                stringResource(R.string.lan_hosts_header, summary.hosts.size)
+            }
             Text(
-                text = stringResource(R.string.lan_hosts_header, summary.hosts.size),
+                text = headerText,
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.SemiBold,
                 modifier = Modifier.padding(horizontal = 4.dp),
             )
 
-            // Network topology mini-map
-            NetworkTopologyCard(hosts = summary.hosts)
-
-            Spacer(Modifier.height(4.dp))
-
-            summary.hosts.forEach { host ->
-                HostCard(
-                    host = host,
-                    expanded = host.ip == expandedHostIp,
-                    onClick = { onToggleExpand(host.ip) },
-                )
+            if (filteredHosts.isEmpty()) {
+                OutlinedCard(modifier = Modifier.fillMaxWidth()) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(32.dp),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Text(
+                            text = stringResource(R.string.lan_no_search_results),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            } else {
+                filteredHosts.forEach { host ->
+                    HostCard(
+                        host = host,
+                        expanded = host.ip == expandedHostIp,
+                        onClick = { onToggleExpand(host.ip) },
+                    )
+                }
             }
         }
     }

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/lan/LanScanViewModel.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/lan/LanScanViewModel.kt
@@ -63,6 +63,9 @@ class LanScanViewModel @Inject constructor(
     private val _isSubnetLoading = MutableStateFlow(false)
     val isSubnetLoading: StateFlow<Boolean> = _isSubnetLoading.asStateFlow()
 
+    private val _searchQuery = MutableStateFlow("")
+    val searchQuery: StateFlow<String> = _searchQuery.asStateFlow()
+
     private var scanJob: Job? = null
 
     init {
@@ -76,6 +79,8 @@ class LanScanViewModel @Inject constructor(
     fun onTimeoutChange(value: Int) { _timeoutMs.value = value }
 
     fun onConcurrencyChange(value: Int) { _concurrency.value = value }
+
+    fun onSearchQueryChange(value: String) { _searchQuery.value = value }
 
     /** Detects the current subnet from active network interfaces on an IO thread. */
     fun refreshSubnet() {
@@ -189,6 +194,7 @@ class LanScanViewModel @Inject constructor(
     fun onClear() {
         AppLogger.d(TAG, "onClear")
         scanJob?.cancel()
+        _searchQuery.value = ""
         _uiState.value = LanScanUiState.Idle
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -198,6 +198,14 @@
     <string name="lan_open_ports_title">Open Ports (%1$d)</string>
     <string name="lan_no_open_ports">None detected</string>
 
+    <!-- LAN Search / Filter -->
+    <string name="lan_search_placeholder">Search IP, hostname, vendor…</string>
+    <string name="lan_filter_all">All</string>
+    <string name="lan_filter_gateway">Gateway</string>
+    <string name="lan_filter_has_ports">Has Ports</string>
+    <string name="lan_hosts_filtered_header">Results (%1$d of %2$d)</string>
+    <string name="lan_no_search_results">No devices match your search</string>
+
     <!-- Debug Log Screen -->
     <string name="debug_log_title">Debug Logs</string>
     <string name="debug_log_subtitle">Internal app diagnostics and crash traces</string>


### PR DESCRIPTION
## Summary

- **Search bar** in scan results — filters by IP, hostname, or vendor as you type, with a clear button
- **Filter chips** (All / Gateway / Has Ports) let users narrow the device list at a glance
- Filtered header shows `Results (N of M)` when a filter or search is active so total count isn't lost
- Network topology map now appears above the search bar for immediate visual context
- Single-pass filtering replaces two chained `.filter{}` iterations
- Extracted `HostFilterChips` composable to eliminate three near-identical `FilterChip` blocks
- Removed WHAT-comments that duplicated what the composable names already say

## Test plan

- [ ] Run a LAN scan and verify the topology map, search bar, and filter chips appear in results
- [ ] Type in search box — confirm IP, hostname, and vendor matches all work; clear button appears and clears
- [ ] Tap each filter chip (All / Gateway / Has Ports) — verify list updates and header shows filtered count
- [ ] Search + filter combined — confirm both predicates apply in a single pass
- [ ] Clear results → confirm search query resets; filter chip resets to All on new results
- [ ] Verify no-results state shows correct empty message for search vs. no-results-from-scan
- [ ] `./gradlew test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)