### PR TITLE
fix: preserve Wi-Fi selections across auto-refresh; About page homepage & licences

### DIFF
--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/WifiScanScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/WifiScanScreen.kt
@@ -128,6 +128,7 @@ fun WifiScanScreen(
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val autoRefresh by viewModel.autoRefresh.collectAsState()
+    val expandedNetworks by viewModel.expandedNetworks.collectAsState()
 
     val requiredPermissions = buildList {
         add(Manifest.permission.ACCESS_FINE_LOCATION)
@@ -179,11 +180,13 @@ fun WifiScanScreen(
             is WifiScanUiState.Success      -> WifiSuccessScreen(
                 state               = state,
                 autoRefresh         = autoRefresh,
+                expandedNetworks    = expandedNetworks,
                 onScan              = { viewModel.startScan() },
                 onToggleAutoRefresh = { viewModel.toggleAutoRefresh() },
                 onBandFilter        = { viewModel.setBandFilter(it) },
                 onSortOrder         = { viewModel.setSortOrder(it) },
-                onSelectAp          = { viewModel.selectAccessPoint(it) }
+                onSelectAp          = { viewModel.selectAccessPoint(it) },
+                onToggleNetworkExpanded = { viewModel.toggleNetworkExpanded(it) }
             )
             is WifiScanUiState.Error        -> WifiErrorScreen(
                 message = state.message,
@@ -302,11 +305,13 @@ fun WifiScanScreen(
 @Composable private fun WifiSuccessScreen(
     state: WifiScanUiState.Success,
     autoRefresh: Boolean,
+    expandedNetworks: Set<String>,
     onScan: () -> Unit,
     onToggleAutoRefresh: () -> Unit,
     onBandFilter: (WifiBand?) -> Unit,
     onSortOrder: (ApSortOrder) -> Unit,
     onSelectAp: (WifiAccessPoint?) -> Unit,
+    onToggleNetworkExpanded: (String) -> Unit,
 ) {
     val networks = state.filteredNetworks
 
@@ -361,7 +366,14 @@ fun WifiScanScreen(
 
         // Network cards (SSID grouped, expandable)
         items(networks.size) { i ->
-            WifiNetworkCard(network = networks[i], onSelectAp = onSelectAp)
+            val network = networks[i]
+            val networkId = "${network.ssid}|${network.security.name}"
+            WifiNetworkCard(
+                network = network,
+                expanded = networkId in expandedNetworks,
+                onToggleExpanded = { onToggleNetworkExpanded(networkId) },
+                onSelectAp = onSelectAp
+            )
         }
 
         item { Spacer(Modifier.height(80.dp)) }
@@ -636,13 +648,14 @@ private fun bandChannelLabels(band: WifiBand): List<Pair<Int, Float>> = when (ba
 
 @Composable private fun WifiNetworkCard(
     network: WifiNetwork,
+    expanded: Boolean,
+    onToggleExpanded: () -> Unit,
     onSelectAp: (WifiAccessPoint?) -> Unit
 ) {
-    var expanded by remember { mutableStateOf(false) }
     val accentColor = networkColor(network.colorIndex)
 
     ElevatedCard(
-        onClick  = { expanded = !expanded },
+        onClick  = onToggleExpanded,
         modifier = Modifier.fillMaxWidth()
     ) {
         Column {

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/settings/SettingsScreen.kt
@@ -20,22 +20,29 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.DarkMode
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.automirrored.filled.OpenInNew
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Speed
 import androidx.compose.material.icons.filled.Tune
+import androidx.compose.foundation.clickable
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Slider
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -91,6 +98,7 @@ fun SettingsScreen(
             )
             DataSection(onClearRecents = viewModel::clearAllRecentHosts)
             AboutSection()
+            LicensesSection()
             Spacer(Modifier.height(8.dp))
         }
     }
@@ -281,23 +289,148 @@ private fun DataSection(onClearRecents: () -> Unit) {
 
 @Composable
 private fun AboutSection() {
+    val uriHandler = LocalUriHandler.current
+
     SectionHeader(Icons.Default.Info, stringResource(R.string.settings_about_section))
 
     ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+        Column {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = stringResource(R.string.settings_version_label),
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Text(
+                    text = BuildConfig.VERSION_NAME,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { uriHandler.openUri("https://github.com/AieatAssam/android-network-tools") }
+                    .padding(16.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = stringResource(R.string.settings_source_code_label),
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    Text(
+                        text = stringResource(R.string.settings_source_code_url),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.primary,
+                        textDecoration = TextDecoration.Underline
+                    )
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.OpenInNew,
+                        contentDescription = null,
+                        modifier = Modifier.size(14.dp),
+                        tint = MaterialTheme.colorScheme.primary
+                    )
+                }
+            }
+        }
+    }
+}
+
+private data class LibraryInfo(
+    val name: String,
+    val version: String,
+    val license: String,
+    val copyright: String? = null
+)
+
+private val THIRD_PARTY_LIBRARIES = listOf(
+    LibraryInfo("dnsjava", "3.6.2", "BSD 3-Clause",
+        "Copyright (c) 1998-2024, Brian Wellington and the dnsjava contributors"),
+    LibraryInfo("MapLibre Compose", "0.12.1", "BSD 3-Clause",
+        "Copyright (c) 2021-2024, MapLibre contributors"),
+    LibraryInfo("SNMP4J", "3.8.0", "Apache 2.0"),
+    LibraryInfo("icmpenguin", "1.0.0-rc.3", "Apache 2.0"),
+    LibraryInfo("Dagger Hilt", "2.59.2", "Apache 2.0"),
+    LibraryInfo("Kotlin Coroutines", "1.9.0", "Apache 2.0"),
+    LibraryInfo("AndroidX / Jetpack Compose", "—", "Apache 2.0"),
+    LibraryInfo("AndroidX DataStore", "1.1.4", "Apache 2.0"),
+)
+
+@Composable
+private fun LicensesSection() {
+    SectionHeader(Icons.Default.Info, stringResource(R.string.settings_licenses_section))
+
+    ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(vertical = 8.dp)) {
+            Text(
+                text = stringResource(R.string.settings_licenses_subtitle),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp)
+            )
+            HorizontalDivider(modifier = Modifier.padding(top = 8.dp))
+            THIRD_PARTY_LIBRARIES.forEachIndexed { index, lib ->
+                LibraryRow(lib)
+                if (index < THIRD_PARTY_LIBRARIES.lastIndex) {
+                    HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun LibraryRow(lib: LibraryInfo) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 10.dp),
+        verticalArrangement = Arrangement.spacedBy(2.dp)
+    ) {
         Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp),
+            modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(
-                text = stringResource(R.string.settings_version_label),
-                style = MaterialTheme.typography.bodyMedium
+                text = lib.name,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.SemiBold
             )
+            Surface(
+                color = MaterialTheme.colorScheme.secondaryContainer,
+                shape = RoundedCornerShape(4.dp)
+            ) {
+                Text(
+                    text = lib.license,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                    modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp)
+                )
+            }
+        }
+        if (lib.version != "—") {
             Text(
-                text = BuildConfig.VERSION_NAME,
-                style = MaterialTheme.typography.labelMedium,
+                text = "v${lib.version}",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        if (lib.copyright != null) {
+            Text(
+                text = lib.copyright,
+                style = MaterialTheme.typography.labelSmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
         }

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/wifi/WifiScanViewModel.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/wifi/WifiScanViewModel.kt
@@ -92,6 +92,10 @@ class WifiScanViewModel @Inject constructor(
     private val _autoRefresh = MutableStateFlow(false)
     val autoRefresh: StateFlow<Boolean> = _autoRefresh.asStateFlow()
 
+    /** Network IDs (ssid|security) that the user has expanded. Survives scans. */
+    private val _expandedNetworks = MutableStateFlow<Set<String>>(emptySet())
+    val expandedNetworks: StateFlow<Set<String>> = _expandedNetworks.asStateFlow()
+
     private var scanJob: Job? = null
     private var autoRefreshJob: Job? = null
 
@@ -109,22 +113,31 @@ class WifiScanViewModel @Inject constructor(
         _uiState.value = WifiScanUiState.NoPermission
     }
 
-    fun startScan() {
+    /**
+     * @param silent When true (auto-refresh), keeps the current Success state visible
+     *   while the scan runs instead of replacing it with the Scanning shimmer.
+     */
+    fun startScan(silent: Boolean = false) {
+        // Capture user selections BEFORE any state mutation so they survive the scan.
+        val prev = _uiState.value as? WifiScanUiState.Success
         scanJob?.cancel()
         scanJob = viewModelScope.launch {
-            _uiState.value = WifiScanUiState.Scanning
+            if (!silent) _uiState.value = WifiScanUiState.Scanning
             try {
                 val result = wifiScanUseCase()
                 if (!result.isWifiEnabled) {
                     _uiState.value = WifiScanUiState.WifiDisabled
                 } else {
-                    val prev = _uiState.value as? WifiScanUiState.Success
                     _uiState.value = WifiScanUiState.Success(
                         result = result,
                         bandFilter = prev?.bandFilter
                             ?.takeIf { it in result.detectedBands }
                             ?: result.detectedBands.firstOrNull(),
-                        sortOrder = prev?.sortOrder ?: ApSortOrder.SIGNAL
+                        sortOrder = prev?.sortOrder ?: ApSortOrder.SIGNAL,
+                        // Keep the detail sheet open if the AP is still present in the new scan.
+                        selectedAp = prev?.selectedAp?.let { prevAp ->
+                            result.accessPoints.find { it.bssid == prevAp.bssid }
+                        }
                     )
                     if (!_autoRefresh.value) startAutoRefresh()
                 }
@@ -155,6 +168,12 @@ class WifiScanViewModel @Inject constructor(
         _uiState.value = current.copy(selectedAp = ap)
     }
 
+    fun toggleNetworkExpanded(networkId: String) {
+        val current = _expandedNetworks.value
+        _expandedNetworks.value =
+            if (networkId in current) current - networkId else current + networkId
+    }
+
     fun toggleAutoRefresh() {
         if (_autoRefresh.value) {
             stopAutoRefresh()
@@ -170,7 +189,7 @@ class WifiScanViewModel @Inject constructor(
             while (true) {
                 delay(AUTO_REFRESH_INTERVAL_MS)
                 if (_uiState.value !is WifiScanUiState.Scanning) {
-                    startScan()
+                    startScan(silent = true)
                 }
             }
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -617,6 +617,14 @@
     <!-- Settings – About -->
     <string name="settings_about_section">About</string>
     <string name="settings_version_label">Version</string>
+    <string name="settings_source_code_label">Source Code</string>
+    <string name="settings_source_code_url">github.com/AieatAssam/android-network-tools</string>
+
+    <!-- Settings – Open Source Licenses -->
+    <string name="settings_licenses_section">Open Source Licenses</string>
+    <string name="settings_licenses_subtitle">Third-party libraries used in this app</string>
+    <string name="settings_license_apache2">Apache 2.0</string>
+    <string name="settings_license_bsd3">BSD 3-Clause</string>
 
     <!-- Generic dialogs -->
     <string name="cancel">Cancel</string>


### PR DESCRIPTION
## Summary

- **Wi-Fi scanner — selections no longer reset on auto-refresh**: fixed a root-cause bug where `prev` state was captured *after* `_uiState.value = Scanning` was set, making it always `null` — meaning band tab, sort order, expanded cards, and selected AP all reset on every scan
- **Silent auto-refresh**: background scans no longer flash the shimmer/scanning screen; the current result stays visible and updates in place
- **Detail sheet stays open**: `selectedAp` is matched by BSSID in the fresh scan result and preserved
- **Expanded card state survives scans**: lifted from local `remember { mutableStateOf(false) }` into a `Set<String>` in the ViewModel, keyed by `ssid|security`
- **About page — GitHub homepage link**: tappable "Source Code" row that opens the repo in the browser
- **About page — Open Source Licences section**: lists all eight third-party libraries with license badges; includes BSD-3-Clause copyright notices for dnsjava and MapLibre Compose (legally required for redistribution)

## Test plan

- [ ] Auto-refresh with 5 GHz tab selected — tab should remain on 5 GHz after each refresh
- [ ] Expand an SSID card, wait for auto-refresh — card stays expanded
- [ ] Open an AP detail sheet, wait for auto-refresh — sheet stays open with updated data
- [ ] Manually tap refresh — scanning shimmer appears (non-silent path unchanged)
- [ ] Settings → About: "Source Code" row is tappable and opens GitHub in browser
- [ ] Settings → Open Source Licences: all 8 libraries listed; dnsjava and MapLibre show copyright lines
- [ ] `./gradlew test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)