### PR TITLE
fix: include native debug symbols in release AAB

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -64,6 +64,9 @@ android {
             } else {
                 signingConfigs.getByName("debug")
             }
+            ndk {
+                debugSymbolLevel = "FULL"
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- Adds `ndk { debugSymbolLevel = "FULL" }` to the release build type in `app/build.gradle.kts`
- This instructs AGP to package native `.so` symbol files into the AAB
- Resolves the Google Play Console warning: *"This App Bundle contains native code, and you've not uploaded debug symbols"*
- Enables proper crash/ANR symbolication for native libraries (e.g. `icmpenguin`)

## Test plan

- [ ] CI passes (unit tests + debug APK build)
- [ ] Release build packages symbol files — verify via `bundleRelease` output under `app/build/intermediates/merged_native_libs/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)