### PR TITLE
fix: generate native-debug-symbols.zip for Play Console manual upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,6 +174,32 @@ jobs:
           echo "Found APK: ${APK}"
           echo "Found AAB: ${AAB}"
 
+      # ── 9b. Package native debug symbols ─────────────────────────────────
+      # The three native deps (libicmpenguin, libandroidx.graphics.path,
+      # libdatastore_shared_counter) ship pre-stripped AARs (.symtab removed;
+      # only .dynsym survives). AGP's built-in symbol extraction finds nothing
+      # and mergeReleaseNativeDebugMetadata runs NO-SOURCE, so no symbols are
+      # embedded in the AAB automatically.
+      #
+      # This step packages the merged native libs (which retain .dynsym for
+      # exported function names) into native-debug-symbols.zip. Upload this
+      # zip to Play Console → App bundle explorer → Native debug symbols to
+      # clear the "no debug symbols" advisory warning.
+      - name: Package native debug symbols
+        id: symbols
+        run: |
+          LIB_DIR=$(find app/build/intermediates/merged_native_libs/release \
+                       -type d -name "lib" | head -1)
+          if [ -n "$LIB_DIR" ] && [ -d "$LIB_DIR" ]; then
+            cd "$(dirname "$LIB_DIR")"
+            zip -r "$RUNNER_TEMP/native-debug-symbols.zip" lib/
+            echo "zip=$RUNNER_TEMP/native-debug-symbols.zip" >> "$GITHUB_OUTPUT"
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::No merged native libs found; symbols zip skipped."
+          fi
+
       # ── 10. Rename artefacts with version ─────────────────────────────────
       - name: Rename artefacts
         id: rename
@@ -187,6 +213,12 @@ jobs:
           cp "$AAB" "${DIR_AAB}/NetSwissKnife-${VERSION}.aab"
           echo "apk_named=${DIR}/NetSwissKnife-${VERSION}.apk"    >> "$GITHUB_OUTPUT"
           echo "aab_named=${DIR_AAB}/NetSwissKnife-${VERSION}.aab" >> "$GITHUB_OUTPUT"
+          if [ "${{ steps.symbols.outputs.found }}" == "true" ]; then
+            cp "${{ steps.symbols.outputs.zip }}" \
+               "${DIR_AAB}/native-debug-symbols-${VERSION}.zip"
+            echo "symbols_named=${DIR_AAB}/native-debug-symbols-${VERSION}.zip" \
+              >> "$GITHUB_OUTPUT"
+          fi
 
       # ── 11. Upload artefacts to workflow run ──────────────────────────────
       - name: Upload APK artefact
@@ -203,6 +235,14 @@ jobs:
           path: ${{ steps.rename.outputs.aab_named }}
           if-no-files-found: error
 
+      - name: Upload native debug symbols artefact
+        if: steps.symbols.outputs.found == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: NetSwissKnife-${{ steps.version.outputs.name }}-native-symbols
+          path: ${{ steps.rename.outputs.symbols_named }}
+          if-no-files-found: warn
+
       # ── 12. Create GitHub Release ─────────────────────────────────────────
       - name: Create GitHub Release
         if: >
@@ -218,6 +258,7 @@ jobs:
           files: |
             ${{ steps.rename.outputs.apk_named }}
             ${{ steps.rename.outputs.aab_named }}
+            ${{ steps.rename.outputs.symbols_named }}
           body: |
             ## Net Swiss Knife ${{ steps.version.outputs.name }}
 
@@ -230,6 +271,13 @@ jobs:
 
             **Play Store (AAB)**
             The `.aab` bundle is intended for Google Play internal testing / production upload.
+
+            **Native debug symbols**
+            Download `native-debug-symbols-${{ steps.version.outputs.name }}.zip` and upload it
+            in Play Console → App bundle explorer → select this release → Native debug symbols.
+            This clears the "no debug symbols" advisory warning. Note: these symbols contain
+            only exported function names (.dynsym); upstream deps ship pre-stripped AARs without
+            full debug info.
 
             ### Requirements
             - Android 8.0 (API 26) or higher

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,10 +65,15 @@ android {
                 signingConfigs.getByName("debug")
             }
             ndk {
-                // FULL requires unstripped input .so files; our native deps ship pre-stripped
-                // in their AARs, so FULL produces nothing (mergeReleaseNativeDebugMetadata
-                // NO-SOURCE). SYMBOL_TABLE uses the stripped libs directly (.dynsym is
-                // preserved), which satisfies Play Store's native symbols check.
+                // All three native deps (libicmpenguin, libandroidx.graphics.path,
+                // libdatastore_shared_counter) ship pre-stripped AARs: only .dynsym
+                // survives, no .symtab or .debug_* sections. AGP's extraction tasks
+                // (extractReleaseNativeSymbolTables / extractReleaseNativeDebugMetadata)
+                // require .symtab or .debug_* respectively, so both produce NO-SOURCE
+                // and no symbols end up in the AAB regardless of this setting.
+                // Set SYMBOL_TABLE (correct intent); the CI workflow generates a
+                // native-debug-symbols.zip from the merged libs for manual Play Console
+                // upload until upstream deps ship unstripped libraries.
                 debugSymbolLevel = "SYMBOL_TABLE"
             }
         }


### PR DESCRIPTION
## Summary

- All three native deps (`libicmpenguin`, `libandroidx.graphics.path`, `libdatastore_shared_counter`) ship pre-stripped AARs — only `.dynsym` survives, no `.symtab` or `.debug_*` sections
- AGP's `extractReleaseNativeSymbolTables` / `extractReleaseNativeDebugMetadata` require `.symtab` or `.debug_*` respectively; both produce `mergeReleaseNativeDebugMetadata NO-SOURCE` regardless of `debugSymbolLevel` setting
- No first-party AGP flag can embed symbols in the AAB for these prebuilt deps
- The release workflow now zips the merged native libs (which retain `.dynsym` for exported function names) as `native-debug-symbols-<version>.zip`, published alongside the APK/AAB in GitHub Releases

## Play Console workflow

To clear the "no debug symbols" advisory warning per release:
1. Download `native-debug-symbols-<version>.zip` from the GitHub Release
2. In Play Console → App bundle explorer → select the release → **Native debug symbols** → upload the zip

Note: these symbols contain only exported function names (`.dynsym`); full line-number info would require upstream deps to ship unstripped AARs.

## Test plan

- [ ] CI passes
- [ ] Release artefacts include `native-debug-symbols-*.zip`
- [ ] Zip contains `lib/<abi>/lib*.so` structure for all 4 ABIs

🤖 Generated with [Claude Code](https://claude.com/claude-code)