### PR TITLE
fix: call addRecent as direct suspend to fix CI flakiness

### DIFF
--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/lan/LanScanViewModel.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/lan/LanScanViewModel.kt
@@ -179,7 +179,7 @@ class LanScanViewModel @Inject constructor(
                             // subnets that immediately fail validation.
                             if (!savedToRecents) {
                                 savedToRecents = true
-                                launch { recentHostsRepository.addRecent(AppPreferenceKeys.RECENT_LAN_SUBNETS, params.subnet) }
+                                recentHostsRepository.addRecent(AppPreferenceKeys.RECENT_LAN_SUBNETS, params.subnet)
                             }
                             liveHosts.add(result.host)
                             _uiState.value = LanScanUiState.Scanning(

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/ping/PingViewModel.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/ping/PingViewModel.kt
@@ -162,7 +162,7 @@ class PingViewModel @Inject constructor(
                         // hosts that immediately fail validation.
                         if (!savedToRecents) {
                             savedToRecents = true
-                            launch { recentHostsRepository.addRecent(AppPreferenceKeys.RECENT_PING_HOSTS, trimmedHost) }
+                            recentHostsRepository.addRecent(AppPreferenceKeys.RECENT_PING_HOSTS, trimmedHost)
                         }
                         accumulatedPackets.add(result.packet)
                         _uiState.value = PingUiState.Running(


### PR DESCRIPTION
## Problem

The `addRecent` call inside `LanScanViewModel.startScan()` and `PingViewModel.startPing()` was wrapped in `launch {}`, creating a child coroutine that could complete **after** the `Finished`/`ScanComplete` state was set. In the CI environment, `coVerify` ran before the child completed, causing a deterministic test failure.

## Fix

Call `recentHostsRepository.addRecent()` as a direct suspend call inside the existing `scanJob`/`pingJob` coroutine instead of spawning a child `launch`. This ensures the write completes before the host is added to the live list and the state advances.

## Test

All 105 tests pass locally with `--rerun-tasks`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)