### PR TITLE
fix: zip native debug symbols with ABI dirs at zip root

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,8 +191,8 @@ jobs:
           LIB_DIR=$(find app/build/intermediates/merged_native_libs/release \
                        -type d -name "lib" | head -1)
           if [ -n "$LIB_DIR" ] && [ -d "$LIB_DIR" ]; then
-            cd "$(dirname "$LIB_DIR")"
-            zip -r "$RUNNER_TEMP/native-debug-symbols.zip" lib/
+            cd "$LIB_DIR"
+            zip -r "$RUNNER_TEMP/native-debug-symbols.zip" .
             echo "zip=$RUNNER_TEMP/native-debug-symbols.zip" >> "$GITHUB_OUTPUT"
             echo "found=true" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
## Summary
- Play Console rejected the previously generated `native-debug-symbols.zip` with: "The native debug symbols contain an invalid directory lib. Only Android ABIs are supported."
- The zip nested `arm64-v8a/`, `armeabi-v7a/`, `x86/`, `x86_64/` under a top-level `lib/` directory; Play Console expects ABI directories at the zip root.
- Fixed by `cd`-ing into the merged `lib/` directory and zipping its contents directly, so ABI folders sit at the zip root.

## Test plan
- [x] Verified locally against `app/build/intermediates/merged_native_libs/release/.../lib`: zip now contains `arm64-v8a/`, `armeabi-v7a/`, `x86/`, `x86_64/` at root (previously `lib/arm64-v8a/...`)
- [ ] CI green on this PR
- [ ] Re-run release workflow and confirm Play Console accepts the new zip

🤖 Generated with [Claude Code](https://claude.com/claude-code)