### PR TITLE
feat: continuous ping mode with rolling window and session log export

### DIFF
--- a/app/src/main/kotlin/net/aieat/netswissknife/app/di/PingModule.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/di/PingModule.kt
@@ -1,5 +1,6 @@
 package net.aieat.netswissknife.app.di
 
+import net.aieat.netswissknife.core.domain.ContinuousPingUseCase
 import net.aieat.netswissknife.core.domain.PingUseCase
 import net.aieat.netswissknife.core.network.ping.PingRepository
 import net.aieat.netswissknife.core.network.ping.PingRepositoryImpl
@@ -21,4 +22,9 @@ object PingModule {
     @Singleton
     fun providePingUseCase(repository: PingRepository): PingUseCase =
         PingUseCase(repository)
+
+    @Provides
+    @Singleton
+    fun provideContinuousPingUseCase(repository: PingRepository): ContinuousPingUseCase =
+        ContinuousPingUseCase(repository)
 }

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/PingScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/PingScreen.kt
@@ -1,5 +1,7 @@
 package net.aieat.netswissknife.app.ui.screens
 
+import android.app.Activity
+import android.view.WindowManager
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.LinearEasing
@@ -30,6 +32,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
@@ -39,6 +42,7 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AllInclusive
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.ExpandLess
@@ -63,14 +67,19 @@ import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -104,7 +113,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import net.aieat.netswissknife.app.R
 import net.aieat.netswissknife.app.ui.components.RecentHostsRow
 import net.aieat.netswissknife.app.ui.screens.ping.PingUiState
@@ -124,7 +135,28 @@ fun PingScreen(
     val count by viewModel.count.collectAsStateWithLifecycle()
     val timeoutMs by viewModel.timeoutMs.collectAsStateWithLifecycle()
     val packetSize by viewModel.packetSize.collectAsStateWithLifecycle()
+    val continuousMode by viewModel.continuousMode.collectAsStateWithLifecycle()
     val recentHosts by viewModel.recentHosts.collectAsStateWithLifecycle()
+
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    // Keep screen on during a continuous ping session.
+    val isRunningContinuous = uiState is PingUiState.Running && (uiState as PingUiState.Running).isContinuous
+    DisposableEffect(isRunningContinuous) {
+        val window = (context as? Activity)?.window
+        if (isRunningContinuous) window?.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        onDispose { window?.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON) }
+    }
+
+    // Stop continuous ping when the activity is backgrounded or the screen is locked (ON_STOP).
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_STOP) viewModel.onLifecycleStop()
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
 
     var visible by remember { mutableStateOf(false) }
     LaunchedEffect(Unit) { visible = true }
@@ -152,11 +184,13 @@ fun PingScreen(
                     timeoutMs = timeoutMs,
                     packetSize = packetSize,
                     isRunning = uiState is PingUiState.Running,
+                    continuousMode = continuousMode,
                     recentHosts = recentHosts,
                     onHostChange = viewModel::onHostChange,
                     onCountChange = viewModel::onCountChange,
                     onTimeoutChange = viewModel::onTimeoutChange,
                     onPacketSizeChange = viewModel::onPacketSizeChange,
+                    onToggleContinuous = viewModel::onToggleContinuous,
                     onStart = viewModel::startPing,
                     onStop = viewModel::onStop,
                     onRemoveRecentHost = viewModel::removeRecentHost,
@@ -270,11 +304,13 @@ private fun PingInputCard(
     timeoutMs: Int,
     packetSize: Int,
     isRunning: Boolean,
+    continuousMode: Boolean,
     recentHosts: List<String>,
     onHostChange: (String) -> Unit,
     onCountChange: (Int) -> Unit,
     onTimeoutChange: (Int) -> Unit,
     onPacketSizeChange: (Int) -> Unit,
+    onToggleContinuous: (Boolean) -> Unit,
     onStart: () -> Unit,
     onStop: () -> Unit,
     onRemoveRecentHost: (String) -> Unit,
@@ -323,15 +359,46 @@ private fun PingInputCard(
                 onClearAll = onClearRecentHosts
             )
 
-            // Count slider
-            PingSliderRow(
-                label = "${stringResource(R.string.ping_count_label)}: $count",
-                value = count.toFloat(),
-                valueRange = 1f..50f,
-                steps = 48,
-                onValueChange = { onCountChange(it.toInt()) },
-                enabled = !isRunning
-            )
+            // Continuous mode toggle
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        Icons.Default.AllInclusive,
+                        contentDescription = null,
+                        tint = if (continuousMode) MaterialTheme.colorScheme.primary
+                               else MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(18.dp)
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        text = stringResource(R.string.ping_continuous_label),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = if (continuousMode) MaterialTheme.colorScheme.primary
+                                else MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                Switch(
+                    checked = continuousMode,
+                    onCheckedChange = { if (!isRunning) onToggleContinuous(it) },
+                    enabled = !isRunning
+                )
+            }
+
+            // Count slider — hidden in continuous mode
+            if (!continuousMode) {
+                PingSliderRow(
+                    label = "${stringResource(R.string.ping_count_label)}: $count",
+                    value = count.toFloat(),
+                    valueRange = 1f..50f,
+                    steps = 48,
+                    onValueChange = { onCountChange(it.toInt()) },
+                    enabled = !isRunning
+                )
+            }
 
             // Timeout chips
             PingTimeoutRow(
@@ -489,7 +556,7 @@ private fun PingIdlePanel() {
 @Composable
 private fun PingRunningPanel(state: PingUiState.Running) {
     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-        // Progress card
+        // Progress / counter card
         ElevatedCard(modifier = Modifier.fillMaxWidth()) {
             Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 Row(
@@ -498,20 +565,33 @@ private fun PingRunningPanel(state: PingUiState.Running) {
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Text(
-                        text = stringResource(R.string.ping_running_title),
+                        text = if (state.isContinuous)
+                            stringResource(R.string.ping_continuous_running_title)
+                        else
+                            stringResource(R.string.ping_running_title),
                         style = MaterialTheme.typography.titleMedium,
                         fontWeight = FontWeight.SemiBold
                     )
-                    Text(
-                        text = stringResource(R.string.ping_progress_format, state.packets.size, state.totalCount),
-                        style = MaterialTheme.typography.labelMedium,
-                        color = MaterialTheme.colorScheme.primary
+                    if (state.isContinuous) {
+                        Text(
+                            text = stringResource(R.string.ping_pings_sent, state.pingsSent),
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.primary
+                        )
+                    } else {
+                        Text(
+                            text = stringResource(R.string.ping_progress_format, state.packets.size, state.totalCount),
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.primary
+                        )
+                    }
+                }
+                if (!state.isContinuous) {
+                    LinearProgressIndicator(
+                        progress = { state.packets.size.toFloat() / state.totalCount.coerceAtLeast(1) },
+                        modifier = Modifier.fillMaxWidth()
                     )
                 }
-                LinearProgressIndicator(
-                    progress = { state.packets.size.toFloat() / state.totalCount.coerceAtLeast(1) },
-                    modifier = Modifier.fillMaxWidth()
-                )
                 Text(
                     text = state.host,
                     style = MaterialTheme.typography.bodyMedium,
@@ -543,13 +623,14 @@ private fun PingRunningPanel(state: PingUiState.Running) {
             }
         }
 
-        // Live RTT chart
+        // Live RTT chart (rolling window in continuous mode)
         if (state.packets.any { it.rtTimeMs != null }) {
             RttChartCard(packets = state.packets)
         }
 
-        // Live packet list
+        // Live packet list — bounded to last 50 in continuous mode
         if (state.packets.isNotEmpty()) {
+            val displayPackets = if (state.isContinuous) state.packets.takeLast(50) else state.packets
             ElevatedCard(modifier = Modifier.fillMaxWidth()) {
                 Column(modifier = Modifier.padding(16.dp)) {
                     Text(
@@ -558,8 +639,8 @@ private fun PingRunningPanel(state: PingUiState.Running) {
                         fontWeight = FontWeight.SemiBold
                     )
                     Spacer(modifier = Modifier.height(8.dp))
-                    state.packets.forEach { packet ->
-                        PacketRow(packet)
+                    LazyColumn(modifier = Modifier.heightIn(max = 320.dp)) {
+                        items(displayPackets) { packet -> PacketRow(packet) }
                     }
                 }
             }
@@ -576,7 +657,7 @@ private fun PingFinishedPanel(
     onClear: () -> Unit
 ) {
     val clipboard = LocalClipboard.current
-    val clipScope = rememberCoroutineScope()
+    val coroutineScope = rememberCoroutineScope()
     val result = state.result
     val context = LocalContext.current
 
@@ -603,7 +684,7 @@ private fun PingFinishedPanel(
                         fontWeight = FontWeight.SemiBold
                     )
                     IconButton(onClick = {
-                        clipScope.launch { clipboard.setClipEntry(ClipEntry(ClipData.newPlainText("", buildCsvOutput(result)))) }
+                        coroutineScope.launch { clipboard.setClipEntry(ClipEntry(ClipData.newPlainText("", buildCsvOutput(result)))) }
                     }) {
                         Icon(Icons.Default.ContentCopy, contentDescription = stringResource(R.string.ping_copy_csv))
                     }
@@ -640,10 +721,26 @@ private fun PingFinishedPanel(
             }
             FilledTonalButton(
                 onClick = {
-                    context.shareText(
-                        text = buildCsvOutput(result),
-                        subject = context.getString(R.string.share_subject_ping, result.host)
-                    )
+                    val logFile = state.sessionLogFile
+                    if (logFile != null) {
+                        // Continuous session: read full log from file on IO then share
+                        coroutineScope.launch(Dispatchers.IO) {
+                            val text = runCatching { logFile.readText() }.getOrElse { "" }
+                            if (text.isNotEmpty()) {
+                                withContext(Dispatchers.Main) {
+                                    context.shareText(
+                                        text = text,
+                                        subject = context.getString(R.string.share_subject_ping, result.host)
+                                    )
+                                }
+                            }
+                        }
+                    } else {
+                        context.shareText(
+                            text = buildCsvOutput(result),
+                            subject = context.getString(R.string.share_subject_ping, result.host)
+                        )
+                    }
                 },
                 modifier = Modifier.weight(1f)
             ) {

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/ping/PingViewModel.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/ping/PingViewModel.kt
@@ -4,16 +4,10 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import net.aieat.netswissknife.app.data.AppPreferenceKeys
-import net.aieat.netswissknife.app.data.RecentHostsRepository
-import net.aieat.netswissknife.core.domain.PingFlowResult
-import net.aieat.netswissknife.core.domain.PingParams
-import net.aieat.netswissknife.core.domain.PingUseCase
-import net.aieat.netswissknife.core.network.ping.PingPacketResult
-import net.aieat.netswissknife.core.network.ping.PingResult
-import net.aieat.netswissknife.core.network.ping.PingStats
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -21,6 +15,19 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import net.aieat.netswissknife.app.data.AppPreferenceKeys
+import net.aieat.netswissknife.app.data.RecentHostsRepository
+import net.aieat.netswissknife.core.domain.ContinuousPingParams
+import net.aieat.netswissknife.core.domain.ContinuousPingUseCase
+import net.aieat.netswissknife.core.domain.PingFlowResult
+import net.aieat.netswissknife.core.domain.PingParams
+import net.aieat.netswissknife.core.domain.PingSessionLogger
+import net.aieat.netswissknife.core.domain.PingUseCase
+import net.aieat.netswissknife.core.network.ping.PingPacketResult
+import net.aieat.netswissknife.core.network.ping.PingResult
+import net.aieat.netswissknife.core.network.ping.PingStats
+import net.aieat.netswissknife.core.network.ping.PingStatus
+import java.io.File
 import javax.inject.Inject
 
 /** All possible states for the Ping UI. */
@@ -29,11 +36,14 @@ sealed interface PingUiState {
     data class Running(
         val host: String,
         val packets: List<PingPacketResult>,
-        val totalCount: Int
+        val totalCount: Int,
+        val isContinuous: Boolean = false,
+        val pingsSent: Int = 0
     ) : PingUiState
     data class Finished(
         val result: PingResult,
-        val showRaw: Boolean = false
+        val showRaw: Boolean = false,
+        val sessionLogFile: File? = null
     ) : PingUiState
     data class Error(val message: String) : PingUiState
 }
@@ -41,9 +51,14 @@ sealed interface PingUiState {
 @HiltViewModel
 class PingViewModel @Inject constructor(
     private val pingUseCase: PingUseCase,
+    private val continuousPingUseCase: ContinuousPingUseCase,
     private val dataStore: DataStore<Preferences>,
     private val recentHostsRepository: RecentHostsRepository
 ) : ViewModel() {
+
+    companion object {
+        private const val ROLLING_WINDOW = 100
+    }
 
     private val _uiState = MutableStateFlow<PingUiState>(PingUiState.Idle)
     val uiState: StateFlow<PingUiState> = _uiState.asStateFlow()
@@ -62,11 +77,15 @@ class PingViewModel @Inject constructor(
     private val _packetSize = MutableStateFlow(56)
     val packetSize: StateFlow<Int> = _packetSize.asStateFlow()
 
+    private val _continuousMode = MutableStateFlow(false)
+    val continuousMode: StateFlow<Boolean> = _continuousMode.asStateFlow()
+
     val recentHosts: StateFlow<List<String>> = recentHostsRepository
         .getRecents(AppPreferenceKeys.RECENT_PING_HOSTS)
         .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
 
     private var pingJob: Job? = null
+    private var sessionLogFile: File? = null
 
     init {
         viewModelScope.launch {
@@ -78,21 +97,15 @@ class PingViewModel @Inject constructor(
 
     // ── User actions ─────────────────────────────────────────────────────────
 
-    fun onHostChange(value: String) {
-        _host.value = value
-    }
+    fun onHostChange(value: String) { _host.value = value }
 
-    fun onCountChange(value: Int) {
-        _count.value = value.coerceIn(1, 100)
-    }
+    fun onCountChange(value: Int) { _count.value = value.coerceIn(1, 100) }
 
-    fun onTimeoutChange(value: Int) {
-        _timeoutMs.value = value.coerceIn(100, 30_000)
-    }
+    fun onTimeoutChange(value: Int) { _timeoutMs.value = value.coerceIn(100, 30_000) }
 
-    fun onPacketSizeChange(value: Int) {
-        _packetSize.value = value.coerceIn(1, 65_507)
-    }
+    fun onPacketSizeChange(value: Int) { _packetSize.value = value.coerceIn(1, 65_507) }
+
+    fun onToggleContinuous(enabled: Boolean) { _continuousMode.value = enabled }
 
     fun onToggleRawView() {
         val current = _uiState.value
@@ -103,22 +116,36 @@ class PingViewModel @Inject constructor(
 
     fun onClearResults() {
         pingJob?.cancel()
+        pingJob = null
+        cleanupSessionFile()
         _uiState.value = PingUiState.Idle
     }
 
     fun onStop() {
         pingJob?.cancel()
+        pingJob = null
         val current = _uiState.value
-        if (current is PingUiState.Running && current.packets.isNotEmpty()) {
-            _uiState.value = PingUiState.Finished(buildResult(current.host, current.packets, current.totalCount))
-        } else {
-            _uiState.value = PingUiState.Idle
+        if (current is PingUiState.Running) {
+            if (current.isContinuous) {
+                finalizeContinuousSession(current)
+            } else if (current.packets.isNotEmpty()) {
+                _uiState.value = PingUiState.Finished(
+                    buildResult(current.host, current.packets, current.totalCount)
+                )
+            } else {
+                _uiState.value = PingUiState.Idle
+            }
         }
     }
 
-    fun onRetry() {
-        startPing()
+    fun onLifecycleStop() {
+        val current = _uiState.value
+        if (current is PingUiState.Running && current.isContinuous) {
+            onStop()
+        }
     }
+
+    fun onRetry() { startPing() }
 
     fun removeRecentHost(host: String) {
         viewModelScope.launch {
@@ -133,6 +160,12 @@ class PingViewModel @Inject constructor(
     }
 
     fun startPing() {
+        if (_continuousMode.value) startContinuousPing() else startNormalPing()
+    }
+
+    // ── Normal (bounded) ping ────────────────────────────────────────────────
+
+    private fun startNormalPing() {
         pingJob?.cancel()
 
         val params = PingParams(
@@ -143,12 +176,12 @@ class PingViewModel @Inject constructor(
         )
         val trimmedHost = params.host.trim()
 
-        // Enter Running state immediately so the UI shows activity and zero-packet
-        // flows (host unreachable, DNS failure) fall through to the Error branch below.
-        _uiState.value = PingUiState.Running(host = trimmedHost, packets = emptyList(), totalCount = params.count)
+        _uiState.value = PingUiState.Running(
+            host = trimmedHost, packets = emptyList(), totalCount = params.count
+        )
 
         pingJob = viewModelScope.launch {
-            val accumulatedPackets = mutableListOf<PingPacketResult>()
+            val accumulated = mutableListOf<PingPacketResult>()
             var savedToRecents = false
 
             pingUseCase(params).collect { result ->
@@ -158,23 +191,20 @@ class PingViewModel @Inject constructor(
                         return@collect
                     }
                     is PingFlowResult.Packet -> {
-                        // Save to recents only on first valid packet — avoids persisting
-                        // hosts that immediately fail validation.
                         if (!savedToRecents) {
                             savedToRecents = true
                             recentHostsRepository.addRecent(AppPreferenceKeys.RECENT_PING_HOSTS, trimmedHost)
                         }
-                        accumulatedPackets.add(result.packet)
+                        accumulated.add(result.packet)
                         _uiState.value = PingUiState.Running(
                             host = trimmedHost,
-                            packets = accumulatedPackets.toList(),
+                            packets = accumulated.toList(),
                             totalCount = params.count
                         )
                     }
                 }
             }
 
-            // Flow completed — move to Finished if we got packets, Error if not
             val current = _uiState.value
             if (current is PingUiState.Running) {
                 _uiState.value = if (current.packets.isEmpty()) {
@@ -184,6 +214,102 @@ class PingViewModel @Inject constructor(
                 }
             }
         }
+    }
+
+    // ── Continuous ping ──────────────────────────────────────────────────────
+
+    private fun startContinuousPing() {
+        pingJob?.cancel()
+        cleanupSessionFile()
+
+        val trimmedHost = _host.value.trim()
+        val params = ContinuousPingParams(
+            host = trimmedHost,
+            timeoutMs = _timeoutMs.value,
+            packetSize = _packetSize.value
+        )
+
+        val logFile = File.createTempFile("ping_session_", ".csv")
+        sessionLogFile = logFile
+        val logger = PingSessionLogger(logFile)
+
+        _uiState.value = PingUiState.Running(
+            host = trimmedHost, packets = emptyList(), totalCount = 0,
+            isContinuous = true, pingsSent = 0
+        )
+
+        pingJob = viewModelScope.launch {
+            // File writes are dispatched to IO via a channel so the collect loop
+            // is never blocked on disk. The channel is cancelled with the pingJob.
+            val logChannel = Channel<Pair<Int, PingPacketResult>>(Channel.UNLIMITED)
+            launch(Dispatchers.IO) {
+                logger.init()
+                for ((seq, packet) in logChannel) {
+                    runCatching { logger.append(seq, packet) }
+                }
+            }
+
+            val window = ArrayDeque<PingPacketResult>(ROLLING_WINDOW)
+            var seq = 0
+            var savedToRecents = false
+
+            continuousPingUseCase(params).collect { result ->
+                when (result) {
+                    is PingFlowResult.ValidationError -> {
+                        logChannel.close()
+                        cleanupSessionFile()
+                        _uiState.value = PingUiState.Error(result.message)
+                        return@collect
+                    }
+                    is PingFlowResult.Packet -> {
+                        seq++
+                        if (!savedToRecents) {
+                            savedToRecents = true
+                            recentHostsRepository.addRecent(AppPreferenceKeys.RECENT_PING_HOSTS, trimmedHost)
+                        }
+                        logChannel.trySend(Pair(seq, result.packet))
+                        if (window.size >= ROLLING_WINDOW) window.removeFirst()
+                        window.addLast(result.packet)
+                        _uiState.value = PingUiState.Running(
+                            host = trimmedHost,
+                            packets = window.toList(),
+                            totalCount = 0,
+                            isContinuous = true,
+                            pingsSent = seq
+                        )
+                    }
+                }
+            }
+
+            logChannel.close()
+            val current = _uiState.value
+            if (current is PingUiState.Running && current.isContinuous) {
+                finalizeContinuousSession(current)
+            }
+        }
+    }
+
+    private fun finalizeContinuousSession(current: PingUiState.Running) {
+        val file = sessionLogFile
+        val pingsSent = current.pingsSent
+        val result = buildResult(current.host, current.packets, pingsSent)
+        _uiState.value = PingUiState.Finished(
+            result = result,
+            sessionLogFile = if (pingsSent > 0) file else null
+        )
+        if (pingsSent == 0) cleanupSessionFile()
+    }
+
+    // ── Cleanup ──────────────────────────────────────────────────────────────
+
+    private fun cleanupSessionFile() {
+        sessionLogFile?.delete()
+        sessionLogFile = null
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        cleanupSessionFile()
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────────
@@ -204,20 +330,25 @@ class PingViewModel @Inject constructor(
         appendLine()
         packets.forEach { p ->
             when (p.status) {
-                net.aieat.netswissknife.core.network.ping.PingStatus.SUCCESS ->
+                PingStatus.SUCCESS ->
                     appendLine("${packetSize + 8} bytes from ${p.host}: icmp_seq=${p.sequence} ttl=64 time=${p.rtTimeMs} ms")
-                net.aieat.netswissknife.core.network.ping.PingStatus.TIMEOUT ->
+                PingStatus.TIMEOUT ->
                     appendLine("Request timeout for icmp_seq ${p.sequence}")
-                net.aieat.netswissknife.core.network.ping.PingStatus.ERROR ->
+                PingStatus.ERROR ->
                     appendLine("Error for icmp_seq ${p.sequence}: ${p.errorMessage}")
             }
         }
         appendLine()
         appendLine("--- $host ping statistics ---")
-        appendLine("${stats.sent} packets transmitted, ${stats.received} packets received, " +
-                "${"%.1f".format(stats.lossPercent)}% packet loss")
+        appendLine(
+            "${stats.sent} packets transmitted, ${stats.received} packets received, " +
+                "${"%.1f".format(stats.lossPercent)}% packet loss"
+        )
         if (stats.received > 0) {
-            appendLine("round-trip min/avg/max/jitter = ${stats.minMs}/${"%.3f".format(stats.avgMs)}/${stats.maxMs}/${"%.3f".format(stats.jitterMs)} ms")
+            appendLine(
+                "round-trip min/avg/max/jitter = ${stats.minMs}/${"%.3f".format(stats.avgMs)}/" +
+                    "${stats.maxMs}/${"%.3f".format(stats.jitterMs)} ms"
+            )
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -70,6 +70,11 @@
     <string name="ping_stop_button">Stop</string>
     <string name="ping_retry">Retry</string>
 
+    <!-- Ping Continuous Mode -->
+    <string name="ping_continuous_label">Continuous</string>
+    <string name="ping_pings_sent">Pings sent: %1$d</string>
+    <string name="ping_continuous_running_title">Pinging continuously…</string>
+
     <!-- Ping States -->
     <string name="ping_idle_title">Enter a host to ping</string>
     <string name="ping_idle_subtitle">Supports hostnames and IPv4 addresses</string>

--- a/app/src/test/kotlin/net/aieat/netswissknife/app/ui/screens/ping/PingViewModelTest.kt
+++ b/app/src/test/kotlin/net/aieat/netswissknife/app/ui/screens/ping/PingViewModelTest.kt
@@ -11,18 +11,23 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import net.aieat.netswissknife.app.data.AppPreferenceKeys
 import net.aieat.netswissknife.app.data.RecentHostsRepository
+import net.aieat.netswissknife.core.domain.ContinuousPingUseCase
 import net.aieat.netswissknife.core.domain.PingFlowResult
 import net.aieat.netswissknife.core.domain.PingUseCase
 import net.aieat.netswissknife.core.network.ping.PingPacketResult
 import net.aieat.netswissknife.core.network.ping.PingStatus
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
@@ -36,34 +41,33 @@ class PingViewModelTest {
     private val testDispatcher = UnconfinedTestDispatcher()
 
     private lateinit var pingUseCase: PingUseCase
+    private lateinit var continuousPingUseCase: ContinuousPingUseCase
     private lateinit var dataStore: DataStore<Preferences>
     private lateinit var recentHostsRepository: RecentHostsRepository
     private lateinit var viewModel: PingViewModel
 
     private val successPacket = PingPacketResult(
-        sequence = 1,
-        host = "example.com",
-        status = PingStatus.SUCCESS,
-        rtTimeMs = 15L
+        sequence = 1, host = "example.com", status = PingStatus.SUCCESS, rtTimeMs = 15L
     )
 
     @BeforeEach
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
         pingUseCase = mockk()
-        dataStore = mockk {
-            every { data } returns flowOf(emptyPreferences())
-        }
+        continuousPingUseCase = mockk()
+        dataStore = mockk { every { data } returns flowOf(emptyPreferences()) }
         recentHostsRepository = mockk(relaxed = true) {
             every { getRecents(any()) } returns flowOf(emptyList())
         }
-        viewModel = PingViewModel(pingUseCase, dataStore, recentHostsRepository)
+        viewModel = PingViewModel(pingUseCase, continuousPingUseCase, dataStore, recentHostsRepository)
     }
 
     @AfterEach
     fun tearDown() {
         Dispatchers.resetMain()
     }
+
+    // ── Initial state ─────────────────────────────────────────────────────────
 
     @Nested
     @DisplayName("initial state")
@@ -83,7 +87,14 @@ class PingViewModelTest {
         fun `count defaults to 10`() {
             assertEquals(10, viewModel.count.value)
         }
+
+        @Test
+        fun `continuous mode starts disabled`() {
+            assertFalse(viewModel.continuousMode.value)
+        }
     }
+
+    // ── Form field actions ────────────────────────────────────────────────────
 
     @Nested
     @DisplayName("form field actions")
@@ -99,15 +110,29 @@ class PingViewModelTest {
         fun `onCountChange clamps to valid range`() {
             viewModel.onCountChange(0)
             assertEquals(1, viewModel.count.value)
-
             viewModel.onCountChange(200)
             assertEquals(100, viewModel.count.value)
         }
+
+        @Test
+        fun `onToggleContinuous enables continuous mode`() {
+            viewModel.onToggleContinuous(true)
+            assertTrue(viewModel.continuousMode.value)
+        }
+
+        @Test
+        fun `onToggleContinuous disables continuous mode`() {
+            viewModel.onToggleContinuous(true)
+            viewModel.onToggleContinuous(false)
+            assertFalse(viewModel.continuousMode.value)
+        }
     }
 
+    // ── Normal ping state transitions ─────────────────────────────────────────
+
     @Nested
-    @DisplayName("startPing state transitions")
-    inner class StartPingStateTransitions {
+    @DisplayName("normal ping state transitions")
+    inner class NormalPingStateTransitions {
 
         @Test
         fun `transitions to Finished after all packets`() = runTest {
@@ -123,10 +148,17 @@ class PingViewModelTest {
         }
 
         @Test
+        fun `Finished state has null sessionLogFile in normal mode`() = runTest {
+            coEvery { pingUseCase(any()) } returns flowOf(PingFlowResult.Packet(successPacket))
+            viewModel.onHostChange("example.com")
+            viewModel.startPing()
+            val state = viewModel.uiState.value as PingUiState.Finished
+            assertNull(state.sessionLogFile)
+        }
+
+        @Test
         fun `transitions to Error on ValidationError`() = runTest {
-            coEvery { pingUseCase(any()) } returns flowOf(
-                PingFlowResult.ValidationError("invalid host")
-            )
+            coEvery { pingUseCase(any()) } returns flowOf(PingFlowResult.ValidationError("invalid host"))
             viewModel.onHostChange("")
             viewModel.startPing()
             val state = viewModel.uiState.value
@@ -139,20 +171,21 @@ class PingViewModelTest {
             coEvery { pingUseCase(any()) } returns flowOf()
             viewModel.onHostChange("unreachable.host")
             viewModel.startPing()
-            // Running is entered before collect; empty flow → Error
             assertTrue(viewModel.uiState.value is PingUiState.Error)
         }
     }
 
+    // ── Normal ping cancel and clear ──────────────────────────────────────────
+
     @Nested
-    @DisplayName("cancel and clear")
-    inner class CancelAndClear {
+    @DisplayName("normal ping cancel and clear")
+    inner class NormalPingCancelAndClear {
 
         @Test
         fun `onStop with collected packets moves to Finished`() = runTest {
             coEvery { pingUseCase(any()) } returns flow {
                 emit(PingFlowResult.Packet(successPacket))
-                kotlinx.coroutines.delay(10_000L)
+                suspendCancellableCoroutine<Nothing> { }
             }
             viewModel.onHostChange("example.com")
             viewModel.startPing()
@@ -168,7 +201,156 @@ class PingViewModelTest {
             viewModel.onClearResults()
             assertTrue(viewModel.uiState.value is PingUiState.Idle)
         }
+
+        @Test
+        fun `onLifecycleStop does NOT stop a normal ping`() = runTest {
+            coEvery { pingUseCase(any()) } returns flow {
+                emit(PingFlowResult.Packet(successPacket))
+                kotlinx.coroutines.delay(10_000L)
+            }
+            viewModel.onHostChange("example.com")
+            viewModel.startPing()
+            val stateBefore = viewModel.uiState.value
+            viewModel.onLifecycleStop()
+            // Normal ping should still be in Running state
+            assertTrue(viewModel.uiState.value is PingUiState.Running)
+            assertFalse((viewModel.uiState.value as PingUiState.Running).isContinuous)
+        }
     }
+
+    // ── Continuous ping ───────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("continuous ping")
+    inner class ContinuousPing {
+
+        // Emits `count` packets immediately then suspends until cancelled, simulating an
+        // ongoing session without advancing virtual time (avoids advanceUntilIdle loops).
+        private fun neverEndingFlow(count: Int = 3) = flow {
+            repeat(count) { i ->
+                emit(PingFlowResult.Packet(successPacket.copy(sequence = i + 1)))
+            }
+            suspendCancellableCoroutine<Nothing> { }
+        }
+
+        @BeforeEach
+        fun enableContinuous() {
+            viewModel.onToggleContinuous(true)
+            viewModel.onHostChange("example.com")
+        }
+
+        @Test
+        fun `Running state has isContinuous true`() = runTest {
+            coEvery { continuousPingUseCase(any()) } returns neverEndingFlow()
+            viewModel.startPing()
+            val state = viewModel.uiState.value
+            assertTrue(state is PingUiState.Running)
+            assertTrue((state as PingUiState.Running).isContinuous)
+        }
+
+        @Test
+        fun `pingsSent increments with each packet`() = runTest {
+            coEvery { continuousPingUseCase(any()) } returns neverEndingFlow()
+            viewModel.startPing()
+            val state = viewModel.uiState.value as PingUiState.Running
+            assertTrue(state.pingsSent > 0)
+        }
+
+        @Test
+        fun `rolling window is capped at 100 packets`() = runTest {
+            coEvery { continuousPingUseCase(any()) } returns flow {
+                repeat(150) { i -> emit(PingFlowResult.Packet(successPacket.copy(sequence = i + 1))) }
+            }
+            viewModel.startPing()
+            // After all 150 emitted the flow completes; state may be Finished
+            val packets = when (val s = viewModel.uiState.value) {
+                is PingUiState.Running -> s.packets
+                is PingUiState.Finished -> s.result.packets
+                else -> emptyList()
+            }
+            assertTrue(packets.size <= 100)
+        }
+
+        @Test
+        fun `onStop transitions continuous session to Finished`() = runTest {
+            coEvery { continuousPingUseCase(any()) } returns neverEndingFlow()
+            viewModel.startPing()
+            viewModel.onStop()
+            assertTrue(viewModel.uiState.value is PingUiState.Finished)
+        }
+
+        @Test
+        fun `Finished after continuous has non-null sessionLogFile`() = runTest {
+            coEvery { continuousPingUseCase(any()) } returns neverEndingFlow()
+            viewModel.startPing()
+            viewModel.onStop()
+            val state = viewModel.uiState.value as PingUiState.Finished
+            assertNotNull(state.sessionLogFile)
+        }
+
+        @Test
+        fun `onLifecycleStop stops continuous ping`() = runTest {
+            coEvery { continuousPingUseCase(any()) } returns neverEndingFlow()
+            viewModel.startPing()
+            assertTrue(viewModel.uiState.value is PingUiState.Running)
+            viewModel.onLifecycleStop()
+            assertTrue(viewModel.uiState.value is PingUiState.Finished)
+        }
+
+        @Test
+        fun `onLifecycleStop is idempotent - safe to call twice`() = runTest {
+            coEvery { continuousPingUseCase(any()) } returns neverEndingFlow()
+            viewModel.startPing()
+            viewModel.onLifecycleStop()
+            val stateAfterFirst = viewModel.uiState.value
+            viewModel.onLifecycleStop() // second call — must not crash or change state
+            assertEquals(stateAfterFirst, viewModel.uiState.value)
+        }
+
+        @Test
+        fun `ValidationError clears session file and shows Error state`() = runTest {
+            coEvery { continuousPingUseCase(any()) } returns flowOf(
+                PingFlowResult.ValidationError("invalid")
+            )
+            viewModel.startPing()
+            assertTrue(viewModel.uiState.value is PingUiState.Error)
+        }
+
+        @Test
+        fun `starting new continuous session deletes previous log file`() = runTest {
+            coEvery { continuousPingUseCase(any()) } returns neverEndingFlow()
+            viewModel.startPing()
+            viewModel.onStop()
+            val firstFile = (viewModel.uiState.value as PingUiState.Finished).sessionLogFile
+            assertNotNull(firstFile)
+
+            // Start a second session
+            coEvery { continuousPingUseCase(any()) } returns neverEndingFlow()
+            viewModel.startPing()
+            // The first file should have been deleted
+            assertTrue(firstFile?.exists() == false)
+        }
+
+        @Test
+        fun `onClearResults resets to Idle and cleans up file`() = runTest {
+            coEvery { continuousPingUseCase(any()) } returns neverEndingFlow()
+            viewModel.startPing()
+            viewModel.onStop()
+            val logFile = (viewModel.uiState.value as PingUiState.Finished).sessionLogFile
+            viewModel.onClearResults()
+            assertTrue(viewModel.uiState.value is PingUiState.Idle)
+            assertTrue(logFile?.exists() == false)
+        }
+
+        @Test
+        fun `addRecent is called on first continuous packet`() = runTest {
+            coEvery { continuousPingUseCase(any()) } returns neverEndingFlow()
+            viewModel.startPing()
+            coVerify { recentHostsRepository.addRecent(AppPreferenceKeys.RECENT_PING_HOSTS, "example.com") }
+        }
+    }
+
+    // ── Recent hosts ──────────────────────────────────────────────────────────
 
     @Nested
     @DisplayName("recent hosts")

--- a/core-domain/src/main/kotlin/net/aieat/netswissknife/core/domain/ContinuousPingParams.kt
+++ b/core-domain/src/main/kotlin/net/aieat/netswissknife/core/domain/ContinuousPingParams.kt
@@ -1,0 +1,7 @@
+package net.aieat.netswissknife.core.domain
+
+data class ContinuousPingParams(
+    val host: String,
+    val timeoutMs: Int = 3_000,
+    val packetSize: Int = 56
+)

--- a/core-domain/src/main/kotlin/net/aieat/netswissknife/core/domain/ContinuousPingUseCase.kt
+++ b/core-domain/src/main/kotlin/net/aieat/netswissknife/core/domain/ContinuousPingUseCase.kt
@@ -1,0 +1,18 @@
+package net.aieat.netswissknife.core.domain
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import net.aieat.netswissknife.core.network.ping.PingRepository
+
+class ContinuousPingUseCase(private val repository: PingRepository) {
+
+    operator fun invoke(params: ContinuousPingParams): Flow<PingFlowResult> {
+        val trimmedHost = params.host.trim()
+        val error = validatePingCommon(trimmedHost, params.timeoutMs, params.packetSize)
+        if (error != null) return flow { emit(PingFlowResult.ValidationError(error)) }
+        return repository
+            .continuousPing(host = trimmedHost, timeoutMs = params.timeoutMs, packetSize = params.packetSize)
+            .map { PingFlowResult.Packet(it) }
+    }
+}

--- a/core-domain/src/main/kotlin/net/aieat/netswissknife/core/domain/PingSessionLogger.kt
+++ b/core-domain/src/main/kotlin/net/aieat/netswissknife/core/domain/PingSessionLogger.kt
@@ -1,0 +1,21 @@
+package net.aieat.netswissknife.core.domain
+
+import net.aieat.netswissknife.core.network.ping.PingPacketResult
+import net.aieat.netswissknife.core.network.ping.PingStatus
+import java.io.File
+
+class PingSessionLogger(internal val file: File) {
+
+    fun init() {
+        file.writeText("seq,timestamp_ms,latency_ms,status\n")
+    }
+
+    fun append(seq: Int, packet: PingPacketResult) {
+        val status = when (packet.status) {
+            PingStatus.SUCCESS -> "ok"
+            PingStatus.TIMEOUT -> "timeout"
+            PingStatus.ERROR -> "error"
+        }
+        file.appendText("$seq,${System.currentTimeMillis()},${packet.rtTimeMs ?: ""},$status\n")
+    }
+}

--- a/core-domain/src/main/kotlin/net/aieat/netswissknife/core/domain/PingUseCase.kt
+++ b/core-domain/src/main/kotlin/net/aieat/netswissknife/core/domain/PingUseCase.kt
@@ -1,41 +1,18 @@
 package net.aieat.netswissknife.core.domain
 
-import net.aieat.netswissknife.core.network.HostValidator
 import net.aieat.netswissknife.core.network.ping.PingRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 
-/**
- * Use case that validates [PingParams] and streams [PingFlowResult]s from the
- * [PingRepository].
- *
- * Validation rules:
- * - Host must not be blank
- * - Host must be a valid hostname or IPv4 address
- * - count must be in 1..100
- * - timeoutMs must be in 100..30_000
- * - packetSize must be in 1..65_507
- */
 class PingUseCase(
     private val repository: PingRepository
 ) {
     operator fun invoke(params: PingParams): Flow<PingFlowResult> {
         val trimmedHost = params.host.trim()
 
-        val errorMessage: String? = when {
-            trimmedHost.isBlank() ->
-                "Host must not be empty"
-            !HostValidator.isValidHostname(trimmedHost) ->
-                "Invalid host or IP address"
-            params.count !in 1..100 ->
-                "Count must be between 1 and 100"
-            params.timeoutMs !in 100..30_000 ->
-                "Timeout must be between 100 ms and 30 000 ms"
-            params.packetSize !in 1..65_507 ->
-                "Packet size must be between 1 and 65 507 bytes"
-            else -> null
-        }
+        val errorMessage: String? = validatePingCommon(trimmedHost, params.timeoutMs, params.packetSize)
+            ?: if (params.count !in 1..100) "Count must be between 1 and 100" else null
 
         if (errorMessage != null) {
             return flow { emit(PingFlowResult.ValidationError(errorMessage)) }

--- a/core-domain/src/main/kotlin/net/aieat/netswissknife/core/domain/PingValidation.kt
+++ b/core-domain/src/main/kotlin/net/aieat/netswissknife/core/domain/PingValidation.kt
@@ -1,0 +1,11 @@
+package net.aieat.netswissknife.core.domain
+
+import net.aieat.netswissknife.core.network.HostValidator
+
+internal fun validatePingCommon(host: String, timeoutMs: Int, packetSize: Int): String? = when {
+    host.isBlank() -> "Host must not be empty"
+    !HostValidator.isValidHostname(host) -> "Invalid host or IP address"
+    timeoutMs !in 100..30_000 -> "Timeout must be between 100 ms and 30 000 ms"
+    packetSize !in 1..65_507 -> "Packet size must be between 1 and 65 507 bytes"
+    else -> null
+}

--- a/core-domain/src/test/kotlin/net/aieat/netswissknife/core/domain/ContinuousPingUseCaseTest.kt
+++ b/core-domain/src/test/kotlin/net/aieat/netswissknife/core/domain/ContinuousPingUseCaseTest.kt
@@ -1,0 +1,133 @@
+package net.aieat.netswissknife.core.domain
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import net.aieat.netswissknife.core.network.ping.PingPacketResult
+import net.aieat.netswissknife.core.network.ping.PingRepository
+import net.aieat.netswissknife.core.network.ping.PingStatus
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@DisplayName("ContinuousPingUseCase")
+class ContinuousPingUseCaseTest {
+
+    private lateinit var repository: PingRepository
+    private lateinit var useCase: ContinuousPingUseCase
+
+    private val samplePacket = PingPacketResult(1, "8.8.8.8", 12L, PingStatus.SUCCESS)
+
+    @BeforeEach
+    fun setUp() {
+        repository = mockk()
+        useCase = ContinuousPingUseCase(repository)
+    }
+
+    @Nested
+    @DisplayName("validation")
+    inner class Validation {
+
+        @Test
+        fun `blank host emits validation error`() = runTest {
+            val result = useCase(ContinuousPingParams(host = "  ")).first()
+            assertTrue(result is PingFlowResult.ValidationError)
+        }
+
+        @Test
+        fun `empty host emits validation error`() = runTest {
+            val result = useCase(ContinuousPingParams(host = "")).first()
+            assertTrue(result is PingFlowResult.ValidationError)
+        }
+
+        @Test
+        fun `invalid host emits validation error`() = runTest {
+            val result = useCase(ContinuousPingParams(host = "not valid!!")).first()
+            assertTrue(result is PingFlowResult.ValidationError)
+        }
+
+        @Test
+        fun `timeout below 100ms emits validation error`() = runTest {
+            val result = useCase(ContinuousPingParams(host = "8.8.8.8", timeoutMs = 99)).first()
+            assertTrue(result is PingFlowResult.ValidationError)
+        }
+
+        @Test
+        fun `timeout above 30000ms emits validation error`() = runTest {
+            val result = useCase(ContinuousPingParams(host = "8.8.8.8", timeoutMs = 30_001)).first()
+            assertTrue(result is PingFlowResult.ValidationError)
+        }
+
+        @Test
+        fun `packetSize below 1 emits validation error`() = runTest {
+            val result = useCase(ContinuousPingParams(host = "8.8.8.8", packetSize = 0)).first()
+            assertTrue(result is PingFlowResult.ValidationError)
+        }
+
+        @Test
+        fun `packetSize above 65507 emits validation error`() = runTest {
+            val result = useCase(ContinuousPingParams(host = "8.8.8.8", packetSize = 65_508)).first()
+            assertTrue(result is PingFlowResult.ValidationError)
+        }
+
+        @Test
+        fun `validation error does not call repository`() = runTest {
+            useCase(ContinuousPingParams(host = "")).toList()
+            verify(exactly = 0) { repository.continuousPing(any(), any(), any()) }
+        }
+    }
+
+    @Nested
+    @DisplayName("happy path")
+    inner class HappyPath {
+
+        @Test
+        fun `valid host delegates to repository continuousPing`() = runTest {
+            every { repository.continuousPing(any(), any(), any()) } returns flowOf(samplePacket)
+            useCase(ContinuousPingParams(host = "8.8.8.8")).toList()
+            verify(exactly = 1) { repository.continuousPing(any(), any(), any()) }
+        }
+
+        @Test
+        fun `host is trimmed before passing to repository`() = runTest {
+            every { repository.continuousPing(any(), any(), any()) } returns flowOf(samplePacket)
+            useCase(ContinuousPingParams(host = "  8.8.8.8  ")).toList()
+            verify { repository.continuousPing("8.8.8.8", any(), any()) }
+        }
+
+        @Test
+        fun `timeoutMs is forwarded to repository`() = runTest {
+            every { repository.continuousPing(any(), any(), any()) } returns flowOf(samplePacket)
+            useCase(ContinuousPingParams(host = "8.8.8.8", timeoutMs = 5_000)).toList()
+            verify { repository.continuousPing(any(), 5_000, any()) }
+        }
+
+        @Test
+        fun `emitted items are wrapped in Packet`() = runTest {
+            every { repository.continuousPing(any(), any(), any()) } returns flowOf(samplePacket)
+            val results = useCase(ContinuousPingParams(host = "8.8.8.8")).toList()
+            assertTrue(results.all { it is PingFlowResult.Packet })
+        }
+
+        @Test
+        fun `flow cancellation stops collection`() = runTest {
+            every { repository.continuousPing(any(), any(), any()) } returns flow {
+                var i = 1
+                while (true) emit(samplePacket.copy(sequence = i++))
+            }
+            val results = useCase(ContinuousPingParams(host = "8.8.8.8")).take(3).toList()
+            assertEquals(3, results.size)
+        }
+    }
+}

--- a/core-domain/src/test/kotlin/net/aieat/netswissknife/core/domain/PingSessionLoggerTest.kt
+++ b/core-domain/src/test/kotlin/net/aieat/netswissknife/core/domain/PingSessionLoggerTest.kt
@@ -1,0 +1,103 @@
+package net.aieat.netswissknife.core.domain
+
+import net.aieat.netswissknife.core.network.ping.PingPacketResult
+import net.aieat.netswissknife.core.network.ping.PingStatus
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.io.File
+
+@DisplayName("PingSessionLogger")
+class PingSessionLoggerTest {
+
+    private lateinit var file: File
+    private lateinit var logger: PingSessionLogger
+
+    @BeforeEach
+    fun setUp() {
+        file = File.createTempFile("ping_test_", ".csv")
+        file.deleteOnExit()
+        logger = PingSessionLogger(file)
+    }
+
+    @Nested
+    @DisplayName("init")
+    inner class Init {
+
+        @Test
+        fun `init writes CSV header`() {
+            logger.init()
+            val lines = file.readLines()
+            assertEquals("seq,timestamp_ms,latency_ms,status", lines[0])
+        }
+
+        @Test
+        fun `init overwrites any existing content`() {
+            file.writeText("stale data\n")
+            logger.init()
+            val lines = file.readLines()
+            assertEquals(1, lines.size)
+            assertEquals("seq,timestamp_ms,latency_ms,status", lines[0])
+        }
+    }
+
+    @Nested
+    @DisplayName("append")
+    inner class Append {
+
+        @Test
+        fun `success packet writes ok status`() {
+            logger.init()
+            logger.append(1, PingPacketResult(1, "8.8.8.8", 15L, PingStatus.SUCCESS))
+            val dataLine = file.readLines()[1]
+            assertTrue(dataLine.endsWith(",ok"), "Expected line to end with ',ok' but was: $dataLine")
+        }
+
+        @Test
+        fun `timeout packet writes timeout status and empty latency`() {
+            logger.init()
+            logger.append(2, PingPacketResult(2, "8.8.8.8", null, PingStatus.TIMEOUT))
+            val dataLine = file.readLines()[1]
+            assertTrue(dataLine.endsWith(",timeout"), "Expected ',timeout' but was: $dataLine")
+            val cols = dataLine.split(",")
+            assertEquals("", cols[2], "latency should be empty for timeout")
+        }
+
+        @Test
+        fun `error packet writes error status`() {
+            logger.init()
+            logger.append(3, PingPacketResult(3, "bad", null, PingStatus.ERROR, "unknown host"))
+            val dataLine = file.readLines()[1]
+            assertTrue(dataLine.endsWith(",error"), "Expected ',error' but was: $dataLine")
+        }
+
+        @Test
+        fun `seq number is written in first column`() {
+            logger.init()
+            logger.append(42, PingPacketResult(42, "8.8.8.8", 10L, PingStatus.SUCCESS))
+            val dataLine = file.readLines()[1]
+            assertEquals("42", dataLine.split(",")[0])
+        }
+
+        @Test
+        fun `latency is written for success packets`() {
+            logger.init()
+            logger.append(1, PingPacketResult(1, "8.8.8.8", 18L, PingStatus.SUCCESS))
+            val dataLine = file.readLines()[1]
+            assertEquals("18", dataLine.split(",")[2])
+        }
+
+        @Test
+        fun `multiple appends produce one row each`() {
+            logger.init()
+            repeat(5) { i ->
+                logger.append(i + 1, PingPacketResult(i + 1, "8.8.8.8", 10L, PingStatus.SUCCESS))
+            }
+            val lines = file.readLines().filter { it.isNotBlank() }
+            assertEquals(6, lines.size) // header + 5 data rows
+        }
+    }
+}

--- a/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/ping/PingRepository.kt
+++ b/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/ping/PingRepository.kt
@@ -23,4 +23,18 @@ interface PingRepository {
         timeoutMs: Int,
         packetSize: Int
     ): Flow<PingPacketResult>
+
+    /**
+     * Sends probes to [host] indefinitely, emitting a [PingPacketResult] for each one.
+     * The flow runs until the collecting coroutine is cancelled.
+     *
+     * @param host       Hostname or IP address to ping
+     * @param timeoutMs  Per-probe timeout in milliseconds
+     * @param packetSize Payload size in bytes (informational)
+     */
+    fun continuousPing(
+        host: String,
+        timeoutMs: Int,
+        packetSize: Int
+    ): Flow<PingPacketResult>
 }

--- a/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/ping/PingRepositoryImpl.kt
+++ b/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/ping/PingRepositoryImpl.kt
@@ -53,25 +53,35 @@ class PingRepositoryImpl(
         packetSize: Int
     ): Flow<PingPacketResult> = flow {
         for (seq in 1..count) {
-            val result = checker(host, timeoutMs)
-
-            val packet = PingPacketResult(
-                sequence = seq,
-                host = host,
-                rtTimeMs = if (result.reachable) result.rtTimeMs else null,
-                status = when {
-                    result.errorMessage != null -> PingStatus.ERROR
-                    result.reachable -> PingStatus.SUCCESS
-                    else -> PingStatus.TIMEOUT
-                },
-                errorMessage = result.errorMessage
-            )
-
-            emit(packet)
-
-            if (seq < count) {
-                delay(delayBetweenProbesMs)
-            }
+            emit(buildPacket(host, seq, timeoutMs))
+            if (seq < count) delay(delayBetweenProbesMs)
         }
     }.flowOn(Dispatchers.IO)
+
+    override fun continuousPing(
+        host: String,
+        timeoutMs: Int,
+        packetSize: Int
+    ): Flow<PingPacketResult> = flow {
+        var seq = 1
+        while (true) {
+            emit(buildPacket(host, seq++, timeoutMs))
+            delay(delayBetweenProbesMs)
+        }
+    }.flowOn(Dispatchers.IO)
+
+    private fun buildPacket(host: String, seq: Int, timeoutMs: Int): PingPacketResult {
+        val result = checker(host, timeoutMs)
+        return PingPacketResult(
+            sequence = seq,
+            host = host,
+            rtTimeMs = if (result.reachable) result.rtTimeMs else null,
+            status = when {
+                result.errorMessage != null -> PingStatus.ERROR
+                result.reachable -> PingStatus.SUCCESS
+                else -> PingStatus.TIMEOUT
+            },
+            errorMessage = result.errorMessage
+        )
+    }
 }

--- a/core-network/src/test/kotlin/net/aieat/netswissknife/core/network/ping/PingRepositoryImplTest.kt
+++ b/core-network/src/test/kotlin/net/aieat/netswissknife/core/network/ping/PingRepositoryImplTest.kt
@@ -1,11 +1,13 @@
 package net.aieat.netswissknife.core.network.ping
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -151,6 +153,60 @@ class PingRepositoryImplTest {
             assertEquals(PingStatus.SUCCESS, packets[1].status)
             assertEquals(PingStatus.TIMEOUT, packets[2].status)
             assertEquals(PingStatus.SUCCESS, packets[3].status)
+        }
+    }
+
+    @Nested
+    @DisplayName("continuousPing")
+    inner class ContinuousPing {
+
+        @Test
+        fun `emits packets until flow is cancelled`() = runTest {
+            val repo = PingRepositoryImpl(checker = successChecker(), delayBetweenProbesMs = 0L)
+            val packets = repo.continuousPing("8.8.8.8", timeoutMs = 1000, packetSize = 56)
+                .take(5)
+                .toList()
+            assertEquals(5, packets.size)
+        }
+
+        @Test
+        fun `sequence numbers increment from 1`() = runTest {
+            val repo = PingRepositoryImpl(checker = successChecker(), delayBetweenProbesMs = 0L)
+            val packets = repo.continuousPing("8.8.8.8", timeoutMs = 1000, packetSize = 56)
+                .take(3)
+                .toList()
+            assertEquals(listOf(1, 2, 3), packets.map { it.sequence })
+        }
+
+        @Test
+        fun `successful probes produce SUCCESS packets`() = runTest {
+            val repo = PingRepositoryImpl(checker = successChecker(rtMs = 20L), delayBetweenProbesMs = 0L)
+            val packet = repo.continuousPing("8.8.8.8", timeoutMs = 1000, packetSize = 56)
+                .take(1)
+                .toList()
+                .first()
+            assertEquals(PingStatus.SUCCESS, packet.status)
+            assertEquals(20L, packet.rtTimeMs)
+        }
+
+        @Test
+        fun `timeout probes produce TIMEOUT packets with null rtt`() = runTest {
+            val repo = PingRepositoryImpl(checker = timeoutChecker(), delayBetweenProbesMs = 0L)
+            val packet = repo.continuousPing("10.0.0.1", timeoutMs = 100, packetSize = 56)
+                .take(1)
+                .toList()
+                .first()
+            assertEquals(PingStatus.TIMEOUT, packet.status)
+            assertNull(packet.rtTimeMs)
+        }
+
+        @Test
+        fun `host is set on every packet`() = runTest {
+            val repo = PingRepositoryImpl(checker = successChecker(), delayBetweenProbesMs = 0L)
+            val packets = repo.continuousPing("example.com", timeoutMs = 1000, packetSize = 56)
+                .take(3)
+                .toList()
+            assertTrue(packets.all { it.host == "example.com" })
         }
     }
 }


### PR DESCRIPTION
Closes #67

## Summary

- Adds a **Continuous** toggle to the Ping tool that runs indefinitely while the app is on screen, replacing the bounded count input
- Live chart and stats reflect a rolling window of the last 100 packets; the raw log panel shows the last 50
- Each packet is written to a session-scoped CSV temp file via a `Channel` + `Dispatchers.IO` child coroutine — file IO never touches the Main thread
- Screen stays on via `FLAG_KEEP_SCREEN_ON` (no new permissions required)
- Auto-stops on `Lifecycle.Event.ON_STOP`, covering backgrounding, screen lock, and in-app navigation (NavBackStackEntry lifecycle transitions)
- Share button in the Finished state shares the full session CSV through the existing `shareText` mechanism

## Architecture changes

- **core-network:** `continuousPing()` — infinite `Flow` that cancels cleanly with the collecting coroutine
- **core-domain:** `ContinuousPingUseCase`, `PingSessionLogger`, `ContinuousPingParams`; `validatePingCommon()` helper extracted from `PingUseCase` to eliminate duplicated validation
- **app:** `PingViewModel` extended with continuous mode state machine and file lifecycle; `PingScreen` gains the toggle, lifecycle observer, and `FLAG_KEEP_SCREEN_ON` effect

## Test plan

- [ ] All existing unit tests pass (`./gradlew test`)
- [ ] New unit tests: `ContinuousPingUseCaseTest`, `PingSessionLoggerTest`, extended `PingRepositoryImplTest`, extended `PingViewModelTest` (rolling window cap, `onLifecycleStop` idempotency, file cleanup, session log presence after stop)
- [ ] Toggle continuous mode on, start ping — verify counter increments, progress bar absent, chart scrolls
- [ ] Background the app mid-session — verify ping stops automatically
- [ ] Rotate screen mid-session — verify ping continues (ViewModel survives, `ON_STOP` not triggered)
- [ ] Tap Share after session ends — verify full CSV shared via system sheet
- [ ] Start a second session — verify previous temp file is deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)