### PR TITLE
feat: add Cloudflare-based Speed Test tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,14 @@ IPv4 subnet calculator with visual binary breakdown and multi-notation conversio
 - Quick example chips for common subnets (`/8`, `/12`, `/16`, `/24`, `/30`, `/0`)
 - Network alignment warning when the entered IP is not on a network boundary, showing the corrected network address
 
+### Speed Test
+Internet connection speed test measuring latency, download, and upload throughput.
+- Three-phase sequence: **latency** (10 round-trip probes), **download**, then **upload** — each streamed live as it runs
+- Animated phase stepper, live circular speed gauge, and a live throughput-over-time chart per phase
+- Final results: latency min/avg/max/jitter, download/upload average & peak Mbps, and total data transferred, each with its own throughput chart
+- Share button exports a plain-text summary of the results
+- **Powered by Cloudflare** — measurement traffic is sent to and timed against `speed.cloudflare.com` (`/__down` and `/__up`), the same backend that powers Cloudflare's public speed test at <https://speed.cloudflare.com>. Net Swiss Knife is an independent app and is **not affiliated with, sponsored by, or endorsed by Cloudflare, Inc.**; "Cloudflare" and the Cloudflare logo are trademarks of Cloudflare, Inc. Full attribution is also shown in-app under Settings → Data Source Attributions.
+
 ---
 
 ## Module Layout
@@ -220,6 +228,7 @@ Android module (Jetpack Compose, Material 3, Hilt). Contains:
 | `httprobe` | HTTP Probe | Implemented |
 | `subnet` | Subnet Calculator | Implemented |
 | `mdns` | mDNS Service Browser | Implemented |
+| `speedtest` | Speed Test | Implemented |
 
 ---
 

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/di/SpeedTestModule.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/di/SpeedTestModule.kt
@@ -1,0 +1,24 @@
+package net.aieat.netswissknife.app.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import net.aieat.netswissknife.core.domain.SpeedTestUseCase
+import net.aieat.netswissknife.core.network.speedtest.SpeedTestRepository
+import net.aieat.netswissknife.core.network.speedtest.SpeedTestRepositoryImpl
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object SpeedTestModule {
+
+    @Provides
+    @Singleton
+    fun provideSpeedTestRepository(): SpeedTestRepository = SpeedTestRepositoryImpl()
+
+    @Provides
+    @Singleton
+    fun provideSpeedTestUseCase(repository: SpeedTestRepository): SpeedTestUseCase =
+        SpeedTestUseCase(repository)
+}

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/navigation/AppNavigation.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/navigation/AppNavigation.kt
@@ -29,6 +29,7 @@ import net.aieat.netswissknife.app.ui.screens.httprobe.HttpProbeScreen
 import net.aieat.netswissknife.app.ui.screens.subnet.SubnetCalculatorScreen
 import net.aieat.netswissknife.app.ui.screens.settings.SettingsScreen
 import net.aieat.netswissknife.app.ui.screens.mdns.MdnsDiscoveryScreen
+import net.aieat.netswissknife.app.ui.screens.speedtest.SpeedTestScreen
 import net.aieat.netswissknife.app.ui.screens.whois.WhoisScreen
 
 // ── Transition helpers ────────────────────────────────────────────────────────
@@ -108,6 +109,7 @@ fun AppNavHost(navController: NavHostController, modifier: Modifier = Modifier) 
         composable(NavRoutes.HttpProbe.route)         { HttpProbeScreen() }
         composable(NavRoutes.SubnetCalculator.route)  { SubnetCalculatorScreen() }
         composable(NavRoutes.MdnsDiscovery.route)     { MdnsDiscoveryScreen() }
+        composable(NavRoutes.SpeedTest.route)         { SpeedTestScreen() }
         composable(NavRoutes.Settings.route)           { SettingsScreen() }
     }
 }

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/navigation/NavRoutes.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/navigation/NavRoutes.kt
@@ -14,6 +14,7 @@ import androidx.compose.material.icons.filled.NetworkCheck
 import androidx.compose.material.icons.filled.Router
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Speed
 import androidx.compose.material.icons.filled.Wifi
 import androidx.compose.material.icons.filled.WifiFind
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -45,6 +46,7 @@ sealed class NavRoutes(
     object HttpProbe : NavRoutes("httprobe", "HTTP Probe", Icons.Default.Http)
     object SubnetCalculator : NavRoutes("subnet", "Subnet Calc", Icons.Default.Calculate)
     object MdnsDiscovery : NavRoutes("mdns", "mDNS Browser", Icons.Default.CellTower)
+    object SpeedTest : NavRoutes("speedtest", "Speed Test", Icons.Default.Speed)
     object Settings : NavRoutes("settings", "Settings", Icons.Default.Settings)
 
     companion object {
@@ -62,6 +64,7 @@ sealed class NavRoutes(
             ToolInfo("httprobe",   "HTTP Probe",    "HTTP",  Icons.Default.Http,          "HTTP/HTTPS request tester with security header analysis"),
             ToolInfo("subnet",     "Subnet Calc",   "Subnet", Icons.Default.Calculate,     "IPv4 subnet calculator with binary breakdown and notation conversion"),
             ToolInfo("mdns",       "mDNS Browser",  "mDNS",  Icons.Default.CellTower,      "Discover LAN services via multicast DNS"),
+            ToolInfo("speedtest",  "Speed Test",    "Speed", Icons.Default.Speed,          "Download, upload speed and latency via Cloudflare"),
         )
 
         /** Default pinned routes shown in the bottom nav (max MAX_PINNED). */

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/httprobe/HttpProbeScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/httprobe/HttpProbeScreen.kt
@@ -93,6 +93,7 @@ import kotlinx.coroutines.launch
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import net.aieat.netswissknife.app.R
 import net.aieat.netswissknife.app.ui.components.RecentHostsRow
+import net.aieat.netswissknife.app.util.formatBytes
 import net.aieat.netswissknife.app.util.shareText
 import net.aieat.netswissknife.core.network.httprobe.HttpMethod
 import net.aieat.netswissknife.core.network.httprobe.HttpProbeResult
@@ -1129,12 +1130,6 @@ private fun methodColor(method: HttpMethod): Color = when (method) {
     HttpMethod.DELETE  -> MaterialTheme.colorScheme.error
     HttpMethod.HEAD    -> Color(0xFF00695C)
     HttpMethod.OPTIONS -> Color(0xFF4E342E)
-}
-
-private fun formatBytes(bytes: Long): String = when {
-    bytes < 1024        -> "$bytes B"
-    bytes < 1024 * 1024 -> "%.1f KB".format(bytes / 1024.0)
-    else                -> "%.1f MB".format(bytes / (1024.0 * 1024.0))
 }
 
 private fun buildHttpShareText(result: HttpProbeResult): String = buildString {

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/settings/SettingsScreen.kt
@@ -98,6 +98,7 @@ fun SettingsScreen(
             )
             DataSection(onClearRecents = viewModel::clearAllRecentHosts)
             AboutSection()
+            AttributionsSection()
             LicensesSection()
             Spacer(Modifier.height(8.dp))
         }
@@ -342,6 +343,53 @@ private fun AboutSection() {
                         tint = MaterialTheme.colorScheme.primary
                     )
                 }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AttributionsSection() {
+    val uriHandler = LocalUriHandler.current
+
+    SectionHeader(Icons.Default.Info, stringResource(R.string.settings_attributions_section))
+
+    ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Icon(imageVector = Icons.Default.Speed, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+                Text(
+                    text = stringResource(R.string.settings_attribution_speedtest_title),
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.SemiBold
+                )
+            }
+            Spacer(Modifier.height(6.dp))
+            Text(
+                text = stringResource(R.string.settings_attribution_speedtest_body),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(Modifier.height(8.dp))
+            Row(
+                modifier = Modifier
+                    .clickable { uriHandler.openUri("https://speed.cloudflare.com") }
+                    .padding(vertical = 4.dp),
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = "speed.cloudflare.com",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                    textDecoration = TextDecoration.Underline
+                )
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.OpenInNew,
+                    contentDescription = null,
+                    modifier = Modifier.size(14.dp),
+                    tint = MaterialTheme.colorScheme.primary
+                )
             }
         }
     }

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/speedtest/SpeedTestScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/speedtest/SpeedTestScreen.kt
@@ -1,0 +1,830 @@
+package net.aieat.netswissknife.app.ui.screens.speedtest
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.OpenInNew
+import androidx.compose.material.icons.filled.ArrowDownward
+import androidx.compose.material.icons.filled.ArrowUpward
+import androidx.compose.material.icons.filled.NetworkCheck
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material.icons.filled.Speed
+import androidx.compose.material.icons.filled.Stop
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.Button
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.drawText
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.rememberTextMeasurer
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import net.aieat.netswissknife.app.R
+import net.aieat.netswissknife.app.util.formatBytes
+import net.aieat.netswissknife.app.util.shareText
+import net.aieat.netswissknife.core.network.speedtest.LatencyStats
+import net.aieat.netswissknife.core.network.speedtest.SpeedTestPhase
+import net.aieat.netswissknife.core.network.speedtest.SpeedTestResult
+import net.aieat.netswissknife.core.network.speedtest.ThroughputResult
+import net.aieat.netswissknife.core.network.speedtest.ThroughputSample
+import kotlin.math.cos
+import kotlin.math.sin
+
+private const val CLOUDFLARE_SPEED_URL = "https://speed.cloudflare.com"
+private const val GAUGE_MAX_MBPS = 1_000.0
+
+@Composable
+fun SpeedTestScreen(viewModel: SpeedTestViewModel = hiltViewModel()) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+
+    var visible by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) { visible = true }
+
+    val phase = remember(uiState) {
+        when (uiState) {
+            is SpeedTestUiState.Idle -> DisplayPhase.IDLE
+            is SpeedTestUiState.Running -> DisplayPhase.RUNNING
+            is SpeedTestUiState.Finished -> DisplayPhase.FINISHED
+            is SpeedTestUiState.Error -> DisplayPhase.ERROR
+        }
+    }
+
+    AnimatedVisibility(
+        visible = visible,
+        enter = fadeIn(tween(400)) + slideInVertically(tween(400)) { it / 4 }
+    ) {
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            contentPadding = PaddingValues(horizontal = 16.dp, vertical = 16.dp)
+        ) {
+            item { SpeedTestHeaderCard() }
+
+            item {
+                AnimatedContent(
+                    targetState = phase,
+                    transitionSpec = { fadeIn(tween(300)) togetherWith fadeOut(tween(200)) },
+                    label = "speedtest_content_state"
+                ) { target ->
+                    when (target) {
+                        DisplayPhase.IDLE ->
+                            SpeedTestIdleContent(onStart = viewModel::startTest)
+                        DisplayPhase.RUNNING ->
+                            (uiState as? SpeedTestUiState.Running)?.let {
+                                SpeedTestRunningContent(it, onCancel = viewModel::onCancel)
+                            }
+                        DisplayPhase.FINISHED ->
+                            (uiState as? SpeedTestUiState.Finished)?.let { finished ->
+                                SpeedTestResultContent(
+                                    result = finished.result,
+                                    onRetry = viewModel::onRetry,
+                                    onShare = {
+                                        context.shareText(
+                                            text = buildSpeedTestShareText(finished.result),
+                                            subject = context.getString(R.string.share_subject_speedtest, "results")
+                                        )
+                                    }
+                                )
+                            }
+                        DisplayPhase.ERROR ->
+                            (uiState as? SpeedTestUiState.Error)?.let {
+                                SpeedTestErrorContent(it, onRetry = viewModel::onRetry)
+                            }
+                    }
+                }
+            }
+
+            item { CloudflareAttributionCard() }
+        }
+    }
+}
+
+private enum class DisplayPhase { IDLE, RUNNING, FINISHED, ERROR }
+
+// ── Header ────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun SpeedTestHeaderCard() {
+    val uriHandler = LocalUriHandler.current
+
+    ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+        Box(modifier = Modifier.fillMaxWidth()) {
+            Canvas(modifier = Modifier.matchParentSize()) {
+                drawRect(
+                    brush = Brush.linearGradient(
+                        listOf(Color(0xFFF38020), Color(0xFF1565C0))
+                    )
+                )
+            }
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp, vertical = 18.dp)
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        imageVector = Icons.Default.Speed,
+                        contentDescription = null,
+                        tint = Color.White,
+                        modifier = Modifier.size(28.dp)
+                    )
+                    Spacer(Modifier.width(10.dp))
+                    Text(
+                        text = stringResource(R.string.speedtest_screen_title),
+                        style = MaterialTheme.typography.headlineMedium,
+                        color = Color.White,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    text = stringResource(R.string.speedtest_screen_subtitle),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = Color.White.copy(alpha = 0.9f)
+                )
+                Spacer(Modifier.height(10.dp))
+                Surface(
+                    color = Color.White.copy(alpha = 0.18f),
+                    shape = RoundedCornerShape(50),
+                    modifier = Modifier.clickable { uriHandler.openUri(CLOUDFLARE_SPEED_URL) }
+                ) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(6.dp),
+                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp)
+                    ) {
+                        Text(
+                            text = stringResource(R.string.speedtest_attribution),
+                            style = MaterialTheme.typography.labelMedium,
+                            color = Color.White
+                        )
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.OpenInNew,
+                            contentDescription = null,
+                            tint = Color.White,
+                            modifier = Modifier.size(14.dp)
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ── Idle state ────────────────────────────────────────────────────────────────
+
+@Composable
+private fun SpeedTestIdleContent(onStart: () -> Unit) {
+    val infiniteTransition = rememberInfiniteTransition(label = "speedtest_idle_pulse")
+    val pulse by infiniteTransition.animateFloat(
+        initialValue = 0.94f, targetValue = 1.0f,
+        animationSpec = infiniteRepeatable(tween(1100), RepeatMode.Reverse),
+        label = "speedtest_idle_pulse_scale"
+    )
+
+    ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(28.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(140.dp)
+                    .scale(pulse)
+                    .background(
+                        brush = Brush.radialGradient(
+                            listOf(
+                                MaterialTheme.colorScheme.primary.copy(alpha = 0.25f),
+                                Color.Transparent
+                            )
+                        ),
+                        shape = CircleShape
+                    )
+                    .clickable(onClick = onStart),
+                contentAlignment = Alignment.Center
+            ) {
+                Surface(
+                    shape = CircleShape,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(96.dp)
+                ) {
+                    Box(contentAlignment = Alignment.Center) {
+                        Icon(
+                            imageVector = Icons.Default.PlayArrow,
+                            contentDescription = stringResource(R.string.speedtest_start_button),
+                            tint = MaterialTheme.colorScheme.onPrimary,
+                            modifier = Modifier.size(44.dp)
+                        )
+                    }
+                }
+            }
+            Spacer(Modifier.height(20.dp))
+            Text(
+                text = stringResource(R.string.speedtest_idle_title),
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.SemiBold
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = stringResource(R.string.speedtest_idle_subtitle),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(Modifier.height(20.dp))
+            Button(onClick = onStart, modifier = Modifier.fillMaxWidth()) {
+                Icon(Icons.Default.PlayArrow, contentDescription = null)
+                Spacer(Modifier.width(8.dp))
+                Text(stringResource(R.string.speedtest_start_button))
+            }
+        }
+    }
+}
+
+// ── Running state ─────────────────────────────────────────────────────────────
+
+@Composable
+private fun SpeedTestRunningContent(state: SpeedTestUiState.Running, onCancel: () -> Unit) {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+            Column(modifier = Modifier.padding(16.dp)) {
+                PhaseStepper(currentPhase = state.phase)
+                Spacer(Modifier.height(16.dp))
+
+                val phaseTitle = when (state.phase) {
+                    SpeedTestPhase.LATENCY -> R.string.speedtest_running_latency
+                    SpeedTestPhase.DOWNLOAD -> R.string.speedtest_running_download
+                    SpeedTestPhase.UPLOAD -> R.string.speedtest_running_upload
+                }
+                Text(
+                    text = stringResource(phaseTitle),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold
+                )
+                Spacer(Modifier.height(16.dp))
+
+                when (state.phase) {
+                    SpeedTestPhase.LATENCY -> LatencyLiveStats(state.latencyStats)
+                    SpeedTestPhase.DOWNLOAD -> ThroughputLiveView(
+                        samples = state.downloadSamples,
+                        accentColor = MaterialTheme.colorScheme.primary,
+                        icon = Icons.Default.ArrowDownward
+                    )
+                    SpeedTestPhase.UPLOAD -> ThroughputLiveView(
+                        samples = state.uploadSamples,
+                        accentColor = MaterialTheme.colorScheme.tertiary,
+                        icon = Icons.Default.ArrowUpward
+                    )
+                }
+            }
+        }
+
+        if (state.phase != SpeedTestPhase.LATENCY) {
+            ResultStrip(downloadResult = state.downloadResult)
+        }
+
+        OutlinedButton(onClick = onCancel, modifier = Modifier.fillMaxWidth()) {
+            Icon(Icons.Default.Stop, contentDescription = null)
+            Spacer(Modifier.width(8.dp))
+            Text(stringResource(R.string.speedtest_cancel_button))
+        }
+    }
+}
+
+@Composable
+private fun PhaseStepper(currentPhase: SpeedTestPhase) {
+    val phases = listOf(
+        SpeedTestPhase.LATENCY to R.string.speedtest_phase_latency,
+        SpeedTestPhase.DOWNLOAD to R.string.speedtest_phase_download,
+        SpeedTestPhase.UPLOAD to R.string.speedtest_phase_upload
+    )
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        phases.forEach { (phase, labelRes) ->
+            val isActive = phase == currentPhase
+            val isDone = phase.ordinal < currentPhase.ordinal
+            val containerColor by animateFloatAsState(
+                targetValue = if (isActive || isDone) 1f else 0f,
+                animationSpec = tween(300),
+                label = "phase_chip_${phase.name}"
+            )
+            Surface(
+                modifier = Modifier.weight(1f),
+                shape = RoundedCornerShape(50),
+                color = androidx.compose.ui.graphics.lerp(
+                    MaterialTheme.colorScheme.surfaceVariant,
+                    MaterialTheme.colorScheme.primary,
+                    containerColor
+                )
+            ) {
+                Text(
+                    text = stringResource(labelRes),
+                    style = MaterialTheme.typography.labelMedium,
+                    fontWeight = if (isActive) FontWeight.Bold else FontWeight.Normal,
+                    color = androidx.compose.ui.graphics.lerp(
+                        MaterialTheme.colorScheme.onSurfaceVariant,
+                        MaterialTheme.colorScheme.onPrimary,
+                        containerColor
+                    ),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 8.dp),
+                    textAlign = androidx.compose.ui.text.style.TextAlign.Center
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun LatencyLiveStats(stats: LatencyStats) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier.fillMaxWidth()) {
+        val infiniteTransition = rememberInfiniteTransition(label = "latency_pulse")
+        val pulse by infiniteTransition.animateFloat(
+            initialValue = 0.9f, targetValue = 1.05f,
+            animationSpec = infiniteRepeatable(tween(700), RepeatMode.Reverse),
+            label = "latency_pulse_scale"
+        )
+        Icon(
+            imageVector = Icons.Default.NetworkCheck,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier
+                .size(56.dp)
+                .scale(pulse)
+        )
+        Spacer(Modifier.height(12.dp))
+        if (stats.samples.isNotEmpty()) {
+            StatGrid(latencyStatGridEntries(stats))
+        }
+    }
+}
+
+@Composable
+private fun latencyStatGridEntries(stats: LatencyStats): List<Pair<String, String>> {
+    val msSuffix = stringResource(R.string.speedtest_ms_suffix)
+    return listOf(
+        stringResource(R.string.speedtest_latency_min) to "${stats.minMs} $msSuffix",
+        stringResource(R.string.speedtest_latency_avg) to "%.1f %s".format(stats.avgMs, msSuffix),
+        stringResource(R.string.speedtest_latency_max) to "${stats.maxMs} $msSuffix",
+        stringResource(R.string.speedtest_latency_jitter) to "%.1f %s".format(stats.jitterMs, msSuffix)
+    )
+}
+
+@Composable
+private fun ThroughputLiveView(
+    samples: List<ThroughputSample>,
+    accentColor: Color,
+    icon: androidx.compose.ui.graphics.vector.ImageVector
+) {
+    val current = samples.lastOrNull()?.instantMbps ?: 0.0
+    Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier.fillMaxWidth()) {
+        SpeedGauge(valueMbps = current, accentColor = accentColor, icon = icon)
+        Spacer(Modifier.height(16.dp))
+        ThroughputChart(samples = samples, accentColor = accentColor)
+    }
+}
+
+// ── Speed gauge ───────────────────────────────────────────────────────────────
+
+@Composable
+private fun SpeedGauge(
+    valueMbps: Double,
+    accentColor: Color,
+    icon: androidx.compose.ui.graphics.vector.ImageVector
+) {
+    val animatedValue by animateFloatAsState(
+        targetValue = valueMbps.toFloat(),
+        animationSpec = tween(500),
+        label = "speed_gauge_value"
+    )
+    val trackColor = MaterialTheme.colorScheme.surfaceVariant
+    val density = LocalDensity.current
+    val strokeWidth = with(density) { 14.dp.toPx() }
+
+    Box(
+        modifier = Modifier.size(180.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Canvas(modifier = Modifier.fillMaxSize()) {
+            val sweepBackground = 270f
+            val startAngle = 135f
+            val inset = strokeWidth / 2
+            val arcSize = androidx.compose.ui.geometry.Size(size.width - strokeWidth, size.height - strokeWidth)
+            val topLeft = Offset(inset, inset)
+
+            drawArc(
+                color = trackColor,
+                startAngle = startAngle,
+                sweepAngle = sweepBackground,
+                useCenter = false,
+                topLeft = topLeft,
+                size = arcSize,
+                style = Stroke(width = strokeWidth, cap = StrokeCap.Round)
+            )
+
+            val progress = (animatedValue / GAUGE_MAX_MBPS.toFloat()).coerceIn(0f, 1f)
+            drawArc(
+                brush = Brush.sweepGradient(listOf(accentColor.copy(alpha = 0.4f), accentColor)),
+                startAngle = startAngle,
+                sweepAngle = sweepBackground * progress,
+                useCenter = false,
+                topLeft = topLeft,
+                size = arcSize,
+                style = Stroke(width = strokeWidth, cap = StrokeCap.Round)
+            )
+        }
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Icon(imageVector = icon, contentDescription = null, tint = accentColor, modifier = Modifier.size(20.dp))
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = "%.1f".format(animatedValue),
+                style = MaterialTheme.typography.displaySmall,
+                fontWeight = FontWeight.Bold
+            )
+            Text(
+                text = stringResource(R.string.speedtest_mbps_suffix),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+// ── Throughput chart ──────────────────────────────────────────────────────────
+
+@Composable
+private fun ThroughputChart(samples: List<ThroughputSample>, accentColor: Color) {
+    if (samples.size < 2) return
+
+    val surfaceColor = MaterialTheme.colorScheme.surfaceVariant
+    val labelColor = MaterialTheme.colorScheme.onSurfaceVariant
+    val textMeasurer = rememberTextMeasurer()
+    val labelStyle = MaterialTheme.typography.labelSmall.copy(fontSize = 9.sp, color = labelColor)
+    val density = LocalDensity.current
+    val leftPad = with(density) { 38.dp.toPx() }
+    val edgePad = with(density) { 8.dp.toPx() }
+
+    Canvas(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(120.dp)
+    ) {
+        val chartWidth = size.width
+        val chartHeight = size.height
+        val maxMbps = (samples.maxOfOrNull { it.instantMbps } ?: 1.0).coerceAtLeast(1.0)
+
+        val gridLines = 4
+        repeat(gridLines) { i ->
+            val y = edgePad + (chartHeight - 2 * edgePad) * i / (gridLines - 1)
+            drawLine(
+                color = surfaceColor,
+                start = Offset(leftPad, y),
+                end = Offset(chartWidth - edgePad, y),
+                strokeWidth = 1f
+            )
+            val valueAtLine = maxMbps * (gridLines - 1 - i) / (gridLines - 1)
+            val measured = textMeasurer.measure("%.0f".format(valueAtLine), style = labelStyle)
+            drawText(textLayoutResult = measured, topLeft = Offset(0f, y - measured.size.height / 2f))
+        }
+
+        val points = samples.mapIndexed { index, sample ->
+            val x = leftPad + (chartWidth - leftPad - edgePad) * index / (samples.size - 1).coerceAtLeast(1)
+            val y = chartHeight - edgePad - (sample.instantMbps / maxMbps).toFloat() * (chartHeight - 2 * edgePad)
+            Offset(x, y)
+        }
+
+        val fillPath = Path().apply {
+            moveTo(points.first().x, chartHeight - edgePad)
+            points.forEach { lineTo(it.x, it.y) }
+            lineTo(points.last().x, chartHeight - edgePad)
+            close()
+        }
+        drawPath(
+            path = fillPath,
+            brush = Brush.verticalGradient(
+                colors = listOf(accentColor.copy(alpha = 0.35f), Color.Transparent),
+                startY = 0f, endY = chartHeight
+            )
+        )
+        val linePath = Path().apply {
+            moveTo(points.first().x, points.first().y)
+            points.drop(1).forEach { lineTo(it.x, it.y) }
+        }
+        drawPath(path = linePath, color = accentColor, style = Stroke(width = 2.5f, cap = StrokeCap.Round))
+    }
+}
+
+// ── Result strip (mini summary while running) ────────────────────────────────
+
+@Composable
+private fun ResultStrip(downloadResult: ThroughputResult?) {
+    if (downloadResult == null) return
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        MiniResultCard(
+            modifier = Modifier.weight(1f),
+            label = stringResource(R.string.speedtest_download_header),
+            icon = Icons.Default.ArrowDownward,
+            accentColor = MaterialTheme.colorScheme.primary,
+            valueMbps = downloadResult.avgMbps
+        )
+    }
+}
+
+@Composable
+private fun MiniResultCard(
+    modifier: Modifier = Modifier,
+    label: String,
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    accentColor: Color,
+    valueMbps: Double
+) {
+    ElevatedCard(modifier = modifier) {
+        Column(
+            modifier = Modifier.padding(14.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                Icon(imageVector = icon, contentDescription = null, tint = accentColor, modifier = Modifier.size(16.dp))
+                Text(text = label, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = "%.1f %s".format(valueMbps, stringResource(R.string.speedtest_mbps_suffix)),
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold,
+                color = accentColor
+            )
+        }
+    }
+}
+
+// ── Finished state ────────────────────────────────────────────────────────────
+
+@Composable
+private fun SpeedTestResultContent(
+    result: SpeedTestResult,
+    onRetry: () -> Unit,
+    onShare: () -> Unit
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        Text(
+            text = stringResource(R.string.speedtest_results_header),
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold
+        )
+
+        LatencyResultCard(result.latency)
+        ThroughputResultCard(
+            title = stringResource(R.string.speedtest_download_header),
+            icon = Icons.Default.ArrowDownward,
+            accentColor = MaterialTheme.colorScheme.primary,
+            result = result.download
+        )
+        ThroughputResultCard(
+            title = stringResource(R.string.speedtest_upload_header),
+            icon = Icons.Default.ArrowUpward,
+            accentColor = MaterialTheme.colorScheme.tertiary,
+            result = result.upload
+        )
+
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+            OutlinedButton(onClick = onShare, modifier = Modifier.weight(1f)) {
+                Icon(Icons.Default.Share, contentDescription = null)
+                Spacer(Modifier.width(8.dp))
+                Text(stringResource(R.string.speedtest_share))
+            }
+            Button(onClick = onRetry, modifier = Modifier.weight(1f)) {
+                Icon(Icons.Default.Refresh, contentDescription = null)
+                Spacer(Modifier.width(8.dp))
+                Text(stringResource(R.string.speedtest_retry))
+            }
+        }
+    }
+}
+
+@Composable
+private fun LatencyResultCard(stats: LatencyStats) {
+    ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Icon(Icons.Default.NetworkCheck, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+                Text(
+                    text = stringResource(R.string.speedtest_latency_header),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold
+                )
+            }
+            Spacer(Modifier.height(12.dp))
+            StatGrid(latencyStatGridEntries(stats))
+        }
+    }
+}
+
+@Composable
+private fun ThroughputResultCard(
+    title: String,
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    accentColor: Color,
+    result: ThroughputResult
+) {
+    ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Icon(imageVector = icon, contentDescription = null, tint = accentColor)
+                Text(text = title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+            }
+            Spacer(Modifier.height(12.dp))
+            StatGrid(
+                listOf(
+                    stringResource(R.string.speedtest_avg_speed) to "%.1f %s".format(result.avgMbps, stringResource(R.string.speedtest_mbps_suffix)),
+                    stringResource(R.string.speedtest_peak_speed) to "%.1f %s".format(result.peakMbps, stringResource(R.string.speedtest_mbps_suffix)),
+                    stringResource(R.string.speedtest_data_transferred) to formatBytes(result.bytesTransferred)
+                )
+            )
+            if (result.samples.size >= 2) {
+                Spacer(Modifier.height(16.dp))
+                Text(
+                    text = stringResource(R.string.speedtest_chart_title),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(Modifier.height(8.dp))
+                ThroughputChart(samples = result.samples, accentColor = accentColor)
+            }
+        }
+    }
+}
+
+// ── Error state ───────────────────────────────────────────────────────────────
+
+@Composable
+private fun SpeedTestErrorContent(state: SpeedTestUiState.Error, onRetry: () -> Unit) {
+    ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Icon(
+                imageVector = Icons.Default.Warning,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.error,
+                modifier = Modifier.size(48.dp)
+            )
+            Spacer(Modifier.height(12.dp))
+            Text(
+                text = stringResource(R.string.speedtest_error_title),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.error
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = state.message,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = androidx.compose.ui.text.style.TextAlign.Center
+            )
+            Spacer(Modifier.height(20.dp))
+            FilledTonalButton(onClick = onRetry) {
+                Icon(Icons.Default.Refresh, contentDescription = null)
+                Spacer(Modifier.width(8.dp))
+                Text(stringResource(R.string.speedtest_retry))
+            }
+        }
+    }
+}
+
+// ── Shared helpers ────────────────────────────────────────────────────────────
+
+@Composable
+private fun StatGrid(entries: List<Pair<String, String>>) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        entries.forEach { (label, value) ->
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Text(text = value, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                Text(text = label, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+        }
+    }
+}
+
+@Composable
+private fun CloudflareAttributionCard() {
+    val uriHandler = LocalUriHandler.current
+    ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = stringResource(R.string.speedtest_attribution_note),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(Modifier.height(8.dp))
+            HorizontalDivider()
+            Spacer(Modifier.height(8.dp))
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { uriHandler.openUri(CLOUDFLARE_SPEED_URL) },
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = CLOUDFLARE_SPEED_URL,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                    textDecoration = TextDecoration.Underline
+                )
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.OpenInNew,
+                    contentDescription = null,
+                    modifier = Modifier.size(14.dp),
+                    tint = MaterialTheme.colorScheme.primary
+                )
+            }
+        }
+    }
+}
+
+private fun buildSpeedTestShareText(result: SpeedTestResult): String = buildString {
+    appendLine("Net Swiss Knife – Speed Test Results")
+    appendLine()
+    appendLine("Latency: min ${result.latency.minMs} ms / avg %.1f ms / max ${result.latency.maxMs} ms / jitter %.1f ms"
+        .format(result.latency.avgMs, result.latency.jitterMs))
+    appendLine("Download: avg %.1f Mbps / peak %.1f Mbps / %s".format(result.download.avgMbps, result.download.peakMbps, formatBytes(result.download.bytesTransferred)))
+    appendLine("Upload: avg %.1f Mbps / peak %.1f Mbps / %s".format(result.upload.avgMbps, result.upload.peakMbps, formatBytes(result.upload.bytesTransferred)))
+    appendLine()
+    appendLine("Measured against $CLOUDFLARE_SPEED_URL")
+}

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/speedtest/SpeedTestViewModel.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/speedtest/SpeedTestViewModel.kt
@@ -1,0 +1,116 @@
+package net.aieat.netswissknife.app.ui.screens.speedtest
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import net.aieat.netswissknife.core.domain.SpeedTestUseCase
+import net.aieat.netswissknife.core.network.speedtest.LatencySample
+import net.aieat.netswissknife.core.network.speedtest.LatencyStats
+import net.aieat.netswissknife.core.network.speedtest.SpeedTestEvent
+import net.aieat.netswissknife.core.network.speedtest.SpeedTestPhase
+import net.aieat.netswissknife.core.network.speedtest.SpeedTestResult
+import net.aieat.netswissknife.core.network.speedtest.ThroughputResult
+import net.aieat.netswissknife.core.network.speedtest.ThroughputSample
+import javax.inject.Inject
+
+/** All possible states for the Speed Test UI. */
+sealed interface SpeedTestUiState {
+    object Idle : SpeedTestUiState
+    data class Running(
+        val phase: SpeedTestPhase,
+        val latencyStats: LatencyStats = LatencyStats.EMPTY,
+        val downloadSamples: List<ThroughputSample> = emptyList(),
+        val downloadResult: ThroughputResult? = null,
+        val uploadSamples: List<ThroughputSample> = emptyList()
+    ) : SpeedTestUiState
+    data class Finished(val result: SpeedTestResult) : SpeedTestUiState
+    data class Error(val phase: SpeedTestPhase, val message: String) : SpeedTestUiState
+}
+
+@HiltViewModel
+class SpeedTestViewModel @Inject constructor(
+    private val speedTestUseCase: SpeedTestUseCase
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<SpeedTestUiState>(SpeedTestUiState.Idle)
+    val uiState: StateFlow<SpeedTestUiState> = _uiState.asStateFlow()
+
+    private var testJob: Job? = null
+
+    fun startTest() {
+        testJob?.cancel()
+
+        val latencySamples = mutableListOf<LatencySample>()
+        val downloadSamples = mutableListOf<ThroughputSample>()
+        val uploadSamples = mutableListOf<ThroughputSample>()
+        var current = SpeedTestUiState.Running(phase = SpeedTestPhase.LATENCY)
+
+        _uiState.value = current
+
+        fun emit(next: SpeedTestUiState.Running) {
+            current = next
+            _uiState.value = next
+        }
+
+        testJob = viewModelScope.launch {
+            speedTestUseCase().collect { event ->
+                when (event) {
+                    is SpeedTestEvent.LatencyProgress -> {
+                        latencySamples.add(event.sample)
+                        emit(current.copy(
+                            phase = SpeedTestPhase.LATENCY,
+                            latencyStats = LatencyStats.compute(latencySamples)
+                        ))
+                    }
+                    is SpeedTestEvent.LatencyFinished -> {
+                        emit(current.copy(phase = SpeedTestPhase.DOWNLOAD, latencyStats = event.stats))
+                    }
+                    is SpeedTestEvent.DownloadProgress -> {
+                        downloadSamples.add(event.sample)
+                        emit(current.copy(downloadSamples = downloadSamples.toList()))
+                    }
+                    is SpeedTestEvent.DownloadFinished -> {
+                        emit(current.copy(phase = SpeedTestPhase.UPLOAD, downloadResult = event.result))
+                    }
+                    is SpeedTestEvent.UploadProgress -> {
+                        uploadSamples.add(event.sample)
+                        emit(current.copy(uploadSamples = uploadSamples.toList()))
+                    }
+                    is SpeedTestEvent.UploadFinished -> {
+                        val download = checkNotNull(current.downloadResult) {
+                            "UploadFinished received before DownloadFinished"
+                        }
+                        _uiState.value = SpeedTestUiState.Finished(
+                            SpeedTestResult(
+                                latency = current.latencyStats,
+                                download = download,
+                                upload = event.result
+                            )
+                        )
+                    }
+                    is SpeedTestEvent.Failed -> {
+                        _uiState.value = SpeedTestUiState.Error(event.phase, event.message)
+                    }
+                }
+            }
+        }
+    }
+
+    fun onCancel() {
+        testJob?.cancel()
+        testJob = null
+        _uiState.value = SpeedTestUiState.Idle
+    }
+
+    fun onRetry() = startTest()
+
+    override fun onCleared() {
+        super.onCleared()
+        testJob?.cancel()
+    }
+}

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/util/FormatUtils.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/util/FormatUtils.kt
@@ -1,0 +1,8 @@
+package net.aieat.netswissknife.app.util
+
+fun formatBytes(bytes: Long): String = when {
+    bytes < 1024 -> "$bytes B"
+    bytes < 1024 * 1024 -> "%.1f KB".format(bytes / 1024.0)
+    bytes < 1024 * 1024 * 1024 -> "%.1f MB".format(bytes / (1024.0 * 1024.0))
+    else -> "%.2f GB".format(bytes / (1024.0 * 1024.0 * 1024.0))
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -620,6 +620,11 @@
     <string name="settings_source_code_label">Source Code</string>
     <string name="settings_source_code_url">github.com/AieatAssam/android-network-tools</string>
 
+    <!-- Settings – Data Source Attributions -->
+    <string name="settings_attributions_section">Data Source Attributions</string>
+    <string name="settings_attribution_speedtest_title">Speed Test — Cloudflare</string>
+    <string name="settings_attribution_speedtest_body">The Speed Test tool sends measurement traffic to and is timed against Cloudflare\'s public speed test service (the same backend that powers speed.cloudflare.com). Net Swiss Knife is an independent app and is not affiliated with, sponsored by, or endorsed by Cloudflare, Inc. Cloudflare and the Cloudflare logo are trademarks of Cloudflare, Inc.</string>
+
     <!-- Settings – Open Source Licenses -->
     <string name="settings_licenses_section">Open Source Licenses</string>
     <string name="settings_licenses_subtitle">Third-party libraries used in this app</string>
@@ -646,5 +651,45 @@
     <string name="share_subject_lan">LAN scan – %1$s</string>
     <string name="share_subject_http">HTTP – %1$s</string>
     <string name="share_subject_dns">DNS %1$s – %2$s</string>
+    <string name="share_subject_speedtest">Speed Test – %1$s</string>
+
+    <!-- Speed Test -->
+    <string name="speedtest_screen_title">Speed Test</string>
+    <string name="speedtest_screen_subtitle">Measure download, upload speed and latency against Cloudflare\'s global network</string>
+    <string name="speedtest_attribution">Powered by Cloudflare Speed Test</string>
+    <string name="speedtest_attribution_note">Test traffic is sent to and measured by Cloudflare\'s speed.cloudflare.com service. Net Swiss Knife is not affiliated with, sponsored by, or endorsed by Cloudflare, Inc.</string>
+
+    <string name="speedtest_idle_title">Ready to test your connection</string>
+    <string name="speedtest_idle_subtitle">Measures latency, download, and upload speed in sequence</string>
+    <string name="speedtest_start_button">Start Test</string>
+    <string name="speedtest_cancel_button">Cancel</string>
+    <string name="speedtest_retry">Run again</string>
+    <string name="speedtest_share">Share results</string>
+
+    <string name="speedtest_phase_latency">Latency</string>
+    <string name="speedtest_phase_download">Download</string>
+    <string name="speedtest_phase_upload">Upload</string>
+
+    <string name="speedtest_running_latency">Measuring latency…</string>
+    <string name="speedtest_running_download">Testing download speed…</string>
+    <string name="speedtest_running_upload">Testing upload speed…</string>
+    <string name="speedtest_error_title">Speed test failed</string>
+
+    <string name="speedtest_mbps_suffix">Mbps</string>
+    <string name="speedtest_ms_suffix">ms</string>
+
+    <string name="speedtest_latency_header">Latency</string>
+    <string name="speedtest_latency_min">Min</string>
+    <string name="speedtest_latency_avg">Avg</string>
+    <string name="speedtest_latency_max">Max</string>
+    <string name="speedtest_latency_jitter">Jitter</string>
+
+    <string name="speedtest_download_header">Download</string>
+    <string name="speedtest_upload_header">Upload</string>
+    <string name="speedtest_avg_speed">Average</string>
+    <string name="speedtest_peak_speed">Peak</string>
+    <string name="speedtest_data_transferred">Data transferred</string>
+    <string name="speedtest_chart_title">Throughput over time</string>
+    <string name="speedtest_results_header">Results</string>
 
 </resources>

--- a/core-domain/src/main/kotlin/net/aieat/netswissknife/core/domain/SpeedTestUseCase.kt
+++ b/core-domain/src/main/kotlin/net/aieat/netswissknife/core/domain/SpeedTestUseCase.kt
@@ -1,0 +1,12 @@
+package net.aieat.netswissknife.core.domain
+
+import kotlinx.coroutines.flow.Flow
+import net.aieat.netswissknife.core.network.speedtest.SpeedTestEvent
+import net.aieat.netswissknife.core.network.speedtest.SpeedTestRepository
+
+/** Orchestrates a full latency/download/upload speed test run. */
+class SpeedTestUseCase(
+    private val repository: SpeedTestRepository
+) {
+    operator fun invoke(): Flow<SpeedTestEvent> = repository.runSpeedTest()
+}

--- a/core-domain/src/test/kotlin/net/aieat/netswissknife/core/domain/SpeedTestUseCaseTest.kt
+++ b/core-domain/src/test/kotlin/net/aieat/netswissknife/core/domain/SpeedTestUseCaseTest.kt
@@ -1,0 +1,32 @@
+package net.aieat.netswissknife.core.domain
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import net.aieat.netswissknife.core.network.speedtest.LatencyStats
+import net.aieat.netswissknife.core.network.speedtest.SpeedTestEvent
+import net.aieat.netswissknife.core.network.speedtest.SpeedTestRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@DisplayName("SpeedTestUseCase")
+class SpeedTestUseCaseTest {
+
+    private class FakeRepository(private val events: List<SpeedTestEvent>) : SpeedTestRepository {
+        override fun runSpeedTest(): Flow<SpeedTestEvent> = flowOf(*events.toTypedArray())
+    }
+
+    @Test
+    fun `delegates to the repository and streams its events unchanged`() = runTest {
+        val expected = listOf(
+            SpeedTestEvent.LatencyFinished(LatencyStats.EMPTY)
+        )
+        val useCase = SpeedTestUseCase(FakeRepository(expected))
+
+        assertEquals(expected, useCase().toList())
+    }
+}

--- a/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/speedtest/SpeedTestModels.kt
+++ b/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/speedtest/SpeedTestModels.kt
@@ -1,0 +1,95 @@
+package net.aieat.netswissknife.core.network.speedtest
+
+/** Phases of a full speed test run, in execution order. */
+enum class SpeedTestPhase {
+    LATENCY, DOWNLOAD, UPLOAD
+}
+
+/** A single round-trip latency probe result. */
+data class LatencySample(
+    val sequence: Int,
+    val rtTimeMs: Long
+)
+
+/** Aggregated statistics over a set of [LatencySample]s. */
+data class LatencyStats(
+    val minMs: Long,
+    val avgMs: Double,
+    val maxMs: Long,
+    val jitterMs: Double,
+    val samples: List<LatencySample>
+) {
+    companion object {
+        val EMPTY = LatencyStats(0L, 0.0, 0L, 0.0, emptyList())
+
+        /** Computes min/avg/max/jitter from a list of samples. Jitter is the mean
+         * absolute difference between consecutive RTTs (RFC 3550 style approximation). */
+        fun compute(samples: List<LatencySample>): LatencyStats {
+            if (samples.isEmpty()) return EMPTY
+            val rtts = samples.map { it.rtTimeMs }
+            val jitter = if (rtts.size > 1) {
+                rtts.zipWithNext { a, b -> kotlin.math.abs(b - a) }.average()
+            } else 0.0
+            return LatencyStats(
+                minMs = rtts.min(),
+                avgMs = rtts.average(),
+                maxMs = rtts.max(),
+                jitterMs = jitter,
+                samples = samples
+            )
+        }
+    }
+}
+
+/** A throughput measurement taken at [elapsedMs] since the phase started. */
+data class ThroughputSample(
+    val elapsedMs: Long,
+    val bytesTransferred: Long,
+    val instantMbps: Double
+)
+
+/** Aggregated result of a download or upload throughput phase. */
+data class ThroughputResult(
+    val avgMbps: Double,
+    val peakMbps: Double,
+    val bytesTransferred: Long,
+    val durationMs: Long,
+    val samples: List<ThroughputSample>
+) {
+    companion object {
+        val EMPTY = ThroughputResult(0.0, 0.0, 0L, 0L, emptyList())
+
+        /** Builds a result from accumulated bytes/duration and the per-interval samples. */
+        fun from(totalBytes: Long, durationMs: Long, samples: List<ThroughputSample>): ThroughputResult {
+            val avgMbps = if (durationMs > 0) {
+                (totalBytes * 8.0 / 1_000_000.0) / (durationMs / 1000.0)
+            } else 0.0
+            val peakMbps = samples.maxOfOrNull { it.instantMbps } ?: avgMbps
+            return ThroughputResult(
+                avgMbps = avgMbps,
+                peakMbps = peakMbps,
+                bytesTransferred = totalBytes,
+                durationMs = durationMs,
+                samples = samples
+            )
+        }
+    }
+}
+
+/** Final, combined result of a completed speed test run. */
+data class SpeedTestResult(
+    val latency: LatencyStats,
+    val download: ThroughputResult,
+    val upload: ThroughputResult
+)
+
+/** Streaming events emitted while a speed test is in progress. */
+sealed interface SpeedTestEvent {
+    data class LatencyProgress(val sample: LatencySample, val total: Int) : SpeedTestEvent
+    data class LatencyFinished(val stats: LatencyStats) : SpeedTestEvent
+    data class DownloadProgress(val sample: ThroughputSample) : SpeedTestEvent
+    data class DownloadFinished(val result: ThroughputResult) : SpeedTestEvent
+    data class UploadProgress(val sample: ThroughputSample) : SpeedTestEvent
+    data class UploadFinished(val result: ThroughputResult) : SpeedTestEvent
+    data class Failed(val phase: SpeedTestPhase, val message: String) : SpeedTestEvent
+}

--- a/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/speedtest/SpeedTestRepository.kt
+++ b/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/speedtest/SpeedTestRepository.kt
@@ -1,0 +1,18 @@
+package net.aieat.netswissknife.core.network.speedtest
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Repository that runs a full internet speed test (latency, download, upload)
+ * against Cloudflare's public speed test endpoints and streams progress as a [Flow].
+ */
+interface SpeedTestRepository {
+
+    /**
+     * Runs latency, download, and upload phases in order, emitting a [SpeedTestEvent]
+     * for each measurement as it becomes available. The flow completes after the
+     * upload phase finishes, or emits [SpeedTestEvent.Failed] and completes if a
+     * phase cannot be measured.
+     */
+    fun runSpeedTest(): Flow<SpeedTestEvent>
+}

--- a/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/speedtest/SpeedTestRepositoryImpl.kt
+++ b/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/speedtest/SpeedTestRepositoryImpl.kt
@@ -1,0 +1,183 @@
+package net.aieat.netswissknife.core.network.speedtest
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import java.net.HttpURLConnection
+import java.net.URI
+import java.security.SecureRandom
+
+/** Streams bytes for a fixed wall-clock [duration][Long], invoking [onChunk] for every
+ * read/write with the number of bytes moved and the elapsed time since the stream started. */
+internal typealias ByteStreamFn = suspend (durationMs: Long, onChunk: suspend (bytesTransferred: Int, elapsedMs: Long) -> Unit) -> Unit
+
+/**
+ * Production [SpeedTestRepository] that measures latency, download, and upload
+ * throughput against Cloudflare's public speed test endpoints
+ * (`speed.cloudflare.com/__down` and `/__up` — the same backend that powers
+ * https://speed.cloudflare.com).
+ *
+ * The [latencyProbe], [downloadStream], and [uploadStream] hooks are injected so
+ * tests can supply deterministic timing/byte sequences without real network I/O;
+ * the defaults perform the real HTTP calls.
+ */
+class SpeedTestRepositoryImpl(
+    private val latencyProbeCount: Int = DEFAULT_LATENCY_PROBE_COUNT,
+    private val latencyTimeoutMs: Int = DEFAULT_LATENCY_TIMEOUT_MS,
+    private val downloadDurationMs: Long = DEFAULT_PHASE_DURATION_MS,
+    private val uploadDurationMs: Long = DEFAULT_PHASE_DURATION_MS,
+    private val sampleIntervalMs: Long = DEFAULT_SAMPLE_INTERVAL_MS,
+    private val latencyProbe: suspend (timeoutMs: Int) -> Long = DEFAULT_LATENCY_PROBE,
+    private val downloadStream: ByteStreamFn = DEFAULT_DOWNLOAD,
+    private val uploadStream: ByteStreamFn = DEFAULT_UPLOAD
+) : SpeedTestRepository {
+
+    companion object {
+        const val BASE_URL = "https://speed.cloudflare.com"
+        const val DEFAULT_LATENCY_PROBE_COUNT = 10
+        const val DEFAULT_LATENCY_TIMEOUT_MS = 5_000
+        const val DEFAULT_PHASE_DURATION_MS = 10_000L
+        const val DEFAULT_SAMPLE_INTERVAL_MS = 200L
+
+        private const val CONNECT_TIMEOUT_MS = 15_000
+        private const val CHUNK_SIZE = 64 * 1024
+        private const val DOWNLOAD_PAYLOAD_BYTES = 25_000_000L
+        private const val UPLOAD_PAYLOAD_BYTES = 10_000_000L
+
+        private fun openConnection(url: String, method: String): HttpURLConnection =
+            (URI(url).toURL().openConnection() as HttpURLConnection).apply {
+                requestMethod = method
+                connectTimeout = CONNECT_TIMEOUT_MS
+                readTimeout = CONNECT_TIMEOUT_MS
+            }
+
+        val DEFAULT_LATENCY_PROBE: suspend (Int) -> Long = { timeoutMs ->
+            val conn = openConnection("$BASE_URL/__down?bytes=0", "GET").apply {
+                connectTimeout = timeoutMs
+                readTimeout = timeoutMs
+            }
+            try {
+                val start = System.nanoTime()
+                conn.connect()
+                conn.responseCode
+                (System.nanoTime() - start) / 1_000_000L
+            } finally {
+                conn.disconnect()
+            }
+        }
+
+        val DEFAULT_DOWNLOAD: ByteStreamFn = { durationMs, onChunk ->
+            val start = System.currentTimeMillis()
+            val buffer = ByteArray(CHUNK_SIZE)
+            while (System.currentTimeMillis() - start < durationMs) {
+                val conn = openConnection("$BASE_URL/__down?bytes=$DOWNLOAD_PAYLOAD_BYTES", "GET")
+                try {
+                    conn.connect()
+                    conn.inputStream.use { stream ->
+                        while (System.currentTimeMillis() - start < durationMs) {
+                            val read = stream.read(buffer)
+                            if (read == -1) break
+                            onChunk(read, System.currentTimeMillis() - start)
+                        }
+                    }
+                } finally {
+                    conn.disconnect()
+                }
+            }
+        }
+
+        val DEFAULT_UPLOAD: ByteStreamFn = { durationMs, onChunk ->
+            val start = System.currentTimeMillis()
+            val payload = ByteArray(CHUNK_SIZE).also { SecureRandom().nextBytes(it) }
+            while (System.currentTimeMillis() - start < durationMs) {
+                val conn = openConnection("$BASE_URL/__up", "POST").apply {
+                    doOutput = true
+                    setChunkedStreamingMode(CHUNK_SIZE)
+                    setRequestProperty("Content-Type", "application/octet-stream")
+                }
+                try {
+                    conn.connect()
+                    conn.outputStream.use { out ->
+                        var written = 0L
+                        while (written < UPLOAD_PAYLOAD_BYTES && System.currentTimeMillis() - start < durationMs) {
+                            val toWrite = minOf(CHUNK_SIZE.toLong(), UPLOAD_PAYLOAD_BYTES - written).toInt()
+                            out.write(payload, 0, toWrite)
+                            written += toWrite
+                            onChunk(toWrite, System.currentTimeMillis() - start)
+                        }
+                    }
+                    conn.responseCode
+                } finally {
+                    conn.disconnect()
+                }
+            }
+        }
+    }
+
+    override fun runSpeedTest(): Flow<SpeedTestEvent> = flow {
+        // ── Phase 1: latency ─────────────────────────────────────────────────
+        val latencySamples = mutableListOf<LatencySample>()
+        for (seq in 1..latencyProbeCount) {
+            val rtt = try {
+                latencyProbe(latencyTimeoutMs)
+            } catch (e: Exception) {
+                emit(SpeedTestEvent.Failed(SpeedTestPhase.LATENCY, e.message ?: "Latency probe failed"))
+                return@flow
+            }
+            val sample = LatencySample(seq, rtt)
+            latencySamples.add(sample)
+            emit(SpeedTestEvent.LatencyProgress(sample, latencyProbeCount))
+        }
+        emit(SpeedTestEvent.LatencyFinished(LatencyStats.compute(latencySamples)))
+
+        // ── Phase 2: download ────────────────────────────────────────────────
+        val downloadResult = try {
+            measureThroughput(downloadDurationMs, downloadStream) { emit(SpeedTestEvent.DownloadProgress(it)) }
+        } catch (e: Exception) {
+            emit(SpeedTestEvent.Failed(SpeedTestPhase.DOWNLOAD, e.message ?: "Download test failed"))
+            return@flow
+        }
+        emit(SpeedTestEvent.DownloadFinished(downloadResult))
+
+        // ── Phase 3: upload ──────────────────────────────────────────────────
+        val uploadResult = try {
+            measureThroughput(uploadDurationMs, uploadStream) { emit(SpeedTestEvent.UploadProgress(it)) }
+        } catch (e: Exception) {
+            emit(SpeedTestEvent.Failed(SpeedTestPhase.UPLOAD, e.message ?: "Upload test failed"))
+            return@flow
+        }
+        emit(SpeedTestEvent.UploadFinished(uploadResult))
+    }.flowOn(Dispatchers.IO)
+
+    /** Drives [streamFn] for [durationMs], turning the raw byte/elapsed callbacks into
+     * periodic [ThroughputSample]s (emitted via [onSample]) and a final [ThroughputResult]. */
+    private suspend fun measureThroughput(
+        durationMs: Long,
+        streamFn: ByteStreamFn,
+        onSample: suspend (ThroughputSample) -> Unit
+    ): ThroughputResult {
+        val samples = mutableListOf<ThroughputSample>()
+        var totalBytes = 0L
+        var intervalBytes = 0L
+        var lastSampleElapsed = 0L
+
+        streamFn(durationMs) { bytesTransferred, elapsedMs ->
+            totalBytes += bytesTransferred
+            intervalBytes += bytesTransferred
+            val sinceLastSample = elapsedMs - lastSampleElapsed
+            if (sinceLastSample >= sampleIntervalMs) {
+                val intervalSec = sinceLastSample / 1000.0
+                val instantMbps = if (intervalSec > 0) (intervalBytes * 8.0 / 1_000_000.0) / intervalSec else 0.0
+                val sample = ThroughputSample(elapsedMs, totalBytes, instantMbps)
+                samples.add(sample)
+                onSample(sample)
+                intervalBytes = 0L
+                lastSampleElapsed = elapsedMs
+            }
+        }
+
+        val actualDurationMs = samples.lastOrNull()?.elapsedMs ?: 0L
+        return ThroughputResult.from(totalBytes, actualDurationMs, samples)
+    }
+}

--- a/core-network/src/test/kotlin/net/aieat/netswissknife/core/network/speedtest/SpeedTestModelsTest.kt
+++ b/core-network/src/test/kotlin/net/aieat/netswissknife/core/network/speedtest/SpeedTestModelsTest.kt
@@ -1,0 +1,86 @@
+package net.aieat.netswissknife.core.network.speedtest
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("SpeedTest model helpers")
+class SpeedTestModelsTest {
+
+    @Nested
+    @DisplayName("LatencyStats.compute")
+    inner class LatencyStatsCompute {
+
+        @Test
+        fun `returns EMPTY for no samples`() {
+            assertEquals(LatencyStats.EMPTY, LatencyStats.compute(emptyList()))
+        }
+
+        @Test
+        fun `computes min avg max from samples`() {
+            val samples = listOf(
+                LatencySample(1, 10L),
+                LatencySample(2, 20L),
+                LatencySample(3, 30L)
+            )
+            val stats = LatencyStats.compute(samples)
+            assertEquals(10L, stats.minMs)
+            assertEquals(20.0, stats.avgMs)
+            assertEquals(30L, stats.maxMs)
+        }
+
+        @Test
+        fun `computes jitter as mean absolute difference between consecutive samples`() {
+            val samples = listOf(
+                LatencySample(1, 10L),
+                LatencySample(2, 20L),
+                LatencySample(3, 15L)
+            )
+            // |20-10| = 10, |15-20| = 5 -> avg = 7.5
+            val stats = LatencyStats.compute(samples)
+            assertEquals(7.5, stats.jitterMs)
+        }
+
+        @Test
+        fun `jitter is zero for a single sample`() {
+            val stats = LatencyStats.compute(listOf(LatencySample(1, 10L)))
+            assertEquals(0.0, stats.jitterMs)
+        }
+    }
+
+    @Nested
+    @DisplayName("ThroughputResult.from")
+    inner class ThroughputResultFrom {
+
+        @Test
+        fun `computes average Mbps from total bytes and duration`() {
+            // 12,500,000 bytes in 10s = 100,000,000 bits / 10s = 10 Mbps
+            val result = ThroughputResult.from(12_500_000L, 10_000L, emptyList())
+            assertEquals(10.0, result.avgMbps, 0.0001)
+        }
+
+        @Test
+        fun `peak Mbps is the maximum instantaneous sample`() {
+            val samples = listOf(
+                ThroughputSample(1000L, 1_000_000L, 8.0),
+                ThroughputSample(2000L, 2_000_000L, 15.5),
+                ThroughputSample(3000L, 3_000_000L, 12.0)
+            )
+            val result = ThroughputResult.from(3_000_000L, 3000L, samples)
+            assertEquals(15.5, result.peakMbps)
+        }
+
+        @Test
+        fun `avgMbps is zero when duration is zero`() {
+            val result = ThroughputResult.from(1_000L, 0L, emptyList())
+            assertEquals(0.0, result.avgMbps)
+        }
+
+        @Test
+        fun `falls back to avgMbps for peak when there are no samples`() {
+            val result = ThroughputResult.from(12_500_000L, 10_000L, emptyList())
+            assertEquals(result.avgMbps, result.peakMbps)
+        }
+    }
+}

--- a/core-network/src/test/kotlin/net/aieat/netswissknife/core/network/speedtest/SpeedTestRepositoryImplTest.kt
+++ b/core-network/src/test/kotlin/net/aieat/netswissknife/core/network/speedtest/SpeedTestRepositoryImplTest.kt
@@ -1,0 +1,132 @@
+package net.aieat.netswissknife.core.network.speedtest
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@DisplayName("SpeedTestRepositoryImpl")
+class SpeedTestRepositoryImplTest {
+
+    /** Fake stream that replays a fixed sequence of (bytes, elapsedMs) chunks, ignoring duration. */
+    private fun fakeStream(chunks: List<Pair<Int, Long>>): ByteStreamFn = { _, onChunk ->
+        chunks.forEach { (bytes, elapsedMs) -> onChunk(bytes, elapsedMs) }
+    }
+
+    private fun repoWith(
+        latencyProbeCount: Int = 3,
+        latencyRtts: List<Long> = listOf(10L, 12L, 11L),
+        downloadChunks: List<Pair<Int, Long>> = listOf(1_250_000 to 1_000L, 1_250_000 to 2_000L),
+        uploadChunks: List<Pair<Int, Long>> = listOf(625_000 to 1_000L, 625_000 to 2_000L)
+    ): SpeedTestRepositoryImpl {
+        var latencyCall = 0
+        return SpeedTestRepositoryImpl(
+            latencyProbeCount = latencyProbeCount,
+            sampleIntervalMs = 500L,
+            latencyProbe = { latencyRtts[latencyCall++] },
+            downloadStream = fakeStream(downloadChunks),
+            uploadStream = fakeStream(uploadChunks)
+        )
+    }
+
+    @Nested
+    @DisplayName("latency phase")
+    inner class LatencyPhase {
+
+        @Test
+        fun `emits a progress event per probe followed by a finished event`() = runTest {
+            val events = repoWith(latencyProbeCount = 3).runSpeedTest().toList()
+            val progress = events.filterIsInstance<SpeedTestEvent.LatencyProgress>()
+            assertEquals(3, progress.size)
+            assertEquals(listOf(1, 2, 3), progress.map { it.sample.sequence })
+            assertEquals(listOf(10L, 12L, 11L), progress.map { it.sample.rtTimeMs })
+
+            val finished = events.filterIsInstance<SpeedTestEvent.LatencyFinished>().single()
+            assertEquals(10L, finished.stats.minMs)
+            assertEquals(12L, finished.stats.maxMs)
+        }
+
+        @Test
+        fun `emits Failed and stops when a probe throws`() = runTest {
+            val repo = SpeedTestRepositoryImpl(
+                latencyProbeCount = 3,
+                latencyProbe = { throw java.io.IOException("timed out") },
+                downloadStream = fakeStream(emptyList()),
+                uploadStream = fakeStream(emptyList())
+            )
+            val events = repo.runSpeedTest().toList()
+            assertEquals(1, events.size)
+            val failure = events.single() as SpeedTestEvent.Failed
+            assertEquals(SpeedTestPhase.LATENCY, failure.phase)
+            assertEquals("timed out", failure.message)
+        }
+    }
+
+    @Nested
+    @DisplayName("download / upload phases")
+    inner class ThroughputPhases {
+
+        @Test
+        fun `streams progress samples and a final result for download`() = runTest {
+            val events = repoWith().runSpeedTest().toList()
+            val progress = events.filterIsInstance<SpeedTestEvent.DownloadProgress>()
+            assertEquals(2, progress.size)
+            assertEquals(1_250_000L, progress[0].sample.bytesTransferred)
+            assertEquals(2_500_000L, progress[1].sample.bytesTransferred)
+
+            val finished = events.filterIsInstance<SpeedTestEvent.DownloadFinished>().single()
+            assertEquals(2_500_000L, finished.result.bytesTransferred)
+            assertEquals(2_000L, finished.result.durationMs)
+            // 2,500,000 bytes over 2s = 20,000,000 bits / 2s = 10 Mbps
+            assertEquals(10.0, finished.result.avgMbps, 0.0001)
+        }
+
+        @Test
+        fun `streams progress samples and a final result for upload`() = runTest {
+            val events = repoWith().runSpeedTest().toList()
+            val progress = events.filterIsInstance<SpeedTestEvent.UploadProgress>()
+            assertEquals(2, progress.size)
+
+            val finished = events.filterIsInstance<SpeedTestEvent.UploadFinished>().single()
+            assertEquals(1_250_000L, finished.result.bytesTransferred)
+            assertEquals(2_000L, finished.result.durationMs)
+            // 1,250,000 bytes over 2s = 10,000,000 bits / 2s = 5 Mbps
+            assertEquals(5.0, finished.result.avgMbps, 0.0001)
+        }
+
+        @Test
+        fun `emits Failed and stops when the download stream throws`() = runTest {
+            val repo = SpeedTestRepositoryImpl(
+                latencyProbeCount = 1,
+                latencyProbe = { 10L },
+                downloadStream = { _, _ -> throw java.io.IOException("connection reset") },
+                uploadStream = fakeStream(emptyList())
+            )
+            val events = repo.runSpeedTest().toList()
+            assertTrue(events.last() is SpeedTestEvent.Failed)
+            val failure = events.last() as SpeedTestEvent.Failed
+            assertEquals(SpeedTestPhase.DOWNLOAD, failure.phase)
+            // No upload events should be emitted after a download failure
+            assertTrue(events.none { it is SpeedTestEvent.UploadProgress || it is SpeedTestEvent.UploadFinished })
+        }
+
+        @Test
+        fun `runs phases in order latency, download, upload`() = runTest {
+            val events = repoWith(latencyProbeCount = 1, latencyRtts = listOf(10L)).runSpeedTest().toList()
+            val phaseOrder = events.mapNotNull {
+                when (it) {
+                    is SpeedTestEvent.LatencyFinished -> SpeedTestPhase.LATENCY
+                    is SpeedTestEvent.DownloadFinished -> SpeedTestPhase.DOWNLOAD
+                    is SpeedTestEvent.UploadFinished -> SpeedTestPhase.UPLOAD
+                    else -> null
+                }
+            }
+            assertEquals(listOf(SpeedTestPhase.LATENCY, SpeedTestPhase.DOWNLOAD, SpeedTestPhase.UPLOAD), phaseOrder)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- New Speed Test tool measuring latency, download, and upload throughput against `speed.cloudflare.com` (`/__down`, `/__up`)
- Animated Compose UI: gradient header, phase stepper, live circular gauge and throughput charts per phase, final result cards with charts
- Cloudflare attribution added to README ("Powered by Cloudflare", non-affiliation disclaimer) and Settings → About (Data Source Attributions)
- Wired into navigation (`speedtest` route, home tools grid)
- TDD: new unit tests in `:core-network` and `:core-domain` for stats computation and repository streaming behaviour

## Test plan
- [x] `./gradlew test` — all unit tests pass
- [x] `./gradlew :app:assembleDebug` — builds successfully
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)