### PR TITLE
fix: switch native debugSymbolLevel from FULL to SYMBOL_TABLE

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,7 +65,11 @@ android {
                 signingConfigs.getByName("debug")
             }
             ndk {
-                debugSymbolLevel = "FULL"
+                // FULL requires unstripped input .so files; our native deps ship pre-stripped
+                // in their AARs, so FULL produces nothing (mergeReleaseNativeDebugMetadata
+                // NO-SOURCE). SYMBOL_TABLE uses the stripped libs directly (.dynsym is
+                // preserved), which satisfies Play Store's native symbols check.
+                debugSymbolLevel = "SYMBOL_TABLE"
             }
         }
     }


### PR DESCRIPTION
## Summary

- `debugSymbolLevel = "FULL"` requires unstripped `.so` input files, but all three native deps (`libicmpenguin`, `libandroidx.graphics.path`, `libdatastore_shared_counter`) ship pre-stripped in their AARs
- This caused `mergeReleaseNativeDebugMetadata` to be `NO-SOURCE` every build, so the AAB contained no `BUNDLE-METADATA/com.android.tools.build.debugsymbols/` entry — Play Store kept warning about missing native symbols
- `SYMBOL_TABLE` uses the stripped libs directly (`.dynsym` is preserved), which produces real output from the merge task and satisfies Play Store's check

## Test plan

- [ ] CI passes
- [ ] After release, verify AAB contains symbols: `unzip -l NetSwissKnife-*.aab | grep debugsymbol`
- [ ] Play Store no longer warns about missing native debug symbols on next upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)