### PR TITLE
fix: prevent traceroute NPE on GeoIP failure and harden HTTP probe redirects

### DIFF
--- a/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/httprobe/HttpProbeRepositoryImpl.kt
+++ b/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/httprobe/HttpProbeRepositoryImpl.kt
@@ -79,8 +79,14 @@ class HttpProbeRepositoryImpl : HttpProbeRepository {
                 if (request.followRedirects && statusCode in 300..399 && attempt < maxRedirects) {
                     val location = conn.getHeaderField("Location")
                     if (!location.isNullOrBlank()) {
+                        val nextUrl = resolveUrl(currentUrl, location)
+                        if (nextUrl.protocol !in listOf("http", "https")) {
+                            return NetworkResult.Error(
+                                "Redirected to unsupported protocol: ${nextUrl.protocol}"
+                            )
+                        }
                         redirectChain.add(currentUrl.toString())
-                        currentUrl = resolveUrl(currentUrl, location)
+                        currentUrl = nextUrl
                         return@repeat // continue loop
                     }
                 }

--- a/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/traceroute/GeoIpRepositoryImpl.kt
+++ b/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/traceroute/GeoIpRepositoryImpl.kt
@@ -16,19 +16,27 @@ import java.util.concurrent.ConcurrentHashMap
  * Private / reserved IP ranges are skipped and return null immediately.
  * Results are cached in-memory to avoid repeat calls for the same IP.
  */
-class GeoIpRepositoryImpl : GeoIpRepository {
+class GeoIpRepositoryImpl(
+    private val baseUrl: String = "https://ipinfo.io"
+) : GeoIpRepository {
 
     private val cache = ConcurrentHashMap<String, HopGeoLocation?>()
 
     override suspend fun lookup(ip: String): HopGeoLocation? {
         if (isPrivateOrReserved(ip)) return null
-        return cache.getOrPut(ip) { fetchGeoIp(ip) }
+        cache[ip]?.let { return it }
+        // ConcurrentHashMap forbids null values, so cache.getOrPut would throw NPE
+        // whenever fetchGeoIp(ip) fails (timeout, rate limit, bad response) — cache
+        // only successful lookups and recompute on every miss/failure instead.
+        val result = fetchGeoIp(ip)
+        if (result != null) cache[ip] = result
+        return result
     }
 
     // ── Network ───────────────────────────────────────────────────────────────
 
     private suspend fun fetchGeoIp(ip: String): HopGeoLocation? = withContext(Dispatchers.IO) {
-        val conn = URI("https://ipinfo.io/$ip/json").toURL().openConnection() as HttpURLConnection
+        val conn = URI("$baseUrl/$ip/json").toURL().openConnection() as HttpURLConnection
         try {
             conn.connectTimeout = 5_000
             conn.readTimeout    = 5_000

--- a/core-network/src/test/kotlin/net/aieat/netswissknife/core/network/httprobe/HttpProbeRepositoryTest.kt
+++ b/core-network/src/test/kotlin/net/aieat/netswissknife/core/network/httprobe/HttpProbeRepositoryTest.kt
@@ -1,11 +1,14 @@
 package net.aieat.netswissknife.core.network.httprobe
 
+import com.sun.net.httpserver.HttpServer
 import kotlinx.coroutines.test.runTest
 import net.aieat.netswissknife.core.network.NetworkResult
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import java.net.InetSocketAddress
 
 @DisplayName("HttpProbeRepositoryImpl – input validation")
 class HttpProbeRepositoryValidationTest {
@@ -200,5 +203,58 @@ class HttpMethodBodySupportTest {
     @DisplayName("DELETE does not support body")
     fun `DELETE does not support body`() {
         assertTrue(!HttpMethod.DELETE.supportsBody)
+    }
+}
+
+@DisplayName("HttpProbeRepositoryImpl – redirect handling")
+class HttpProbeRepositoryRedirectTest {
+
+    private var server: HttpServer? = null
+    private val repo = HttpProbeRepositoryImpl()
+
+    @AfterEach
+    fun tearDown() {
+        server?.stop(0)
+    }
+
+    private fun startServer(handler: (path: String) -> Triple<Int, String, String?>): String {
+        val httpServer = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+        httpServer.createContext("/") { exchange ->
+            val (status, body, location) = handler(exchange.requestURI.path)
+            location?.let { exchange.responseHeaders.add("Location", it) }
+            val bytes = body.toByteArray()
+            exchange.sendResponseHeaders(status, bytes.size.toLong())
+            exchange.responseBody.use { it.write(bytes) }
+        }
+        httpServer.start()
+        server = httpServer
+        return "http://127.0.0.1:${httpServer.address.port}"
+    }
+
+    @Test
+    @DisplayName("probe rejects a redirect to a non-http(s) scheme")
+    fun `probe rejects redirect to file scheme`() = runTest {
+        val baseUrl = startServer { Triple(302, "", "file:///etc/passwd") }
+
+        val result = repo.probe(HttpProbeRequest(url = baseUrl))
+
+        assertTrue(result is NetworkResult.Error)
+        assertTrue((result as NetworkResult.Error).message.contains("protocol", ignoreCase = true))
+    }
+
+    @Test
+    @DisplayName("probe follows a normal http redirect to completion")
+    fun `probe follows http redirect`() = runTest {
+        lateinit var baseUrl: String
+        baseUrl = startServer { path ->
+            if (path == "/target") Triple(200, "ok", null)
+            else Triple(302, "", "$baseUrl/target")
+        }
+
+        val result = repo.probe(HttpProbeRequest(url = baseUrl))
+
+        assertTrue(result is NetworkResult.Success)
+        assertEquals(200, (result as NetworkResult.Success).data.statusCode)
+        assertTrue(result.data.redirectChain.isNotEmpty())
     }
 }

--- a/core-network/src/test/kotlin/net/aieat/netswissknife/core/network/traceroute/GeoIpRepositoryImplTest.kt
+++ b/core-network/src/test/kotlin/net/aieat/netswissknife/core/network/traceroute/GeoIpRepositoryImplTest.kt
@@ -1,0 +1,90 @@
+package net.aieat.netswissknife.core.network.traceroute
+
+import com.sun.net.httpserver.HttpServer
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.net.InetSocketAddress
+
+@DisplayName("GeoIpRepositoryImpl")
+class GeoIpRepositoryImplTest {
+
+    private var server: HttpServer? = null
+
+    @AfterEach
+    fun tearDown() {
+        server?.stop(0)
+    }
+
+    private fun startServer(handler: (String) -> Pair<Int, String>): String {
+        val httpServer = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+        httpServer.createContext("/") { exchange ->
+            val (status, body) = handler(exchange.requestURI.path)
+            val bytes = body.toByteArray()
+            exchange.sendResponseHeaders(status, bytes.size.toLong())
+            exchange.responseBody.use { it.write(bytes) }
+        }
+        httpServer.start()
+        server = httpServer
+        return "http://127.0.0.1:${httpServer.address.port}"
+    }
+
+    @Test
+    @DisplayName("lookup does not throw and returns null when the GeoIP API errors")
+    fun `lookup does not throw when API returns non-200`() = runTest {
+        val baseUrl = startServer { 500 to "error" }
+        val repo = GeoIpRepositoryImpl(baseUrl = baseUrl)
+
+        val result = repo.lookup("8.8.8.8")
+
+        assertNull(result)
+    }
+
+    @Test
+    @DisplayName("repeated lookups after an API failure keep returning null without crashing")
+    fun `repeated lookups after failure do not throw`() = runTest {
+        val baseUrl = startServer { 500 to "error" }
+        val repo = GeoIpRepositoryImpl(baseUrl = baseUrl)
+
+        assertNull(repo.lookup("8.8.8.8"))
+        assertNull(repo.lookup("8.8.8.8"))
+    }
+
+    @Test
+    @DisplayName("lookup returns null for malformed JSON without crashing")
+    fun `lookup does not throw on malformed response body`() = runTest {
+        val baseUrl = startServer { 200 to "{ not valid json" }
+        val repo = GeoIpRepositoryImpl(baseUrl = baseUrl)
+
+        val result = repo.lookup("8.8.8.8")
+
+        assertNull(result)
+    }
+
+    @Test
+    @DisplayName("lookup parses a successful response and caches it")
+    fun `lookup parses successful response`() = runTest {
+        val baseUrl = startServer {
+            200 to """{"ip":"8.8.8.8","city":"Mountain View","country":"US","loc":"37.38,-122.08","org":"AS15169 Google LLC"}"""
+        }
+        val repo = GeoIpRepositoryImpl(baseUrl = baseUrl)
+
+        val result = repo.lookup("8.8.8.8")
+
+        assertEquals("United States", result?.country)
+        assertEquals("Mountain View", result?.city)
+    }
+
+    @Test
+    @DisplayName("lookup returns null immediately for private IPs without contacting the server")
+    fun `lookup short-circuits for private IPs`() = runTest {
+        val repo = GeoIpRepositoryImpl(baseUrl = "http://127.0.0.1:1")
+
+        val result = repo.lookup("192.168.1.1")
+
+        assertNull(result)
+    }
+}


### PR DESCRIPTION
## Summary
- `GeoIpRepositoryImpl.lookup()` used `ConcurrentHashMap.getOrPut`, which calls `put(key, null)` whenever the GeoIP fetch fails (timeout, rate limit, bad response). `ConcurrentHashMap` throws `NullPointerException` on null values, crashing the entire traceroute flow on any single GeoIP lookup failure — trivially reproducible by hitting ipinfo.io's free-tier rate limit. Fixed to only cache successful lookups.
- `HttpProbeRepositoryImpl` validated the URL scheme on the initial request but never re-validated after following a redirect. A malicious/compromised server could redirect the prober to `file://` (or other non-http schemes) and have local file contents returned as the HTTP response body. Redirect targets are now re-validated against the http/https allowlist on every hop.

## Test plan
- [x] Added `GeoIpRepositoryImplTest` (5 cases: API error, malformed JSON, repeated failures, successful parse, private-IP short-circuit) using a local `HttpServer` instead of the real network
- [x] Added `HttpProbeRepositoryRedirectTest` (2 cases: rejects `file://` redirect, follows normal http redirect)
- [x] `./gradlew :core-network:test` and `:core-domain:test` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G53tXD9M5YzQPyTanmFMuH