### PR TITLE
feat: add Android 13+ monochrome themed app icon

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -108,6 +108,13 @@ dependencies {
     implementation(libs.compose.material3)
     implementation(libs.compose.material.icons.extended)
     implementation(libs.compose.animation)
+    // foundation-layout:1.8.2 is pulled to the runtime classpath by
+    // navigation-compose:2.9.0 (via hilt-navigation-compose:1.3.0), but the BOM
+    // only pins the compile classpath to 1.7.6.  The 1.8.x API added
+    // itemVerticalAlignment to FlowRow, making it binary-incompatible with 1.7.x.
+    // Explicitly declaring 1.8.2 here aligns compile with runtime so calls compile
+    // against the same signature that is bundled at runtime.
+    implementation("androidx.compose.foundation:foundation-layout:1.8.2")
     debugImplementation(libs.compose.ui.tooling)
 
     // Navigation

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/MainActivity.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/MainActivity.kt
@@ -159,9 +159,12 @@ private fun AppBottomNavigationBar(
             )
         }
 
-        // "More" is always last
+        // "More" is always last — highlighted when the current screen is not Home and not a pinned tool
+        val isMoreSelected = currentRoute != null &&
+            currentRoute != NavRoutes.Home.route &&
+            pinnedTools.none { it.route == currentRoute }
         NavigationBarItem(
-            selected = false,
+            selected = isMoreSelected,
             onClick  = onMoreClick,
             icon     = { Icon(Icons.Default.MoreHoriz, contentDescription = null) },
             label    = { Text(stringResource(R.string.nav_more)) }

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/MainActivity.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/MainActivity.kt
@@ -31,6 +31,8 @@ import net.aieat.netswissknife.app.ui.navigation.AppNavHost
 import net.aieat.netswissknife.app.ui.navigation.AppNavigationViewModel
 import net.aieat.netswissknife.app.ui.navigation.MoreToolsSheet
 import net.aieat.netswissknife.app.ui.navigation.NavRoutes
+import net.aieat.netswissknife.app.ui.screens.onboarding.OnboardingSheet
+import net.aieat.netswissknife.app.ui.screens.onboarding.OnboardingViewModel
 import net.aieat.netswissknife.app.ui.screens.settings.SettingsViewModel
 import net.aieat.netswissknife.app.ui.theme.NetSwissKnifeTheme
 import dagger.hilt.android.AndroidEntryPoint
@@ -61,6 +63,8 @@ fun NetSwissKnifeApp(navController: NavHostController) {
     val navViewModel: AppNavigationViewModel = hiltViewModel()
     val pinnedRoutes by navViewModel.pinnedRoutes.collectAsState()
     var showMoreSheet by remember { mutableStateOf(false) }
+    val onboardingViewModel: OnboardingViewModel = hiltViewModel()
+    val shouldShowOnboarding by onboardingViewModel.shouldShowOnboarding.collectAsState()
 
     Scaffold(
         bottomBar = {
@@ -104,6 +108,10 @@ fun NetSwissKnifeApp(navController: NavHostController) {
                 }
             }) else ({}),
         )
+    }
+
+    if (shouldShowOnboarding) {
+        OnboardingSheet(onDismiss = { onboardingViewModel.completeOnboarding() })
     }
 }
 

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/data/AppPreferencesDataStore.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/data/AppPreferencesDataStore.kt
@@ -3,6 +3,7 @@ package net.aieat.netswissknife.app.data
 import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
@@ -11,6 +12,10 @@ import androidx.datastore.preferences.preferencesDataStore
 val Context.appPreferences: DataStore<Preferences> by preferencesDataStore(name = "app_prefs")
 
 object AppPreferenceKeys {
+
+    // ── Onboarding ────────────────────────────────────────────────────────────
+    /** Whether the user has completed/dismissed the first-run onboarding. */
+    val ONBOARDING_COMPLETED = booleanPreferencesKey("onboarding_completed")
 
     // ── Navigation ────────────────────────────────────────────────────────────
     /** Ordered pipe-delimited list of pinned route strings, e.g. "ping|dns|ports". */

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/components/RecentHostsRow.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/components/RecentHostsRow.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
@@ -70,12 +71,12 @@ fun RecentHostsRow(
                         )
                         IconButton(
                             onClick = { onRemoveHost(host) },
-                            modifier = Modifier.size(24.dp)
+                            modifier = Modifier.size(32.dp).wrapContentSize(Alignment.Center)
                         ) {
                             Icon(
                                 imageVector = Icons.Default.Close,
                                 contentDescription = stringResource(R.string.action_remove_recent),
-                                modifier = Modifier.size(12.dp),
+                                modifier = Modifier.size(14.dp),
                                 tint = MaterialTheme.colorScheme.onSurfaceVariant
                             )
                         }
@@ -84,7 +85,7 @@ fun RecentHostsRow(
             }
             IconButton(
                 onClick = onClearAll,
-                modifier = Modifier.size(32.dp)
+                modifier = Modifier.size(40.dp)
             ) {
                 Icon(
                     imageVector = Icons.Default.DeleteSweep,

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/components/ToolHelpSheet.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/components/ToolHelpSheet.kt
@@ -1,0 +1,75 @@
+package net.aieat.netswissknife.app.ui.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+data class HelpSection(val heading: String, val body: String)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ToolHelpSheet(
+    title: String,
+    sections: List<HelpSection>,
+    onDismiss: () -> Unit
+) {
+    val sheetState = rememberModalBottomSheetState()
+
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 24.dp)
+                .padding(bottom = 40.dp)
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = "How to use",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.primary
+            )
+            Spacer(Modifier.height(16.dp))
+            HorizontalDivider()
+            Spacer(Modifier.height(16.dp))
+
+            sections.forEachIndexed { index, section ->
+                Text(
+                    text = section.heading,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    text = section.body,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                if (index < sections.lastIndex) {
+                    Spacer(Modifier.height(16.dp))
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/components/ToolHeroHeader.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/components/ToolHeroHeader.kt
@@ -1,0 +1,122 @@
+package net.aieat.netswissknife.app.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import net.aieat.netswissknife.app.R
+import net.aieat.netswissknife.app.ui.theme.AppShapes
+import net.aieat.netswissknife.app.ui.theme.AppSpacing
+
+/**
+ * Standard hero header for all tool screens.
+ *
+ * Provides an ElevatedCard with a gradient background, icon, title, subtitle,
+ * and a trailing help icon button. Screens that need animated icons can pass a
+ * custom [iconContent] composable instead of relying on the default.
+ */
+@Composable
+fun ToolHeroHeader(
+    title: String,
+    subtitle: String,
+    icon: ImageVector,
+    onHelpClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    iconContent: @Composable (() -> Unit)? = null,
+) {
+    ElevatedCard(
+        modifier = modifier.fillMaxWidth(),
+        shape = AppShapes.large,
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(
+                    Brush.linearGradient(
+                        listOf(
+                            MaterialTheme.colorScheme.primaryContainer,
+                            MaterialTheme.colorScheme.secondaryContainer,
+                        )
+                    )
+                )
+                .padding(AppSpacing.l),
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                if (iconContent != null) {
+                    iconContent()
+                } else {
+                    Box(
+                        modifier = Modifier
+                            .size(52.dp)
+                            .clip(CircleShape)
+                            .background(
+                                Brush.radialGradient(
+                                    listOf(
+                                        MaterialTheme.colorScheme.primary,
+                                        MaterialTheme.colorScheme.tertiary,
+                                    )
+                                )
+                            ),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Icon(
+                            imageVector = icon,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onPrimary,
+                            modifier = Modifier.size(28.dp),
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.width(AppSpacing.m))
+
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = title,
+                        style = MaterialTheme.typography.displaySmall,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    Text(
+                        text = subtitle,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.8f),
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+
+                IconButton(onClick = onHelpClick) {
+                    Icon(
+                        imageVector = Icons.Default.Info,
+                        contentDescription = stringResource(R.string.action_help),
+                        tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/navigation/AppNavigation.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/navigation/AppNavigation.kt
@@ -110,6 +110,12 @@ fun AppNavHost(navController: NavHostController, modifier: Modifier = Modifier) 
         composable(NavRoutes.SubnetCalculator.route)  { SubnetCalculatorScreen() }
         composable(NavRoutes.MdnsDiscovery.route)     { MdnsDiscoveryScreen() }
         composable(NavRoutes.SpeedTest.route)         { SpeedTestScreen() }
-        composable(NavRoutes.Settings.route)           { SettingsScreen() }
+        composable(
+            route            = NavRoutes.Settings.route,
+            enterTransition  = { fadeIn(tween(ANIM_DURATION)) },
+            exitTransition   = { fadeOut(tween(ANIM_DURATION)) },
+            popEnterTransition  = { fadeIn(tween(ANIM_DURATION)) },
+            popExitTransition   = { fadeOut(tween(ANIM_DURATION)) },
+        ) { SettingsScreen() }
     }
 }

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/navigation/MoreToolsSheet.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/navigation/MoreToolsSheet.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
@@ -26,17 +27,33 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Snackbar
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
 import net.aieat.netswissknife.app.R
+
+private data class ToolSection(val labelRes: Int, val routes: List<String>)
+
+private val TOOL_SECTIONS = listOf(
+    ToolSection(R.string.more_section_diagnostics, listOf("ping", "traceroute", "ports", "dns")),
+    ToolSection(R.string.more_section_wifi_lan,    listOf("wifi_scan", "lan", "topology", "mdns")),
+    ToolSection(R.string.more_section_security,    listOf("tls", "whois", "httprobe")),
+    ToolSection(R.string.more_section_utilities,   listOf("subnet", "speedtest")),
+)
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -50,109 +67,103 @@ fun MoreToolsSheet(
     onDebugLogsClick: () -> Unit = {},
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val snackbarHostState = remember { SnackbarHostState() }
+    val coroutineScope = rememberCoroutineScope()
+    val pinLimitMessage = stringResource(R.string.more_pin_limit_reached, maxPinned)
 
     ModalBottomSheet(
         onDismissRequest = onDismiss,
-        sheetState = sheetState
+        sheetState = sheetState,
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .verticalScroll(rememberScrollState())
-                .padding(horizontal = 20.dp)
-        ) {
-            Text(
-                text = stringResource(R.string.more_sheet_title),
-                style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
-                color = MaterialTheme.colorScheme.onSurface
-            )
-
-            Spacer(Modifier.height(4.dp))
-
-            Text(
-                text = stringResource(R.string.more_sheet_subtitle, maxPinned),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-
-            Spacer(Modifier.height(16.dp))
-
-            NavRoutes.allTools.forEachIndexed { index, tool ->
-                val isPinned = pinnedRoutes.contains(tool.route)
-                val canPin = isPinned || pinnedRoutes.size < maxPinned
-
-                ToolSheetRow(
-                    tool = tool,
-                    isPinned = isPinned,
-                    canPin = canPin,
-                    onNavigate = { onNavigate(tool.route) },
-                    onTogglePin = { onTogglePin(tool.route) }
-                )
-
-                if (index < NavRoutes.allTools.lastIndex) {
-                    HorizontalDivider(
-                        modifier = Modifier.padding(start = 64.dp),
-                        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
-                    )
+        Scaffold(
+            snackbarHost = {
+                SnackbarHost(snackbarHostState) { data ->
+                    Snackbar(snackbarData = data)
                 }
-            }
-
-            Spacer(Modifier.height(16.dp))
-
-            HorizontalDivider()
-
-            Spacer(Modifier.height(8.dp))
-
-            Row(
+            },
+            containerColor = MaterialTheme.colorScheme.surface,
+        ) { scaffoldPadding ->
+            Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .clickable(onClick = onSettingsClick)
-                    .padding(vertical = 10.dp),
-                verticalAlignment = Alignment.CenterVertically,
+                    .padding(scaffoldPadding)
+                    .padding(horizontal = 20.dp),
             ) {
-                Box(
-                    modifier = Modifier
-                        .size(44.dp)
-                        .clip(RoundedCornerShape(12.dp))
-                        .background(MaterialTheme.colorScheme.secondaryContainer),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    Icon(
-                        imageVector = Icons.Default.Settings,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onSecondaryContainer,
-                        modifier = Modifier.size(22.dp),
-                    )
-                }
+                // ── Header (non-scrolling) ────────────────────────────────────
+                Text(
+                    text = stringResource(R.string.more_sheet_title),
+                    style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+
+                Spacer(Modifier.height(4.dp))
+
+                Text(
+                    text = stringResource(R.string.more_sheet_subtitle, maxPinned),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+
+                Spacer(Modifier.height(12.dp))
+
+                // ── Scrollable tools area ─────────────────────────────────────
                 Column(
                     modifier = Modifier
-                        .weight(1f)
-                        .padding(horizontal = 14.dp),
+                        .fillMaxWidth()
+                        .heightIn(max = 460.dp)
+                        .verticalScroll(rememberScrollState()),
                 ) {
-                    Text(
-                        text = stringResource(R.string.settings_entry_label),
-                        style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.SemiBold),
-                        color = MaterialTheme.colorScheme.onSurface,
-                    )
-                    Text(
-                        text = stringResource(R.string.settings_entry_subtitle),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
+                    TOOL_SECTIONS.forEach { section ->
+                        val sectionTools = NavRoutes.allTools.filter { it.route in section.routes }
+                        if (sectionTools.isEmpty()) return@forEach
+
+                        Text(
+                            text = stringResource(section.labelRes),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.padding(top = 12.dp, bottom = 2.dp),
+                        )
+
+                        sectionTools.forEachIndexed { index, tool ->
+                            val isPinned = pinnedRoutes.contains(tool.route)
+                            val canPin = isPinned || pinnedRoutes.size < maxPinned
+
+                            ToolSheetRow(
+                                tool = tool,
+                                isPinned = isPinned,
+                                onNavigate = { onNavigate(tool.route) },
+                                onTogglePin = {
+                                    if (canPin) {
+                                        onTogglePin(tool.route)
+                                    } else {
+                                        coroutineScope.launch {
+                                            snackbarHostState.showSnackbar(pinLimitMessage)
+                                        }
+                                    }
+                                },
+                            )
+
+                            if (index < sectionTools.lastIndex) {
+                                HorizontalDivider(
+                                    modifier = Modifier.padding(start = 64.dp),
+                                    color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
+                                )
+                            }
+                        }
+                    }
+
+                    Spacer(Modifier.height(8.dp))
                 }
-            }
 
-            if (net.aieat.netswissknife.app.BuildConfig.DEBUG) {
-                Spacer(Modifier.height(8.dp))
-
+                // ── Sticky footer: Settings + Debug ───────────────────────────
                 HorizontalDivider()
 
-                Spacer(Modifier.height(8.dp))
+                Spacer(Modifier.height(4.dp))
 
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .clickable(onClick = onDebugLogsClick)
+                        .clickable(onClick = onSettingsClick)
                         .padding(vertical = 10.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
@@ -160,13 +171,13 @@ fun MoreToolsSheet(
                         modifier = Modifier
                             .size(44.dp)
                             .clip(RoundedCornerShape(12.dp))
-                            .background(MaterialTheme.colorScheme.errorContainer),
+                            .background(MaterialTheme.colorScheme.secondaryContainer),
                         contentAlignment = Alignment.Center,
                     ) {
                         Icon(
-                            imageVector = Icons.Default.BugReport,
+                            imageVector = Icons.Default.Settings,
                             contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onErrorContainer,
+                            tint = MaterialTheme.colorScheme.onSecondaryContainer,
                             modifier = Modifier.size(22.dp),
                         )
                     }
@@ -176,20 +187,65 @@ fun MoreToolsSheet(
                             .padding(horizontal = 14.dp),
                     ) {
                         Text(
-                            text = stringResource(R.string.debug_log_title),
+                            text = stringResource(R.string.settings_entry_label),
                             style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.SemiBold),
                             color = MaterialTheme.colorScheme.onSurface,
                         )
                         Text(
-                            text = stringResource(R.string.debug_log_subtitle),
+                            text = stringResource(R.string.settings_entry_subtitle),
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
                     }
                 }
-            }
 
-            Spacer(Modifier.height(24.dp))
+                if (net.aieat.netswissknife.app.BuildConfig.DEBUG) {
+                    HorizontalDivider()
+
+                    Spacer(Modifier.height(4.dp))
+
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable(onClick = onDebugLogsClick)
+                            .padding(vertical = 10.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .size(44.dp)
+                                .clip(RoundedCornerShape(12.dp))
+                                .background(MaterialTheme.colorScheme.errorContainer),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.BugReport,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onErrorContainer,
+                                modifier = Modifier.size(22.dp),
+                            )
+                        }
+                        Column(
+                            modifier = Modifier
+                                .weight(1f)
+                                .padding(horizontal = 14.dp),
+                        ) {
+                            Text(
+                                text = stringResource(R.string.debug_log_title),
+                                style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.SemiBold),
+                                color = MaterialTheme.colorScheme.onSurface,
+                            )
+                            Text(
+                                text = stringResource(R.string.debug_log_subtitle),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    }
+                }
+
+                Spacer(Modifier.height(24.dp))
+            }
         }
     }
 }
@@ -198,18 +254,16 @@ fun MoreToolsSheet(
 private fun ToolSheetRow(
     tool: ToolInfo,
     isPinned: Boolean,
-    canPin: Boolean,
     onNavigate: () -> Unit,
-    onTogglePin: () -> Unit
+    onTogglePin: () -> Unit,
 ) {
     val pinTint by animateColorAsState(
-        targetValue = when {
-            isPinned -> MaterialTheme.colorScheme.primary
-            canPin   -> MaterialTheme.colorScheme.onSurfaceVariant
-            else     -> MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.38f)
-        },
+        targetValue = if (isPinned)
+            MaterialTheme.colorScheme.primary
+        else
+            MaterialTheme.colorScheme.onSurfaceVariant,
         animationSpec = tween(200),
-        label = "pin-tint-${tool.route}"
+        label = "pin-tint-${tool.route}",
     )
     val iconBg by animateColorAsState(
         targetValue = if (isPinned)
@@ -217,7 +271,7 @@ private fun ToolSheetRow(
         else
             MaterialTheme.colorScheme.secondaryContainer,
         animationSpec = tween(200),
-        label = "icon-bg-${tool.route}"
+        label = "icon-bg-${tool.route}",
     )
     val iconTint by animateColorAsState(
         targetValue = if (isPinned)
@@ -225,7 +279,7 @@ private fun ToolSheetRow(
         else
             MaterialTheme.colorScheme.onSecondaryContainer,
         animationSpec = tween(200),
-        label = "icon-tint-${tool.route}"
+        label = "icon-tint-${tool.route}",
     )
 
     Row(
@@ -233,44 +287,41 @@ private fun ToolSheetRow(
             .fillMaxWidth()
             .clickable(onClick = onNavigate)
             .padding(vertical = 10.dp),
-        verticalAlignment = Alignment.CenterVertically
+        verticalAlignment = Alignment.CenterVertically,
     ) {
         Box(
             modifier = Modifier
                 .size(44.dp)
                 .clip(RoundedCornerShape(12.dp))
                 .background(iconBg),
-            contentAlignment = Alignment.Center
+            contentAlignment = Alignment.Center,
         ) {
             Icon(
                 imageVector = tool.icon,
                 contentDescription = null,
                 tint = iconTint,
-                modifier = Modifier.size(22.dp)
+                modifier = Modifier.size(22.dp),
             )
         }
 
         Column(
             modifier = Modifier
                 .weight(1f)
-                .padding(horizontal = 14.dp)
+                .padding(horizontal = 14.dp),
         ) {
             Text(
                 text = tool.label,
                 style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.SemiBold),
-                color = MaterialTheme.colorScheme.onSurface
+                color = MaterialTheme.colorScheme.onSurface,
             )
             Text(
                 text = tool.description,
                 style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
 
-        IconButton(
-            onClick = onTogglePin,
-            enabled = canPin
-        ) {
+        IconButton(onClick = onTogglePin) {
             Icon(
                 imageVector = if (isPinned) Icons.Filled.PushPin else Icons.Outlined.PushPin,
                 contentDescription = if (isPinned)
@@ -278,7 +329,7 @@ private fun ToolSheetRow(
                 else
                     stringResource(R.string.more_pin_description, tool.label),
                 tint = pinTint,
-                modifier = Modifier.size(20.dp)
+                modifier = Modifier.size(20.dp),
             )
         }
     }

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/navigation/NavRoutes.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/navigation/NavRoutes.kt
@@ -12,10 +12,10 @@ import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.automirrored.filled.ManageSearch
 import androidx.compose.material.icons.filled.NetworkCheck
 import androidx.compose.material.icons.filled.Router
-import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Devices
+import androidx.compose.material.icons.filled.TravelExplore
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Speed
-import androidx.compose.material.icons.filled.Wifi
 import androidx.compose.material.icons.filled.WifiFind
 import androidx.compose.ui.graphics.vector.ImageVector
 
@@ -35,8 +35,8 @@ sealed class NavRoutes(
     object Home : NavRoutes("home", "Home", Icons.Default.Home)
     object Ping : NavRoutes("ping", "Ping", Icons.Default.NetworkCheck)
     object Traceroute : NavRoutes("traceroute", "Traceroute", Icons.Default.Router)
-    object Ports : NavRoutes("ports", "Port Scanner", Icons.Default.Search)
-    object Lan : NavRoutes("lan", "LAN Scanner", Icons.Default.Wifi)
+    object Ports : NavRoutes("ports", "Port Scanner", Icons.Default.TravelExplore)
+    object Lan : NavRoutes("lan", "LAN Scanner", Icons.Default.Devices)
     object Dns : NavRoutes("dns", "DNS Lookup", Icons.Default.Language)
     object DebugLogs : NavRoutes("debug_logs", "Debug Logs", Icons.Default.BugReport)
     object WifiScan : NavRoutes("wifi_scan", "Wi-Fi Scanner", Icons.Default.WifiFind)
@@ -54,8 +54,8 @@ sealed class NavRoutes(
         val allTools = listOf(
             ToolInfo("ping",       "Ping",          "Ping",  Icons.Default.NetworkCheck, "ICMP round-trip latency"),
             ToolInfo("traceroute", "Traceroute",    "Trace", Icons.Default.Router,       "Network path hop analysis"),
-            ToolInfo("ports",      "Port Scanner",  "Ports", Icons.Default.Search,       "TCP port reachability"),
-            ToolInfo("lan",        "LAN Scanner",   "LAN",   Icons.Default.Wifi,         "Local device discovery"),
+            ToolInfo("ports",      "Port Scanner",  "Ports", Icons.Default.TravelExplore, "TCP port reachability"),
+            ToolInfo("lan",        "LAN Scanner",   "LAN",   Icons.Default.Devices,       "Local device discovery"),
             ToolInfo("dns",        "DNS Lookup",    "DNS",   Icons.Default.Language,     "Resolve hostnames & records"),
             ToolInfo("wifi_scan",  "Wi-Fi Scanner", "Wi-Fi",     Icons.Default.WifiFind,     "Scan channels & access points"),
             ToolInfo("topology",   "Network Topology", "Topology", Icons.Default.AccountTree, "SNMP switch & neighbour discovery"),

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/DnsScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/DnsScreen.kt
@@ -97,7 +97,9 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import kotlinx.coroutines.launch
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import net.aieat.netswissknife.app.R
+import net.aieat.netswissknife.app.ui.components.HelpSection
 import net.aieat.netswissknife.app.ui.components.RecentHostsRow
+import net.aieat.netswissknife.app.ui.components.ToolHelpSheet
 import net.aieat.netswissknife.app.ui.screens.dns.DnsUiState
 import net.aieat.netswissknife.app.ui.screens.dns.DnsViewModel
 import net.aieat.netswissknife.app.util.shareText
@@ -124,6 +126,7 @@ fun DnsScreen(viewModel: DnsViewModel = hiltViewModel()) {
         animationSpec = tween(400),
         label         = "screen-alpha"
     )
+    var showHelp by remember { mutableStateOf(false) }
 
     LazyColumn(
         modifier = Modifier
@@ -132,7 +135,7 @@ fun DnsScreen(viewModel: DnsViewModel = hiltViewModel()) {
             .alpha(screenAlpha),
         contentPadding = PaddingValues(bottom = 32.dp)
     ) {
-            item { DnsHeroHeader() }
+            item { DnsHeroHeader(onHelpClick = { showHelp = true }) }
 
             item {
                 DnsInputCard(
@@ -186,12 +189,24 @@ fun DnsScreen(viewModel: DnsViewModel = hiltViewModel()) {
                 }
             }
         }
+
+    if (showHelp) {
+        ToolHelpSheet(
+            title = stringResource(R.string.help_dns_title),
+            sections = listOf(
+                HelpSection(stringResource(R.string.help_dns_what_heading), stringResource(R.string.help_dns_what_body)),
+                HelpSection(stringResource(R.string.help_dns_params_heading), stringResource(R.string.help_dns_params_body)),
+                HelpSection(stringResource(R.string.help_dns_results_heading), stringResource(R.string.help_dns_results_body))
+            ),
+            onDismiss = { showHelp = false }
+        )
+    }
 }
 
 // ── Hero header ───────────────────────────────────────────────────────────────
 
 @Composable
-private fun DnsHeroHeader() {
+private fun DnsHeroHeader(onHelpClick: () -> Unit) {
     Box(
         modifier = Modifier
             .fillMaxWidth()
@@ -237,7 +252,7 @@ private fun DnsHeroHeader() {
 
             Spacer(Modifier.width(16.dp))
 
-            Column {
+            Column(modifier = Modifier.weight(1f)) {
                 Text(
                     text = stringResource(R.string.dns_screen_title),
                     style = MaterialTheme.typography.displaySmall.copy(fontWeight = FontWeight.Bold),
@@ -247,6 +262,13 @@ private fun DnsHeroHeader() {
                     text = stringResource(R.string.dns_screen_subtitle),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            IconButton(onClick = onHelpClick) {
+                Icon(
+                    imageVector = Icons.Default.Info,
+                    contentDescription = stringResource(R.string.action_help),
+                    tint = MaterialTheme.colorScheme.onPrimaryContainer
                 )
             }
         }

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/DnsScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/DnsScreen.kt
@@ -707,7 +707,7 @@ private fun DnsErrorPanel(
             )
             TextButton(
                 onClick = onRetry,
-                colors = androidx.compose.material3.ButtonDefaults.textButtonColors(
+                colors = ButtonDefaults.textButtonColors(
                     contentColor = MaterialTheme.colorScheme.error
                 )
             ) {

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/DnsScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/DnsScreen.kt
@@ -95,6 +95,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import kotlinx.coroutines.launch
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -113,6 +114,7 @@ import net.aieat.netswissknife.core.network.dns.DnsServer
 
 // ── Entry point ───────────────────────────────────────────────────────────────
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DnsScreen(viewModel: DnsViewModel = hiltViewModel()) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -130,7 +132,14 @@ fun DnsScreen(viewModel: DnsViewModel = hiltViewModel()) {
         label         = "screen-alpha"
     )
     var showHelp by remember { mutableStateOf(false) }
+    val isRefreshing = uiState is DnsUiState.Loading
+    val canRefresh = uiState is DnsUiState.Success || uiState is DnsUiState.Error
 
+    PullToRefreshBox(
+        isRefreshing = isRefreshing,
+        onRefresh = { if (canRefresh) viewModel.onRetry() },
+        modifier = Modifier.fillMaxSize()
+    ) {
     LazyColumn(
         modifier = Modifier
             .fillMaxSize()
@@ -192,6 +201,7 @@ fun DnsScreen(viewModel: DnsViewModel = hiltViewModel()) {
                 }
             }
         }
+    } // end PullToRefreshBox
 
     if (showHelp) {
         ToolHelpSheet(

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/DnsScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/DnsScreen.kt
@@ -79,6 +79,8 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.graphics.vector.ImageVector
 import android.content.ClipData
 import androidx.compose.runtime.rememberCoroutineScope
@@ -99,6 +101,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import net.aieat.netswissknife.app.R
 import net.aieat.netswissknife.app.ui.components.HelpSection
 import net.aieat.netswissknife.app.ui.components.RecentHostsRow
+import net.aieat.netswissknife.app.ui.theme.AppShapes
 import net.aieat.netswissknife.app.ui.components.ToolHelpSheet
 import net.aieat.netswissknife.app.ui.screens.dns.DnsUiState
 import net.aieat.netswissknife.app.ui.screens.dns.DnsViewModel
@@ -255,8 +258,10 @@ private fun DnsHeroHeader(onHelpClick: () -> Unit) {
             Column(modifier = Modifier.weight(1f)) {
                 Text(
                     text = stringResource(R.string.dns_screen_title),
-                    style = MaterialTheme.typography.displaySmall.copy(fontWeight = FontWeight.Bold),
-                    color = MaterialTheme.colorScheme.onPrimaryContainer
+                    style = MaterialTheme.typography.displaySmall,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
                 )
                 Text(
                     text = stringResource(R.string.dns_screen_subtitle),
@@ -296,7 +301,7 @@ private fun DnsInputCard(
 ) {
     ElevatedCard(
         modifier = modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(20.dp)
+        shape = AppShapes.large
     ) {
         Column(
             modifier = Modifier.padding(20.dp),
@@ -331,7 +336,7 @@ private fun DnsInputCard(
                     onSearch = { onLookup() }
                 ),
                 modifier = Modifier.fillMaxWidth(),
-                shape = RoundedCornerShape(12.dp)
+                shape = AppShapes.medium
             )
 
             RecentHostsRow(
@@ -378,14 +383,14 @@ private fun DnsInputCard(
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(52.dp),
-                shape = RoundedCornerShape(12.dp),
+                shape = AppShapes.medium,
                 colors = ButtonDefaults.buttonColors(
                     containerColor = MaterialTheme.colorScheme.primary
                 )
             ) {
                 if (isLoading) {
                     CircularProgressIndicator(
-                        modifier = Modifier.size(20.dp),
+                        modifier = Modifier.size(20.dp).semantics { contentDescription = "Loading" },
                         color = MaterialTheme.colorScheme.onPrimary,
                         strokeWidth = 2.dp
                     )
@@ -520,7 +525,7 @@ private fun DnsServerSelector(
             modifier = Modifier
                 .fillMaxWidth()
                 .menuAnchor(MenuAnchorType.PrimaryEditable, enabled = true),
-            shape = RoundedCornerShape(12.dp),
+            shape = AppShapes.medium,
             colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors()
         )
 
@@ -621,7 +626,7 @@ private fun DnsIdleHint(modifier: Modifier = Modifier) {
 private fun DnsLoadingPanel(modifier: Modifier = Modifier) {
     ElevatedCard(
         modifier = modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(20.dp)
+        shape = AppShapes.large
     ) {
         Column(
             modifier = Modifier
@@ -631,7 +636,7 @@ private fun DnsLoadingPanel(modifier: Modifier = Modifier) {
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             CircularProgressIndicator(
-                modifier = Modifier.size(48.dp),
+                modifier = Modifier.size(48.dp).semantics { contentDescription = "Loading" },
                 color = MaterialTheme.colorScheme.primary,
                 strokeWidth = 3.dp
             )
@@ -659,7 +664,7 @@ private fun DnsErrorPanel(
 ) {
     ElevatedCard(
         modifier = modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(20.dp)
+        shape = AppShapes.large
     ) {
         Column(
             modifier = Modifier
@@ -750,7 +755,7 @@ private fun DnsResultSummaryCard(
 ) {
     val context = LocalContext.current
     ElevatedCard(
-        shape = RoundedCornerShape(20.dp),
+        shape = AppShapes.large,
         modifier = Modifier.fillMaxWidth()
     ) {
         Column(
@@ -774,7 +779,7 @@ private fun DnsResultSummaryCard(
                 Column(modifier = Modifier.weight(1f)) {
                     Text(
                         text = result.domain,
-                        style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
+                        style = MaterialTheme.typography.titleLarge,
                         color = MaterialTheme.colorScheme.onPrimaryContainer,
                         maxLines = 2,
                         overflow = TextOverflow.Ellipsis
@@ -901,7 +906,7 @@ private fun DnsRecordCard(record: DnsRecord, index: Int) {
         modifier = Modifier
             .fillMaxWidth()
             .alpha(alpha),
-        shape = RoundedCornerShape(16.dp)
+        shape = AppShapes.large
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
             Row(
@@ -1147,7 +1152,7 @@ private fun PlainValueDisplay(value: String) {
 private fun DnsNoRecordsCard(result: DnsResult) {
     ElevatedCard(
         modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(16.dp)
+        shape = AppShapes.large
     ) {
         Column(
             modifier = Modifier
@@ -1186,7 +1191,7 @@ private fun DnsRawToggleCard(
 ) {
     OutlinedCard(
         modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(16.dp)
+        shape = AppShapes.large
     ) {
         Column {
             Row(

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/PingScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/PingScreen.kt
@@ -298,7 +298,8 @@ private fun PingHeroHeader(onHelpClick: () -> Unit) {
                         text = stringResource(R.string.ping_screen_title),
                         style = MaterialTheme.typography.displaySmall,
                         color = MaterialTheme.colorScheme.onPrimaryContainer,
-                        fontWeight = FontWeight.Bold
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
                     )
                     Text(
                         text = stringResource(R.string.ping_screen_subtitle),

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/PingScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/PingScreen.kt
@@ -55,6 +55,7 @@ import androidx.compose.material.icons.filled.Speed
 import androidx.compose.material.icons.filled.Stop
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.FilledTonalButton
@@ -341,6 +342,7 @@ private fun PingInputCard(
     onClearRecentHosts: () -> Unit
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
+    val isHostInvalid = host.isNotBlank() && host.contains(' ')
 
     ElevatedCard(modifier = Modifier.fillMaxWidth()) {
         Column(
@@ -363,6 +365,10 @@ private fun PingInputCard(
                         }
                     }
                 },
+                isError = isHostInvalid,
+                supportingText = if (isHostInvalid) {
+                    { Text(stringResource(R.string.error_invalid_host)) }
+                } else null,
                 singleLine = true,
                 keyboardOptions = KeyboardOptions(
                     keyboardType = KeyboardType.Uri,
@@ -442,7 +448,11 @@ private fun PingInputCard(
             if (isRunning) {
                 Button(
                     onClick = onStop,
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.error,
+                        contentColor = MaterialTheme.colorScheme.onError
+                    )
                 ) {
                     Icon(Icons.Default.Stop, contentDescription = null)
                     Spacer(modifier = Modifier.width(8.dp))
@@ -455,7 +465,7 @@ private fun PingInputCard(
                         onStart()
                     },
                     modifier = Modifier.fillMaxWidth(),
-                    enabled = host.isNotBlank()
+                    enabled = host.isNotBlank() && !isHostInvalid
                 ) {
                     Icon(Icons.Default.Speed, contentDescription = null)
                     Spacer(modifier = Modifier.width(8.dp))

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/PingScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/PingScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AllInclusive
 import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
@@ -117,7 +118,9 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import net.aieat.netswissknife.app.R
+import net.aieat.netswissknife.app.ui.components.HelpSection
 import net.aieat.netswissknife.app.ui.components.RecentHostsRow
+import net.aieat.netswissknife.app.ui.components.ToolHelpSheet
 import net.aieat.netswissknife.app.ui.screens.ping.PingUiState
 import net.aieat.netswissknife.app.ui.screens.ping.PingViewModel
 import net.aieat.netswissknife.app.util.shareText
@@ -165,6 +168,7 @@ fun PingScreen(
         animationSpec = tween(400),
         label         = "screen-alpha"
     )
+    var showHelp by remember { mutableStateOf(false) }
 
     LazyColumn(
         modifier = Modifier.fillMaxSize().alpha(screenAlpha),
@@ -173,7 +177,7 @@ fun PingScreen(
         ) {
             // ── Hero header ─────────────────────────────────────────────────
             item {
-                PingHeroHeader()
+                PingHeroHeader(onHelpClick = { showHelp = true })
             }
 
             // ── Input card ──────────────────────────────────────────────────
@@ -226,12 +230,24 @@ fun PingScreen(
                 }
             }
         }
+
+    if (showHelp) {
+        ToolHelpSheet(
+            title = stringResource(R.string.help_ping_title),
+            sections = listOf(
+                HelpSection(stringResource(R.string.help_ping_what_heading), stringResource(R.string.help_ping_what_body)),
+                HelpSection(stringResource(R.string.help_ping_params_heading), stringResource(R.string.help_ping_params_body)),
+                HelpSection(stringResource(R.string.help_ping_results_heading), stringResource(R.string.help_ping_results_body))
+            ),
+            onDismiss = { showHelp = false }
+        )
+    }
 }
 
 // ── Hero header ───────────────────────────────────────────────────────────────
 
 @Composable
-private fun PingHeroHeader() {
+private fun PingHeroHeader(onHelpClick: () -> Unit) {
     val infiniteTransition = rememberInfiniteTransition(label = "ping_pulse")
     val pulse by infiniteTransition.animateFloat(
         initialValue = 0.85f, targetValue = 1.0f,
@@ -277,7 +293,7 @@ private fun PingHeroHeader() {
                     )
                 }
                 Spacer(modifier = Modifier.width(16.dp))
-                Column {
+                Column(modifier = Modifier.weight(1f)) {
                     Text(
                         text = stringResource(R.string.ping_screen_title),
                         style = MaterialTheme.typography.displaySmall,
@@ -288,6 +304,13 @@ private fun PingHeroHeader() {
                         text = stringResource(R.string.ping_screen_subtitle),
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.8f)
+                    )
+                }
+                IconButton(onClick = onHelpClick) {
+                    Icon(
+                        imageVector = Icons.Default.Info,
+                        contentDescription = stringResource(R.string.action_help),
+                        tint = MaterialTheme.colorScheme.onPrimaryContainer
                     )
                 }
             }

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/PortsScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/PortsScreen.kt
@@ -884,6 +884,7 @@ private fun PortResultRow(result: PortScanResult) {
         modifier = Modifier
             .fillMaxWidth()
             .padding(vertical = 2.dp)
+            .alpha(cardAlpha)
     ) {
         Row(
             modifier = Modifier.padding(12.dp),

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/PortsScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/PortsScreen.kt
@@ -81,6 +81,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import android.content.ClipData
@@ -355,8 +357,9 @@ private fun PortScanHeader(onHelpClick: () -> Unit) {
                 Text(
                     text = stringResource(R.string.ports_screen_title),
                     style = MaterialTheme.typography.displaySmall,
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.onPrimaryContainer
+                    color = MaterialTheme.colorScheme.onPrimaryContainer,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
                 )
                 Text(
                     text = stringResource(R.string.ports_screen_subtitle),
@@ -632,7 +635,7 @@ private fun PortScanProgressCard(state: PortScanUiState.Scanning) {
                     fontWeight = FontWeight.Bold
                 )
                 CircularProgressIndicator(
-                    modifier = Modifier.size(28.dp),
+                    modifier = Modifier.size(28.dp).semantics { contentDescription = "Loading" },
                     strokeCap = StrokeCap.Round,
                     strokeWidth = 3.dp
                 )

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/PortsScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/PortsScreen.kt
@@ -102,7 +102,9 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.launch
 import net.aieat.netswissknife.app.R
+import net.aieat.netswissknife.app.ui.components.HelpSection
 import net.aieat.netswissknife.app.ui.components.RecentHostsRow
+import net.aieat.netswissknife.app.ui.components.ToolHelpSheet
 import net.aieat.netswissknife.app.ui.screens.portscan.PortScanUiState
 import net.aieat.netswissknife.app.ui.screens.portscan.PortScanViewModel
 import net.aieat.netswissknife.app.util.shareText
@@ -136,6 +138,7 @@ fun PortsScreen(viewModel: PortScanViewModel = hiltViewModel()) {
     val clipScope = rememberCoroutineScope()
     val context = LocalContext.current
     var showAll by remember { mutableStateOf(false) }
+    var showHelp by remember { mutableStateOf(false) }
 
     LazyColumn(
         modifier = Modifier.fillMaxSize().alpha(screenAlpha),
@@ -144,7 +147,7 @@ fun PortsScreen(viewModel: PortScanViewModel = hiltViewModel()) {
     ) {
             // ── Header ──────────────────────────────────────────────────────────
             item {
-                PortScanHeader()
+                PortScanHeader(onHelpClick = { showHelp = true })
             }
 
             // ── Input Card ──────────────────────────────────────────────────────
@@ -300,12 +303,24 @@ fun PortsScreen(viewModel: PortScanViewModel = hiltViewModel()) {
                 }
             }
         }
+
+    if (showHelp) {
+        ToolHelpSheet(
+            title = stringResource(R.string.help_portscan_title),
+            sections = listOf(
+                HelpSection(stringResource(R.string.help_portscan_what_heading), stringResource(R.string.help_portscan_what_body)),
+                HelpSection(stringResource(R.string.help_portscan_params_heading), stringResource(R.string.help_portscan_params_body)),
+                HelpSection(stringResource(R.string.help_portscan_results_heading), stringResource(R.string.help_portscan_results_body))
+            ),
+            onDismiss = { showHelp = false }
+        )
+    }
 }
 
 // ── Header ───────────────────────────────────────────────────────────────────
 
 @Composable
-private fun PortScanHeader() {
+private fun PortScanHeader(onHelpClick: () -> Unit) {
     Box(
         modifier = Modifier
             .fillMaxWidth()
@@ -336,7 +351,7 @@ private fun PortScanHeader() {
                 )
             }
             Spacer(Modifier.width(16.dp))
-            Column {
+            Column(modifier = Modifier.weight(1f)) {
                 Text(
                     text = stringResource(R.string.ports_screen_title),
                     style = MaterialTheme.typography.displaySmall,
@@ -347,6 +362,13 @@ private fun PortScanHeader() {
                     text = stringResource(R.string.ports_screen_subtitle),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.8f)
+                )
+            }
+            IconButton(onClick = onHelpClick) {
+                Icon(
+                    imageVector = Icons.Default.Info,
+                    contentDescription = stringResource(R.string.action_help),
+                    tint = MaterialTheme.colorScheme.onPrimaryContainer
                 )
             }
         }

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/TracerouteScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/TracerouteScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -81,6 +82,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Brush
@@ -275,8 +280,10 @@ private fun TracerouteHeroHeader(onHelpClick: () -> Unit) {
                 Column(modifier = Modifier.weight(1f)) {
                     Text(
                         text  = stringResource(R.string.traceroute_screen_title),
-                        style = MaterialTheme.typography.displaySmall.copy(fontWeight = FontWeight.Bold),
-                        color = MaterialTheme.colorScheme.onPrimaryContainer
+                        style = MaterialTheme.typography.displaySmall,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
                     )
                     Text(
                         text  = stringResource(R.string.traceroute_screen_subtitle),
@@ -553,7 +560,7 @@ private fun TracerouteRunningPanel(state: TracerouteUiState.Running) {
                 modifier          = Modifier.padding(16.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                CircularProgressIndicator(modifier = Modifier.size(24.dp), strokeWidth = 2.dp)
+                CircularProgressIndicator(modifier = Modifier.size(24.dp).semantics { contentDescription = "Loading" }, strokeWidth = 2.dp)
                 Spacer(Modifier.width(12.dp))
                 Column {
                     Text(
@@ -1081,6 +1088,7 @@ private fun HopCard(hop: HopResult, index: Int) {
         modifier = Modifier
             .fillMaxWidth()
             .clickable { expanded = !expanded }
+            .semantics { role = Role.Button }
     ) {
         Column(modifier = Modifier.animateContentSize(animationSpec = tween(200))) {
             Row(
@@ -1312,15 +1320,17 @@ private fun RawOutputCard(rawOutput: String) {
             Spacer(Modifier.height(8.dp))
             HorizontalDivider()
             Spacer(Modifier.height(8.dp))
-            SelectionContainer {
-                Text(
-                    text  = rawOutput,
-                    style = MaterialTheme.typography.bodySmall.copy(
-                        fontFamily = FontFamily.Monospace,
-                        lineHeight = 20.sp
-                    ),
-                    color = MaterialTheme.colorScheme.onSurface
-                )
+            Box(modifier = Modifier.heightIn(max = 280.dp)) {
+                SelectionContainer {
+                    Text(
+                        text  = rawOutput,
+                        style = MaterialTheme.typography.bodySmall.copy(
+                            fontFamily = FontFamily.Monospace,
+                            lineHeight = 20.sp
+                        ),
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                }
             }
         }
     }

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/TracerouteScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/TracerouteScreen.kt
@@ -103,7 +103,9 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import net.aieat.netswissknife.app.R
+import net.aieat.netswissknife.app.ui.components.HelpSection
 import net.aieat.netswissknife.app.ui.components.RecentHostsRow
+import net.aieat.netswissknife.app.ui.components.ToolHelpSheet
 import net.aieat.netswissknife.app.ui.screens.traceroute.TracerouteUiState
 import net.aieat.netswissknife.app.util.shareText
 import net.aieat.netswissknife.app.ui.screens.traceroute.TracerouteViewModel
@@ -143,13 +145,14 @@ fun TracerouteScreen(viewModel: TracerouteViewModel = hiltViewModel()) {
         animationSpec = tween(400),
         label         = "screen-alpha"
     )
+    var showHelp by remember { mutableStateOf(false) }
 
     LazyColumn(
         modifier          = Modifier.fillMaxSize().alpha(screenAlpha),
         contentPadding    = PaddingValues(16.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
-            item { TracerouteHeroHeader() }
+            item { TracerouteHeroHeader(onHelpClick = { showHelp = true }) }
 
             item {
                 TracerouteInputCard(
@@ -204,12 +207,24 @@ fun TracerouteScreen(viewModel: TracerouteViewModel = hiltViewModel()) {
                 }
             }
         }
+
+    if (showHelp) {
+        ToolHelpSheet(
+            title = stringResource(R.string.help_traceroute_title),
+            sections = listOf(
+                HelpSection(stringResource(R.string.help_traceroute_what_heading), stringResource(R.string.help_traceroute_what_body)),
+                HelpSection(stringResource(R.string.help_traceroute_params_heading), stringResource(R.string.help_traceroute_params_body)),
+                HelpSection(stringResource(R.string.help_traceroute_results_heading), stringResource(R.string.help_traceroute_results_body))
+            ),
+            onDismiss = { showHelp = false }
+        )
+    }
 }
 
 // ── Hero header ───────────────────────────────────────────────────────────────
 
 @Composable
-private fun TracerouteHeroHeader() {
+private fun TracerouteHeroHeader(onHelpClick: () -> Unit) {
     val infiniteTransition = rememberInfiniteTransition(label = "hero-pulse")
     val pulseAlpha by infiniteTransition.animateFloat(
         initialValue  = 0.6f,
@@ -257,7 +272,7 @@ private fun TracerouteHeroHeader() {
                     )
                 }
                 Spacer(Modifier.width(16.dp))
-                Column {
+                Column(modifier = Modifier.weight(1f)) {
                     Text(
                         text  = stringResource(R.string.traceroute_screen_title),
                         style = MaterialTheme.typography.displaySmall.copy(fontWeight = FontWeight.Bold),
@@ -267,6 +282,13 @@ private fun TracerouteHeroHeader() {
                         text  = stringResource(R.string.traceroute_screen_subtitle),
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.8f)
+                    )
+                }
+                IconButton(onClick = onHelpClick) {
+                    Icon(
+                        imageVector = Icons.Default.Info,
+                        contentDescription = stringResource(R.string.action_help),
+                        tint = MaterialTheme.colorScheme.onPrimaryContainer
                     )
                 }
             }

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/TracerouteScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/TracerouteScreen.kt
@@ -56,6 +56,7 @@ import androidx.compose.material.icons.filled.Timer
 import androidx.compose.material.icons.filled.TravelExplore
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.FilledTonalButton
@@ -329,6 +330,7 @@ private fun TracerouteInputCard(
 ) {
     val keyboard = LocalSoftwareKeyboardController.current
     val mtuDiscovery = packetSize == 0
+    val isHostInvalid = host.isNotBlank() && host.contains(' ')
 
     ElevatedCard(modifier = Modifier.fillMaxWidth()) {
         Column(
@@ -354,6 +356,10 @@ private fun TracerouteInputCard(
                         }
                     }
                 },
+                isError = isHostInvalid,
+                supportingText = if (isHostInvalid) {
+                    { Text(stringResource(R.string.error_invalid_host)) }
+                } else null,
                 singleLine    = true,
                 enabled       = !isRunning,
                 modifier      = Modifier.fillMaxWidth(),
@@ -459,7 +465,11 @@ private fun TracerouteInputCard(
             if (isRunning) {
                 Button(
                     onClick  = onStop,
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.error,
+                        contentColor = MaterialTheme.colorScheme.onError
+                    )
                 ) {
                     Icon(Icons.Default.Stop, null)
                     Spacer(Modifier.width(8.dp))
@@ -468,7 +478,7 @@ private fun TracerouteInputCard(
             } else {
                 Button(
                     onClick  = { keyboard?.hide(); onStart() },
-                    enabled  = host.isNotBlank(),
+                    enabled  = host.isNotBlank() && !isHostInvalid,
                     modifier = Modifier.fillMaxWidth()
                 ) {
                     Icon(Icons.Default.Public, null)

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/WifiScanScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/WifiScanScreen.kt
@@ -60,7 +60,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -88,6 +88,11 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import net.aieat.netswissknife.app.ui.theme.AppShapes
 import net.aieat.netswissknife.app.ui.theme.StatusBad
 import net.aieat.netswissknife.app.ui.theme.StatusCritical
 import net.aieat.netswissknife.app.ui.theme.StatusGood
@@ -99,6 +104,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import net.aieat.netswissknife.app.ui.screens.wifi.ApSortOrder
@@ -130,9 +136,9 @@ private fun networkColor(colorIndex: Int): Color =
 fun WifiScanScreen(
     viewModel: WifiScanViewModel = hiltViewModel()
 ) {
-    val uiState by viewModel.uiState.collectAsState()
-    val autoRefresh by viewModel.autoRefresh.collectAsState()
-    val expandedNetworks by viewModel.expandedNetworks.collectAsState()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val autoRefresh by viewModel.autoRefresh.collectAsStateWithLifecycle()
+    val expandedNetworks by viewModel.expandedNetworks.collectAsStateWithLifecycle()
 
     val requiredPermissions = buildList {
         add(Manifest.permission.ACCESS_FINE_LOCATION)
@@ -204,7 +210,10 @@ fun WifiScanScreen(
 
 @Composable private fun WifiIdleScreen() {
     Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        CircularProgressIndicator(color = MaterialTheme.colorScheme.primary)
+        CircularProgressIndicator(
+            modifier = Modifier.semantics { contentDescription = "Loading" },
+            color = MaterialTheme.colorScheme.primary
+        )
     }
 }
 
@@ -683,7 +692,7 @@ private fun bandChannelLabels(band: WifiBand): List<Pair<Int, Float>> = when (ba
 
     ElevatedCard(
         onClick  = onToggleExpanded,
-        modifier = Modifier.fillMaxWidth()
+        modifier = Modifier.fillMaxWidth().semantics { role = Role.Button }
     ) {
         Column {
             // ── Header row ────────────────────────────────────────────────────

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/WifiScanScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/WifiScanScreen.kt
@@ -106,7 +106,11 @@ import net.aieat.netswissknife.app.ui.screens.wifi.WifiScanUiState
 import net.aieat.netswissknife.app.ui.screens.wifi.WifiScanViewModel
 import net.aieat.netswissknife.core.network.wifi.WifiAccessPoint
 import net.aieat.netswissknife.core.network.wifi.WifiNetwork
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material3.IconButton
 import net.aieat.netswissknife.app.R
+import net.aieat.netswissknife.app.ui.components.HelpSection
+import net.aieat.netswissknife.app.ui.components.ToolHelpSheet
 import net.aieat.netswissknife.core.network.wifi.WifiBand
 
 // ── Network colour palette (12 visually distinct colours) ────────────────────
@@ -314,6 +318,7 @@ fun WifiScanScreen(
     onToggleNetworkExpanded: (String) -> Unit,
 ) {
     val networks = state.filteredNetworks
+    var showHelp by remember { mutableStateOf(false) }
 
     LazyColumn(
         modifier = Modifier.fillMaxSize().padding(horizontal = 16.dp),
@@ -326,7 +331,8 @@ fun WifiScanScreen(
                 result = state.result,
                 autoRefresh = autoRefresh,
                 onScan = onScan,
-                onToggleAutoRefresh = onToggleAutoRefresh
+                onToggleAutoRefresh = onToggleAutoRefresh,
+                onHelpClick = { showHelp = true }
             )
         }
 
@@ -376,12 +382,24 @@ fun WifiScanScreen(
             )
         }
 
-        item { Spacer(Modifier.height(80.dp)) }
+        item { Spacer(Modifier.height(16.dp)) }
     }
 
     if (state.selectedAp != null) {
         WifiApDetailSheet(ap = state.selectedAp, connectedInfo = state.result.connectedNetwork,
             onDismiss = { onSelectAp(null) })
+    }
+
+    if (showHelp) {
+        ToolHelpSheet(
+            title = stringResource(R.string.help_wifi_title),
+            sections = listOf(
+                HelpSection(stringResource(R.string.help_wifi_what_heading), stringResource(R.string.help_wifi_what_body)),
+                HelpSection(stringResource(R.string.help_wifi_params_heading), stringResource(R.string.help_wifi_params_body)),
+                HelpSection(stringResource(R.string.help_wifi_results_heading), stringResource(R.string.help_wifi_results_body))
+            ),
+            onDismiss = { showHelp = false }
+        )
     }
 }
 
@@ -392,6 +410,7 @@ fun WifiScanScreen(
     autoRefresh: Boolean,
     onScan: () -> Unit,
     onToggleAutoRefresh: () -> Unit,
+    onHelpClick: () -> Unit,
 ) {
     val gradient = Brush.linearGradient(
         listOf(MaterialTheme.colorScheme.primaryContainer, MaterialTheme.colorScheme.tertiaryContainer)
@@ -403,14 +422,18 @@ fun WifiScanScreen(
                     Icon(Icons.Default.Wifi, null, Modifier.size(28.dp),
                         tint = MaterialTheme.colorScheme.onPrimaryContainer)
                     Spacer(Modifier.width(10.dp))
-                    Text(stringResource(R.string.wifi_screen_title), style = MaterialTheme.typography.displaySmall,
-                        color = MaterialTheme.colorScheme.onPrimaryContainer)
-                    Spacer(Modifier.weight(1f))
-                    FilledTonalIconButton(onClick = onScan) {
-                        Icon(Icons.Default.Refresh, "Scan")
+                    Text(
+                        stringResource(R.string.wifi_screen_title),
+                        style = MaterialTheme.typography.displaySmall,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer,
+                        modifier = Modifier.weight(1f)
+                    )
+                    IconButton(onClick = onHelpClick) {
+                        Icon(Icons.Default.Info, contentDescription = stringResource(R.string.action_help),
+                            tint = MaterialTheme.colorScheme.onPrimaryContainer)
                     }
                 }
-                Spacer(Modifier.height(8.dp))
+                Spacer(Modifier.height(4.dp))
                 val time = remember(result.scanTimestampMs) {
                     SimpleDateFormat("HH:mm:ss", Locale.getDefault()).format(Date(result.scanTimestampMs))
                 }
@@ -425,6 +448,10 @@ fun WifiScanScreen(
                         style = MaterialTheme.typography.labelSmall,
                         color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f)
                     )
+                }
+                Spacer(Modifier.height(8.dp))
+                FilledTonalIconButton(onClick = onScan) {
+                    Icon(Icons.Default.Refresh, contentDescription = stringResource(R.string.wifi_scan_button))
                 }
             }
         }

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/httprobe/HttpProbeScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/httprobe/HttpProbeScreen.kt
@@ -289,6 +289,9 @@ private fun HttpProbeInputCard(
     onClearRecentHosts: () -> Unit
 ) {
     val focusManager = LocalFocusManager.current
+    val url = uiState.url
+    val isUrlInvalid = url.isNotBlank() &&
+        !url.startsWith("http://") && !url.startsWith("https://") && url.contains('.')
 
     ElevatedCard(modifier = Modifier.fillMaxWidth()) {
         Column(
@@ -297,18 +300,22 @@ private fun HttpProbeInputCard(
         ) {
             // URL field
             OutlinedTextField(
-                value = uiState.url,
+                value = url,
                 onValueChange = onUrlChange,
                 label = { Text(stringResource(R.string.httprobe_url_label)) },
                 placeholder = { Text(stringResource(R.string.httprobe_url_placeholder)) },
                 leadingIcon = { Icon(Icons.Default.Http, contentDescription = null) },
                 trailingIcon = {
-                    if (uiState.url.isNotEmpty()) {
+                    if (url.isNotEmpty()) {
                         IconButton(onClick = { onUrlChange("") }) {
                             Icon(Icons.Default.Clear, contentDescription = stringResource(R.string.clear))
                         }
                     }
                 },
+                isError = isUrlInvalid,
+                supportingText = if (isUrlInvalid) {
+                    { Text(stringResource(R.string.error_invalid_url)) }
+                } else null,
                 singleLine = true,
                 modifier = Modifier.fillMaxWidth(),
                 keyboardOptions = KeyboardOptions(
@@ -478,7 +485,7 @@ private fun HttpProbeInputCard(
                     focusManager.clearFocus()
                     onSend()
                 },
-                enabled = uiState.url.isNotBlank() && !uiState.isLoading,
+                enabled = uiState.url.isNotBlank() && !uiState.isLoading && !isUrlInvalid,
                 modifier = Modifier.fillMaxWidth(),
                 colors = ButtonDefaults.buttonColors(
                     containerColor = MaterialTheme.colorScheme.primary

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/httprobe/HttpProbeScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/httprobe/HttpProbeScreen.kt
@@ -92,7 +92,9 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import kotlinx.coroutines.launch
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import net.aieat.netswissknife.app.R
+import net.aieat.netswissknife.app.ui.components.HelpSection
 import net.aieat.netswissknife.app.ui.components.RecentHostsRow
+import net.aieat.netswissknife.app.ui.components.ToolHelpSheet
 import net.aieat.netswissknife.app.util.formatBytes
 import net.aieat.netswissknife.app.util.shareText
 import net.aieat.netswissknife.core.network.httprobe.HttpMethod
@@ -110,6 +112,7 @@ fun HttpProbeScreen(viewModel: HttpProbeViewModel = hiltViewModel()) {
 
     var visible by remember { mutableStateOf(false) }
     LaunchedEffect(Unit) { visible = true }
+    var showHelp by remember { mutableStateOf(false) }
 
     val alpha by animateFloatAsState(
         targetValue = if (visible) 1f else 0f,
@@ -128,7 +131,7 @@ fun HttpProbeScreen(viewModel: HttpProbeViewModel = hiltViewModel()) {
                 horizontal = 16.dp, vertical = 16.dp
             )
         ) {
-            item { HttpProbeHeaderCard() }
+            item { HttpProbeHeaderCard(onHelpClick = { showHelp = true }) }
 
             item {
                 HttpProbeInputCard(
@@ -182,6 +185,18 @@ fun HttpProbeScreen(viewModel: HttpProbeViewModel = hiltViewModel()) {
             }
         }
     }
+
+    if (showHelp) {
+        ToolHelpSheet(
+            title = stringResource(R.string.help_httprobe_title),
+            sections = listOf(
+                HelpSection(stringResource(R.string.help_httprobe_what_heading), stringResource(R.string.help_httprobe_what_body)),
+                HelpSection(stringResource(R.string.help_httprobe_params_heading), stringResource(R.string.help_httprobe_params_body)),
+                HelpSection(stringResource(R.string.help_httprobe_results_heading), stringResource(R.string.help_httprobe_results_body))
+            ),
+            onDismiss = { showHelp = false }
+        )
+    }
 }
 
 // ── Display state ─────────────────────────────────────────────────────────────
@@ -196,45 +211,57 @@ private sealed class DisplayState {
 // ── Header card ───────────────────────────────────────────────────────────────
 
 @Composable
-private fun HttpProbeHeaderCard() {
+private fun HttpProbeHeaderCard(onHelpClick: () -> Unit) {
     ElevatedCard(modifier = Modifier.fillMaxWidth()) {
-        Box(modifier = Modifier.fillMaxWidth().height(90.dp)) {
-            Canvas(modifier = Modifier.matchParentSize()) {
-                drawRect(
-                    brush = Brush.linearGradient(
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(
+                    Brush.linearGradient(
                         listOf(
-                            Color(0xFF1565C0),
-                            Color(0xFF0288D1)
+                            MaterialTheme.colorScheme.primaryContainer,
+                            MaterialTheme.colorScheme.secondaryContainer
                         )
                     )
                 )
-            }
-            Column(
-                modifier = Modifier
-                    .align(Alignment.CenterStart)
-                    .padding(horizontal = 20.dp, vertical = 16.dp)
-            ) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
+                .padding(20.dp)
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Box(
+                    modifier = Modifier
+                        .size(52.dp)
+                        .clip(RoundedCornerShape(14.dp))
+                        .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.15f)),
+                    contentAlignment = Alignment.Center
+                ) {
                     Icon(
                         imageVector = Icons.Default.Http,
                         contentDescription = null,
-                        tint = Color.White,
-                        modifier = Modifier.size(26.dp)
-                    )
-                    Spacer(Modifier.width(10.dp))
-                    Text(
-                        text = stringResource(R.string.httprobe_screen_title),
-                        style = MaterialTheme.typography.headlineMedium,
-                        color = Color.White,
-                        fontWeight = FontWeight.Bold
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(28.dp)
                     )
                 }
-                Spacer(Modifier.height(4.dp))
-                Text(
-                    text = stringResource(R.string.httprobe_screen_subtitle),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = Color.White.copy(alpha = 0.85f)
-                )
+                Spacer(Modifier.width(16.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = stringResource(R.string.httprobe_screen_title),
+                        style = MaterialTheme.typography.displaySmall,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer,
+                        fontWeight = FontWeight.Bold
+                    )
+                    Text(
+                        text = stringResource(R.string.httprobe_screen_subtitle),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.8f)
+                    )
+                }
+                IconButton(onClick = onHelpClick) {
+                    Icon(
+                        imageVector = Icons.Default.Info,
+                        contentDescription = stringResource(R.string.action_help),
+                        tint = MaterialTheme.colorScheme.onPrimaryContainer
+                    )
+                }
             }
         }
     }

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/httprobe/HttpProbeScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/httprobe/HttpProbeScreen.kt
@@ -247,7 +247,8 @@ private fun HttpProbeHeaderCard(onHelpClick: () -> Unit) {
                         text = stringResource(R.string.httprobe_screen_title),
                         style = MaterialTheme.typography.displaySmall,
                         color = MaterialTheme.colorScheme.onPrimaryContainer,
-                        fontWeight = FontWeight.Bold
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
                     )
                     Text(
                         text = stringResource(R.string.httprobe_screen_subtitle),

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/lan/LanScanScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/lan/LanScanScreen.kt
@@ -62,6 +62,7 @@ import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.SmartToy
 import androidx.compose.material.icons.filled.Stop
 import androidx.compose.material.icons.filled.Wifi
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -81,7 +82,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
+// collectAsState replaced by collectAsStateWithLifecycle below
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -93,6 +94,8 @@ import androidx.compose.ui.draw.scale
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
@@ -114,12 +117,12 @@ import net.aieat.netswissknife.core.network.lan.LanScanSummary
 
 @Composable
 fun LanScreen(viewModel: LanScanViewModel = hiltViewModel()) {
-    val uiState by viewModel.uiState.collectAsState()
-    val subnet by viewModel.subnet.collectAsState()
-    val timeoutMs by viewModel.timeoutMs.collectAsState()
-    val concurrency by viewModel.concurrency.collectAsState()
-    val isSubnetLoading by viewModel.isSubnetLoading.collectAsState()
-    val searchQuery by viewModel.searchQuery.collectAsState()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val subnet by viewModel.subnet.collectAsStateWithLifecycle()
+    val timeoutMs by viewModel.timeoutMs.collectAsStateWithLifecycle()
+    val concurrency by viewModel.concurrency.collectAsStateWithLifecycle()
+    val isSubnetLoading by viewModel.isSubnetLoading.collectAsStateWithLifecycle()
+    val searchQuery by viewModel.searchQuery.collectAsStateWithLifecycle()
     val recentSubnets by viewModel.recentSubnets.collectAsStateWithLifecycle()
 
     var visible by remember { mutableStateOf(false) }
@@ -243,6 +246,8 @@ private fun LanHeaderCard(onHelpClick: () -> Unit) {
                         text = stringResource(R.string.lan_screen_title),
                         style = MaterialTheme.typography.displaySmall,
                         color = MaterialTheme.colorScheme.onPrimaryContainer,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
                     )
                     Text(
                         text = stringResource(R.string.lan_screen_subtitle),
@@ -310,7 +315,8 @@ private fun LanInputCard(
                         CircularProgressIndicator(
                             modifier = Modifier
                                 .size(24.dp)
-                                .padding(end = 8.dp),
+                                .padding(end = 8.dp)
+                                .semantics { contentDescription = "Loading" },
                             strokeWidth = 2.dp,
                         )
                     } else {
@@ -691,17 +697,30 @@ private fun LanFinishedContent(
         }
 
         if (summary.hosts.isEmpty()) {
-            OutlinedCard(modifier = Modifier.fillMaxWidth()) {
-                Box(
+            ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+                Column(
                     modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(32.dp),
-                    contentAlignment = Alignment.Center,
+                        .padding(24.dp)
+                        .fillMaxWidth(),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
+                    Icon(
+                        imageVector = Icons.Default.Wifi,
+                        contentDescription = null,
+                        modifier = Modifier.size(48.dp),
+                        tint = MaterialTheme.colorScheme.primary.copy(alpha = 0.5f),
+                    )
                     Text(
-                        text = stringResource(R.string.lan_no_hosts_found),
-                        style = MaterialTheme.typography.bodyMedium,
+                        text = stringResource(R.string.lan_empty_title),
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                    Text(
+                        text = stringResource(R.string.lan_empty_body),
+                        style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        textAlign = TextAlign.Center,
                     )
                 }
             }

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/lan/LanScanScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/lan/LanScanScreen.kt
@@ -57,6 +57,7 @@ import androidx.compose.material.icons.filled.Lan
 import androidx.compose.material.icons.filled.NetworkCheck
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Router
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.SmartToy
 import androidx.compose.material.icons.filled.Stop
@@ -102,7 +103,9 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import net.aieat.netswissknife.app.R
+import net.aieat.netswissknife.app.ui.components.HelpSection
 import net.aieat.netswissknife.app.ui.components.RecentHostsRow
+import net.aieat.netswissknife.app.ui.components.ToolHelpSheet
 import net.aieat.netswissknife.app.util.shareText
 import net.aieat.netswissknife.core.network.lan.LanHost
 import net.aieat.netswissknife.core.network.lan.LanScanSummary
@@ -121,6 +124,7 @@ fun LanScreen(viewModel: LanScanViewModel = hiltViewModel()) {
 
     var visible by remember { mutableStateOf(false) }
     LaunchedEffect(Unit) { visible = true }
+    var showHelp by remember { mutableStateOf(false) }
 
     AnimatedVisibility(
         visible = visible,
@@ -133,7 +137,7 @@ fun LanScreen(viewModel: LanScanViewModel = hiltViewModel()) {
                 .padding(horizontal = 16.dp, vertical = 8.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
-            LanHeaderCard()
+            LanHeaderCard(onHelpClick = { showHelp = true })
 
             LanInputCard(
                 subnet = subnet,
@@ -182,12 +186,24 @@ fun LanScreen(viewModel: LanScanViewModel = hiltViewModel()) {
             }
         }
     }
+
+    if (showHelp) {
+        ToolHelpSheet(
+            title = stringResource(R.string.help_lan_title),
+            sections = listOf(
+                HelpSection(stringResource(R.string.help_lan_what_heading), stringResource(R.string.help_lan_what_body)),
+                HelpSection(stringResource(R.string.help_lan_params_heading), stringResource(R.string.help_lan_params_body)),
+                HelpSection(stringResource(R.string.help_lan_results_heading), stringResource(R.string.help_lan_results_body))
+            ),
+            onDismiss = { showHelp = false }
+        )
+    }
 }
 
 // ── Header card ───────────────────────────────────────────────────────────────
 
 @Composable
-private fun LanHeaderCard() {
+private fun LanHeaderCard(onHelpClick: () -> Unit) {
     ElevatedCard(modifier = Modifier.fillMaxWidth()) {
         Box(
             modifier = Modifier
@@ -222,7 +238,7 @@ private fun LanHeaderCard() {
                         modifier = Modifier.size(28.dp),
                     )
                 }
-                Column {
+                Column(modifier = Modifier.weight(1f)) {
                     Text(
                         text = stringResource(R.string.lan_screen_title),
                         style = MaterialTheme.typography.displaySmall,
@@ -232,6 +248,13 @@ private fun LanHeaderCard() {
                         text = stringResource(R.string.lan_screen_subtitle),
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.75f),
+                    )
+                }
+                IconButton(onClick = onHelpClick) {
+                    Icon(
+                        imageVector = Icons.Default.Info,
+                        contentDescription = stringResource(R.string.action_help),
+                        tint = MaterialTheme.colorScheme.onPrimaryContainer
                     )
                 }
             }
@@ -279,26 +302,23 @@ private fun LanInputCard(
                     Icon(Icons.Default.Wifi, contentDescription = null)
                 },
                 trailingIcon = {
-                    Row {
-                        if (subnet.isNotEmpty()) {
-                            IconButton(onClick = { onSubnetChange("") }) {
-                                Icon(Icons.Default.Clear, contentDescription = stringResource(R.string.clear))
-                            }
+                    if (subnet.isNotEmpty()) {
+                        IconButton(onClick = { onSubnetChange("") }) {
+                            Icon(Icons.Default.Clear, contentDescription = stringResource(R.string.clear))
                         }
-                        if (isSubnetLoading) {
-                            CircularProgressIndicator(
-                                modifier = Modifier
-                                    .size(24.dp)
-                                    .padding(end = 8.dp),
-                                strokeWidth = 2.dp,
+                    } else if (isSubnetLoading) {
+                        CircularProgressIndicator(
+                            modifier = Modifier
+                                .size(24.dp)
+                                .padding(end = 8.dp),
+                            strokeWidth = 2.dp,
+                        )
+                    } else {
+                        IconButton(onClick = onRefreshSubnet) {
+                            Icon(
+                                Icons.Default.Refresh,
+                                contentDescription = stringResource(R.string.lan_detect_subnet),
                             )
-                        } else {
-                            IconButton(onClick = onRefreshSubnet) {
-                                Icon(
-                                    Icons.Default.Refresh,
-                                    contentDescription = stringResource(R.string.lan_detect_subnet),
-                                )
-                            }
                         }
                     }
                 },

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/mdns/MdnsDiscoveryScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/mdns/MdnsDiscoveryScreen.kt
@@ -78,15 +78,21 @@ import androidx.compose.material.icons.filled.Info
 import androidx.compose.material3.IconButton
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import net.aieat.netswissknife.app.R
+import net.aieat.netswissknife.app.ui.theme.AppShapes
 import net.aieat.netswissknife.app.ui.components.HelpSection
 import net.aieat.netswissknife.app.ui.components.ToolHelpSheet
 import net.aieat.netswissknife.core.network.mdns.DiscoveredService
 
 @Composable
 fun MdnsDiscoveryScreen(viewModel: MdnsDiscoveryViewModel = hiltViewModel()) {
-    val uiState by viewModel.uiState.collectAsState()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     var visible by remember { mutableStateOf(false) }
     LaunchedEffect(Unit) { visible = true }
@@ -117,18 +123,21 @@ fun MdnsDiscoveryScreen(viewModel: MdnsDiscoveryViewModel = hiltViewModel()) {
                     uiState.error != null -> "error"
                     uiState.services.isEmpty() && !uiState.isScanning && !uiState.scanComplete -> "idle"
                     uiState.services.isEmpty() && uiState.isScanning -> "scanning_empty"
+                    uiState.services.isEmpty() && uiState.scanComplete -> "empty_done"
                     else -> "results"
                 },
                 transitionSpec = {
                     fadeIn(tween(300)) togetherWith fadeOut(tween(200))
                 },
-                label = "mdns-state"
+                label = "mdns-state",
+                modifier = Modifier.weight(1f)
             ) { state ->
                 when (state) {
                     "idle" -> IdleHint()
                     "scanning_empty" -> ScanningPlaceholder()
+                    "empty_done" -> EmptyResultHint()
                     "error" -> ErrorCard(uiState.error ?: "Unknown error") { viewModel.reset() }
-                    "results" -> ServiceList(
+                    else -> ServiceList(
                         servicesByType = uiState.servicesByType,
                         isScanning = uiState.isScanning
                     )
@@ -162,7 +171,7 @@ private fun HeroCard(state: MdnsDiscoveryUiState, onHelpClick: () -> Unit) {
     )
 
     ElevatedCard(
-        shape = RoundedCornerShape(20.dp),
+        shape = AppShapes.large,
         modifier = Modifier.fillMaxWidth()
     ) {
         Column(
@@ -281,7 +290,7 @@ private fun ControlRow(
                 ) {
                     Icon(Icons.Default.Close, null, modifier = Modifier.size(18.dp))
                     Spacer(Modifier.width(8.dp))
-                    Text("Stop")
+                    Text(stringResource(R.string.mdns_stop_button))
                 }
             } else {
                 Button(
@@ -290,14 +299,14 @@ private fun ControlRow(
                 ) {
                     Icon(Icons.Default.PlayArrow, null, modifier = Modifier.size(18.dp))
                     Spacer(Modifier.width(8.dp))
-                    Text("Scan Network")
+                    Text(stringResource(R.string.mdns_scan_button))
                 }
             }
         }
 
         if (hasPriorResults && !isScanning) {
             FilledTonalButton(onClick = onReset) {
-                Text("Clear")
+                Text(stringResource(R.string.mdns_clear_button))
             }
         }
     }
@@ -322,13 +331,13 @@ private fun IdleHint() {
             )
             Spacer(Modifier.height(12.dp))
             Text(
-                text = "Tap Scan to discover services",
+                text = stringResource(R.string.mdns_idle_hint),
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
             )
             Spacer(Modifier.height(4.dp))
             Text(
-                text = "Finds printers, Chromecasts, AirPlay, HomeKit, and more",
+                text = stringResource(R.string.mdns_idle_body),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f)
             )
@@ -354,12 +363,14 @@ private fun ScanningPlaceholder() {
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
         CircularProgressIndicator(
-            modifier = Modifier.size(52.dp),
+            modifier = Modifier
+                .size(52.dp)
+                .semantics { contentDescription = "Scanning for mDNS services" },
             strokeCap = StrokeCap.Round,
             color = MaterialTheme.colorScheme.primary.copy(alpha = pulse)
         )
         Text(
-            text = "Listening for mDNS announcements…",
+            text = stringResource(R.string.mdns_scanning_hint),
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
         )
@@ -369,14 +380,14 @@ private fun ScanningPlaceholder() {
 @Composable
 private fun ErrorCard(message: String, onRetry: () -> Unit) {
     ElevatedCard(
-        shape = RoundedCornerShape(16.dp),
+        shape = AppShapes.large,
         colors = CardDefaults.elevatedCardColors(
             containerColor = MaterialTheme.colorScheme.errorContainer
         )
     ) {
         Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
             Text(
-                text = "Discovery failed",
+                text = stringResource(R.string.mdns_error_title),
                 style = MaterialTheme.typography.titleSmall,
                 color = MaterialTheme.colorScheme.onErrorContainer,
                 fontWeight = FontWeight.SemiBold
@@ -386,7 +397,7 @@ private fun ErrorCard(message: String, onRetry: () -> Unit) {
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onErrorContainer.copy(alpha = 0.8f)
             )
-            FilledTonalButton(onClick = onRetry) { Text("Dismiss") }
+            FilledTonalButton(onClick = onRetry) { Text(stringResource(R.string.mdns_error_dismiss)) }
         }
     }
 }
@@ -409,11 +420,13 @@ private fun ServiceList(
                     modifier = Modifier.padding(vertical = 4.dp)
                 ) {
                     CircularProgressIndicator(
-                        modifier = Modifier.size(14.dp),
+                        modifier = Modifier
+                            .size(14.dp)
+                            .semantics { contentDescription = "Scanning in progress" },
                         strokeWidth = 2.dp
                     )
                     Text(
-                        "Scanning…",
+                        stringResource(R.string.mdns_scanning_inline_label),
                         style = MaterialTheme.typography.labelMedium,
                         color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
                     )
@@ -466,9 +479,10 @@ private fun ServiceTypeHeader(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(12.dp))
+            .clip(AppShapes.medium)
             .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f))
             .clickable(onClick = onClick)
+            .semantics { role = Role.Button }
             .padding(horizontal = 14.dp, vertical = 10.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
@@ -515,12 +529,13 @@ private fun ServiceItem(service: DiscoveredService) {
     var expanded by remember { mutableStateOf(false) }
 
     OutlinedCard(
-        shape = RoundedCornerShape(12.dp),
+        shape = AppShapes.medium,
         modifier = Modifier
             .fillMaxWidth()
             .padding(start = 8.dp)
             .animateContentSize()
             .clickable { expanded = !expanded }
+            .semantics { role = Role.Button }
     ) {
         Column(modifier = Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
             Row(verticalAlignment = Alignment.CenterVertically) {
@@ -576,7 +591,7 @@ private fun ServiceItem(service: DiscoveredService) {
                     if (service.txtRecords.isNotEmpty()) {
                         HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
                         Text(
-                            "TXT Records",
+                            stringResource(R.string.mdns_txt_records_label),
                             style = MaterialTheme.typography.labelSmall,
                             color = MaterialTheme.colorScheme.primary,
                             fontWeight = FontWeight.SemiBold
@@ -603,6 +618,40 @@ private fun ServiceItem(service: DiscoveredService) {
                     }
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun EmptyResultHint() {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 32.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Icon(
+                imageVector = Icons.Default.NetworkPing,
+                contentDescription = null,
+                modifier = Modifier.size(64.dp),
+                tint = MaterialTheme.colorScheme.primary.copy(alpha = 0.4f)
+            )
+            Text(
+                text = stringResource(R.string.mdns_empty_title),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
+            )
+            Text(
+                text = stringResource(R.string.mdns_empty_body),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f),
+                textAlign = androidx.compose.ui.text.style.TextAlign.Center,
+                modifier = Modifier.padding(horizontal = 24.dp)
+            )
         }
     }
 }

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/mdns/MdnsDiscoveryScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/mdns/MdnsDiscoveryScreen.kt
@@ -74,7 +74,14 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material3.IconButton
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
+import net.aieat.netswissknife.app.R
+import net.aieat.netswissknife.app.ui.components.HelpSection
+import net.aieat.netswissknife.app.ui.components.ToolHelpSheet
 import net.aieat.netswissknife.core.network.mdns.DiscoveredService
 
 @Composable
@@ -83,6 +90,7 @@ fun MdnsDiscoveryScreen(viewModel: MdnsDiscoveryViewModel = hiltViewModel()) {
 
     var visible by remember { mutableStateOf(false) }
     LaunchedEffect(Unit) { visible = true }
+    var showHelp by remember { mutableStateOf(false) }
 
     AnimatedVisibility(
         visible = visible,
@@ -94,7 +102,7 @@ fun MdnsDiscoveryScreen(viewModel: MdnsDiscoveryViewModel = hiltViewModel()) {
                 .padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
-            HeroCard(uiState)
+            HeroCard(uiState, onHelpClick = { showHelp = true })
 
             ControlRow(
                 isScanning = uiState.isScanning,
@@ -128,12 +136,24 @@ fun MdnsDiscoveryScreen(viewModel: MdnsDiscoveryViewModel = hiltViewModel()) {
             }
         }
     }
+
+    if (showHelp) {
+        ToolHelpSheet(
+            title = stringResource(R.string.help_mdns_title),
+            sections = listOf(
+                HelpSection(stringResource(R.string.help_mdns_what_heading), stringResource(R.string.help_mdns_what_body)),
+                HelpSection(stringResource(R.string.help_mdns_params_heading), stringResource(R.string.help_mdns_params_body)),
+                HelpSection(stringResource(R.string.help_mdns_results_heading), stringResource(R.string.help_mdns_results_body))
+            ),
+            onDismiss = { showHelp = false }
+        )
+    }
 }
 
 // ── Hero card ─────────────────────────────────────────────────────────────────
 
 @Composable
-private fun HeroCard(state: MdnsDiscoveryUiState) {
+private fun HeroCard(state: MdnsDiscoveryUiState, onHelpClick: () -> Unit) {
     val gradient = Brush.linearGradient(
         colors = listOf(
             MaterialTheme.colorScheme.primaryContainer,
@@ -145,50 +165,65 @@ private fun HeroCard(state: MdnsDiscoveryUiState) {
         shape = RoundedCornerShape(20.dp),
         modifier = Modifier.fillMaxWidth()
     ) {
-        Box(
+        Column(
             modifier = Modifier
                 .fillMaxWidth()
                 .background(gradient)
-                .padding(20.dp)
+                .padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
             Row(verticalAlignment = Alignment.CenterVertically) {
-                Icon(
-                    imageVector = Icons.Default.Devices,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.size(40.dp)
-                )
+                Box(
+                    modifier = Modifier
+                        .size(52.dp)
+                        .clip(CircleShape)
+                        .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.15f)),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Devices,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(28.dp)
+                    )
+                }
                 Spacer(Modifier.width(16.dp))
-                Column {
+                Column(modifier = Modifier.weight(1f)) {
                     Text(
-                        text = "mDNS Service Browser",
-                        style = MaterialTheme.typography.titleMedium,
+                        text = stringResource(R.string.mdns_screen_title),
+                        style = MaterialTheme.typography.displaySmall,
                         fontWeight = FontWeight.Bold,
                         color = MaterialTheme.colorScheme.onPrimaryContainer
                     )
                     Text(
-                        text = "Discover services on your local network",
-                        style = MaterialTheme.typography.bodySmall,
+                        text = stringResource(R.string.mdns_screen_subtitle),
+                        style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.8f)
+                    )
+                }
+                IconButton(onClick = onHelpClick) {
+                    Icon(
+                        imageVector = Icons.Default.Info,
+                        contentDescription = stringResource(R.string.action_help),
+                        tint = MaterialTheme.colorScheme.onPrimaryContainer
                     )
                 }
             }
 
-            // Stats badges — top right
+            // Stats badges
             if (state.services.isNotEmpty() || state.isScanning) {
                 Row(
-                    modifier = Modifier.align(Alignment.TopEnd),
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     StatBadge(
                         value = state.services.size.toString(),
-                        label = "found"
+                        label = stringResource(R.string.mdns_stat_found)
                     )
                     if (state.isScanning) {
                         StatBadge(
                             value = "${state.elapsedMs / 1000}s",
-                            label = "elapsed"
+                            label = stringResource(R.string.mdns_stat_elapsed)
                         )
                     }
                 }

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/onboarding/OnboardingSheet.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/onboarding/OnboardingSheet.kt
@@ -1,0 +1,185 @@
+package net.aieat.netswissknife.app.ui.screens.onboarding
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.slideInVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Hub
+import androidx.compose.material.icons.filled.Language
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.NetworkCheck
+import androidx.compose.material.icons.filled.Speed
+import androidx.compose.material.icons.filled.Wifi
+import androidx.compose.material3.Button
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import net.aieat.netswissknife.app.R
+
+private data class OnboardingFeature(
+    val icon: ImageVector,
+    val title: String,
+    val description: String
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun OnboardingSheet(onDismiss: () -> Unit) {
+    val sheetState = rememberModalBottomSheetState()
+    var contentVisible by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) { contentVisible = true }
+
+    val features = listOf(
+        OnboardingFeature(Icons.Default.NetworkCheck, "Diagnostics", "Ping, traceroute, port scan, and LAN discovery to analyse your network."),
+        OnboardingFeature(Icons.Default.Wifi,         "Wi-Fi Analysis", "Scan nearby networks, visualise the spectrum, and find the best channel."),
+        OnboardingFeature(Icons.Default.Lock,         "Security Tools", "Inspect TLS certificates, probe HTTP endpoints, and look up WHOIS data."),
+        OnboardingFeature(Icons.Default.Speed,        "Speed Test",     "Measure download, upload, and latency against Cloudflare's global network."),
+        OnboardingFeature(Icons.Default.Language,     "DNS & Subnet",   "Resolve DNS records, calculate subnets, and browse mDNS services.")
+    )
+
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
+        AnimatedVisibility(
+            visible = contentVisible,
+            enter = fadeIn(tween(300)) + slideInVertically(tween(300)) { it / 4 }
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .verticalScroll(rememberScrollState())
+                    .padding(horizontal = 24.dp)
+                    .padding(bottom = 40.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(72.dp)
+                        .clip(CircleShape)
+                        .background(
+                            Brush.radialGradient(
+                                listOf(
+                                    MaterialTheme.colorScheme.primary,
+                                    MaterialTheme.colorScheme.tertiary
+                                )
+                            )
+                        ),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Hub,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onPrimary,
+                        modifier = Modifier.size(40.dp)
+                    )
+                }
+
+                Spacer(Modifier.height(16.dp))
+
+                Text(
+                    text = stringResource(R.string.app_name),
+                    style = MaterialTheme.typography.headlineMedium,
+                    fontWeight = FontWeight.Bold,
+                    textAlign = TextAlign.Center
+                )
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    text = stringResource(R.string.onboarding_subtitle),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center
+                )
+
+                Spacer(Modifier.height(24.dp))
+
+                features.forEach { feature ->
+                    OnboardingFeatureRow(feature)
+                    Spacer(Modifier.height(12.dp))
+                }
+
+                Spacer(Modifier.height(8.dp))
+
+                Button(
+                    onClick = onDismiss,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text(stringResource(R.string.onboarding_get_started))
+                }
+                Spacer(Modifier.height(8.dp))
+                OutlinedButton(
+                    onClick = onDismiss,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text(stringResource(R.string.onboarding_dont_show_again))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun OnboardingFeatureRow(feature: OnboardingFeature) {
+    ElevatedCard(modifier = Modifier.fillMaxWidth(), shape = RoundedCornerShape(12.dp)) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(40.dp)
+                    .clip(RoundedCornerShape(10.dp))
+                    .background(MaterialTheme.colorScheme.primaryContainer),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = feature.icon,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                    modifier = Modifier.size(22.dp)
+                )
+            }
+            Spacer(Modifier.width(16.dp))
+            Column {
+                Text(feature.title, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+                Text(
+                    feature.description,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/onboarding/OnboardingViewModel.kt
@@ -1,0 +1,31 @@
+package net.aieat.netswissknife.app.ui.screens.onboarding
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import net.aieat.netswissknife.app.data.AppPreferenceKeys
+import javax.inject.Inject
+
+@HiltViewModel
+class OnboardingViewModel @Inject constructor(
+    private val dataStore: DataStore<Preferences>
+) : ViewModel() {
+
+    val shouldShowOnboarding: StateFlow<Boolean> = dataStore.data
+        .map { prefs -> prefs[AppPreferenceKeys.ONBOARDING_COMPLETED] != true }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, true)
+
+    fun completeOnboarding() {
+        viewModelScope.launch {
+            dataStore.edit { it[AppPreferenceKeys.ONBOARDING_COMPLETED] = true }
+        }
+    }
+}

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/settings/SettingsScreen.kt
@@ -458,8 +458,6 @@ private data class LibraryInfo(
 private val THIRD_PARTY_LIBRARIES = listOf(
     LibraryInfo("dnsjava", "3.6.2", "BSD 3-Clause",
         "Copyright (c) 1998-2024, Brian Wellington and the dnsjava contributors"),
-    LibraryInfo("MapLibre Compose", "0.12.1", "BSD 3-Clause",
-        "Copyright (c) 2021-2024, MapLibre contributors"),
     LibraryInfo("SNMP4J", "3.8.0", "Apache 2.0"),
     LibraryInfo("icmpenguin", "1.0.0-rc.3", "Apache 2.0"),
     LibraryInfo("Dagger Hilt", "2.59.2", "Apache 2.0"),

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/settings/SettingsScreen.kt
@@ -45,9 +45,10 @@ import androidx.compose.material3.TextButton
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -55,21 +56,24 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import net.aieat.netswissknife.app.BuildConfig
 import net.aieat.netswissknife.app.R
+import net.aieat.netswissknife.app.ui.theme.AppShapes
 import kotlin.math.roundToInt
 
 @Composable
 fun SettingsScreen(
     viewModel: SettingsViewModel = hiltViewModel()
 ) {
-    val themeOverride by viewModel.themeOverride.collectAsState()
-    val defaultPingCount by viewModel.defaultPingCount.collectAsState()
-    val defaultTimeoutMs by viewModel.defaultTimeoutMs.collectAsState()
-    val defaultConcurrency by viewModel.defaultConcurrency.collectAsState()
+    val themeOverride by viewModel.themeOverride.collectAsStateWithLifecycle()
+    val defaultPingCount by viewModel.defaultPingCount.collectAsStateWithLifecycle()
+    val defaultTimeoutMs by viewModel.defaultTimeoutMs.collectAsStateWithLifecycle()
+    val defaultConcurrency by viewModel.defaultConcurrency.collectAsStateWithLifecycle()
 
     var visible by remember { mutableStateOf(false) }
     LaunchedEffect(Unit) { visible = true }
@@ -122,8 +126,9 @@ private fun SettingsHeader() {
             Text(
                 text = stringResource(R.string.settings_screen_title),
                 style = MaterialTheme.typography.displaySmall,
-                fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.onBackground
+                color = MaterialTheme.colorScheme.onBackground,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
             )
             Text(
                 text = stringResource(R.string.settings_screen_subtitle),
@@ -227,7 +232,9 @@ private fun SliderSetting(
             onValueChange = onValueChange,
             valueRange = valueRange,
             steps = steps,
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier.fillMaxWidth().semantics {
+                contentDescription = "$label: ${value.toInt()}"
+            }
         )
     }
 }

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/settings/SettingsScreen.kt
@@ -22,8 +22,10 @@ import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.automirrored.filled.OpenInNew
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.SmartToy
 import androidx.compose.material.icons.filled.Speed
 import androidx.compose.material.icons.filled.Tune
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.foundation.clickable
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
@@ -97,6 +99,7 @@ fun SettingsScreen(
                 onConcurrencyChange = viewModel::setDefaultConcurrency
             )
             DataSection(onClearRecents = viewModel::clearAllRecentHosts)
+            OnboardingResetSection(onReset = viewModel::resetOnboarding)
             AboutSection()
             AttributionsSection()
             LicensesSection()
@@ -277,6 +280,49 @@ private fun DataSection(onClearRecents: () -> Unit) {
                     )
                 ) {
                     Text(stringResource(R.string.settings_clear_recents_confirm_button))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showConfirmDialog = false }) {
+                    Text(stringResource(R.string.cancel))
+                }
+            }
+        )
+    }
+}
+
+@Composable
+private fun OnboardingResetSection(onReset: () -> Unit) {
+    var showConfirmDialog by remember { mutableStateOf(false) }
+
+    SectionHeader(Icons.Default.SmartToy, stringResource(R.string.settings_guide_section))
+
+    ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text(
+                text = stringResource(R.string.settings_reset_onboarding_label),
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold
+            )
+            Text(
+                text = stringResource(R.string.settings_reset_onboarding_subtitle),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            OutlinedButton(onClick = { showConfirmDialog = true }) {
+                Text(stringResource(R.string.settings_reset_onboarding_button))
+            }
+        }
+    }
+
+    if (showConfirmDialog) {
+        AlertDialog(
+            onDismissRequest = { showConfirmDialog = false },
+            title = { Text(stringResource(R.string.settings_reset_onboarding_confirm_title)) },
+            text = { Text(stringResource(R.string.settings_reset_onboarding_confirm_message)) },
+            confirmButton = {
+                TextButton(onClick = { onReset(); showConfirmDialog = false }) {
+                    Text(stringResource(R.string.settings_reset_onboarding_confirm_button))
                 }
             },
             dismissButton = {

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/settings/SettingsViewModel.kt
@@ -59,6 +59,12 @@ class SettingsViewModel @Inject constructor(
         }
     }
 
+    fun resetOnboarding() {
+        viewModelScope.launch {
+            dataStore.edit { it[AppPreferenceKeys.ONBOARDING_COMPLETED] = false }
+        }
+    }
+
     fun clearAllRecentHosts() {
         viewModelScope.launch {
             dataStore.edit { prefs ->

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/speedtest/SpeedTestScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/speedtest/SpeedTestScreen.kt
@@ -78,6 +78,7 @@ import androidx.compose.ui.text.drawText
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -222,7 +223,8 @@ private fun SpeedTestHeaderCard(onHelpClick: () -> Unit) {
                         text = stringResource(R.string.speedtest_screen_title),
                         style = MaterialTheme.typography.displaySmall,
                         color = MaterialTheme.colorScheme.onPrimaryContainer,
-                        fontWeight = FontWeight.Bold
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
                     )
                     Text(
                         text = stringResource(R.string.speedtest_screen_subtitle),
@@ -537,7 +539,6 @@ private fun SpeedGauge(
             Text(
                 text = "%.1f".format(animatedValue),
                 style = MaterialTheme.typography.displaySmall,
-                fontWeight = FontWeight.Bold
             )
             Text(
                 text = stringResource(R.string.speedtest_mbps_suffix),

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/speedtest/SpeedTestScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/speedtest/SpeedTestScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.OpenInNew
 import androidx.compose.material.icons.filled.ArrowDownward
 import androidx.compose.material.icons.filled.ArrowUpward
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.NetworkCheck
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Refresh
@@ -45,6 +46,7 @@ import androidx.compose.material.icons.filled.Stop
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.Button
 import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -67,6 +69,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalUriHandler
@@ -80,6 +83,8 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import net.aieat.netswissknife.app.R
+import net.aieat.netswissknife.app.ui.components.HelpSection
+import net.aieat.netswissknife.app.ui.components.ToolHelpSheet
 import net.aieat.netswissknife.app.util.formatBytes
 import net.aieat.netswissknife.app.util.shareText
 import net.aieat.netswissknife.core.network.speedtest.LatencyStats
@@ -100,6 +105,7 @@ fun SpeedTestScreen(viewModel: SpeedTestViewModel = hiltViewModel()) {
 
     var visible by remember { mutableStateOf(false) }
     LaunchedEffect(Unit) { visible = true }
+    var showHelp by remember { mutableStateOf(false) }
 
     val phase = remember(uiState) {
         when (uiState) {
@@ -119,7 +125,7 @@ fun SpeedTestScreen(viewModel: SpeedTestViewModel = hiltViewModel()) {
             verticalArrangement = Arrangement.spacedBy(12.dp),
             contentPadding = PaddingValues(horizontal = 16.dp, vertical = 16.dp)
         ) {
-            item { SpeedTestHeaderCard() }
+            item { SpeedTestHeaderCard(onHelpClick = { showHelp = true }) }
 
             item {
                 AnimatedContent(
@@ -158,6 +164,18 @@ fun SpeedTestScreen(viewModel: SpeedTestViewModel = hiltViewModel()) {
             item { CloudflareAttributionCard() }
         }
     }
+
+    if (showHelp) {
+        ToolHelpSheet(
+            title = stringResource(R.string.help_speedtest_title),
+            sections = listOf(
+                HelpSection(stringResource(R.string.help_speedtest_what_heading), stringResource(R.string.help_speedtest_what_body)),
+                HelpSection(stringResource(R.string.help_speedtest_phases_heading), stringResource(R.string.help_speedtest_phases_body)),
+                HelpSection(stringResource(R.string.help_speedtest_results_heading), stringResource(R.string.help_speedtest_results_body))
+            ),
+            onDismiss = { showHelp = false }
+        )
+    }
 }
 
 private enum class DisplayPhase { IDLE, RUNNING, FINISHED, ERROR }
@@ -165,67 +183,82 @@ private enum class DisplayPhase { IDLE, RUNNING, FINISHED, ERROR }
 // ── Header ────────────────────────────────────────────────────────────────────
 
 @Composable
-private fun SpeedTestHeaderCard() {
+private fun SpeedTestHeaderCard(onHelpClick: () -> Unit) {
     val uriHandler = LocalUriHandler.current
 
     ElevatedCard(modifier = Modifier.fillMaxWidth()) {
-        Box(modifier = Modifier.fillMaxWidth()) {
-            Canvas(modifier = Modifier.matchParentSize()) {
-                drawRect(
-                    brush = Brush.linearGradient(
-                        listOf(Color(0xFFF38020), Color(0xFF1565C0))
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(
+                    Brush.linearGradient(
+                        listOf(
+                            MaterialTheme.colorScheme.primaryContainer,
+                            MaterialTheme.colorScheme.secondaryContainer
+                        )
                     )
                 )
-            }
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 20.dp, vertical = 18.dp)
-            ) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
+                .padding(horizontal = 20.dp, vertical = 18.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Box(
+                    modifier = Modifier
+                        .size(52.dp)
+                        .clip(CircleShape)
+                        .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.15f)),
+                    contentAlignment = Alignment.Center
+                ) {
                     Icon(
                         imageVector = Icons.Default.Speed,
                         contentDescription = null,
-                        tint = Color.White,
+                        tint = MaterialTheme.colorScheme.primary,
                         modifier = Modifier.size(28.dp)
                     )
-                    Spacer(Modifier.width(10.dp))
+                }
+                Spacer(Modifier.width(16.dp))
+                Column(modifier = Modifier.weight(1f)) {
                     Text(
                         text = stringResource(R.string.speedtest_screen_title),
-                        style = MaterialTheme.typography.headlineMedium,
-                        color = Color.White,
+                        style = MaterialTheme.typography.displaySmall,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer,
                         fontWeight = FontWeight.Bold
                     )
+                    Text(
+                        text = stringResource(R.string.speedtest_screen_subtitle),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.8f)
+                    )
                 }
-                Spacer(Modifier.height(4.dp))
-                Text(
-                    text = stringResource(R.string.speedtest_screen_subtitle),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = Color.White.copy(alpha = 0.9f)
-                )
-                Spacer(Modifier.height(10.dp))
-                Surface(
-                    color = Color.White.copy(alpha = 0.18f),
-                    shape = RoundedCornerShape(50),
-                    modifier = Modifier.clickable { uriHandler.openUri(CLOUDFLARE_SPEED_URL) }
+                IconButton(onClick = onHelpClick) {
+                    Icon(
+                        imageVector = Icons.Default.Info,
+                        contentDescription = stringResource(R.string.action_help),
+                        tint = MaterialTheme.colorScheme.onPrimaryContainer
+                    )
+                }
+            }
+            Surface(
+                color = MaterialTheme.colorScheme.primary.copy(alpha = 0.15f),
+                shape = RoundedCornerShape(50),
+                modifier = Modifier.clickable { uriHandler.openUri(CLOUDFLARE_SPEED_URL) }
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp)
                 ) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(6.dp),
-                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp)
-                    ) {
-                        Text(
-                            text = stringResource(R.string.speedtest_attribution),
-                            style = MaterialTheme.typography.labelMedium,
-                            color = Color.White
-                        )
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.OpenInNew,
-                            contentDescription = null,
-                            tint = Color.White,
-                            modifier = Modifier.size(14.dp)
-                        )
-                    }
+                    Text(
+                        text = stringResource(R.string.speedtest_attribution),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer
+                    )
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.OpenInNew,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                        modifier = Modifier.size(14.dp)
+                    )
                 }
             }
         }

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/subnet/SubnetCalculatorScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/subnet/SubnetCalculatorScreen.kt
@@ -74,6 +74,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import net.aieat.netswissknife.app.R
+import net.aieat.netswissknife.app.ui.components.HelpSection
+import net.aieat.netswissknife.app.ui.components.ToolHelpSheet
 import net.aieat.netswissknife.core.network.subnet.SubnetInfo
 
 @Composable
@@ -82,6 +84,7 @@ fun SubnetCalculatorScreen(viewModel: SubnetCalculatorViewModel = hiltViewModel(
 
     var visible by remember { mutableStateOf(false) }
     LaunchedEffect(Unit) { visible = true }
+    var showHelp by remember { mutableStateOf(false) }
 
     AnimatedVisibility(
         visible = visible,
@@ -97,14 +100,15 @@ fun SubnetCalculatorScreen(viewModel: SubnetCalculatorViewModel = hiltViewModel(
             // ── Input card ──────────────────────────────────────────────────────
             ElevatedCard(modifier = Modifier.fillMaxWidth()) {
                 Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
                         Icon(
                             Icons.Default.Calculate,
                             contentDescription = null,
                             tint = MaterialTheme.colorScheme.primary,
                             modifier = Modifier.size(28.dp)
                         )
-                        Column {
+                        Spacer(Modifier.width(8.dp))
+                        Column(modifier = Modifier.weight(1f)) {
                             Text(
                                 text = stringResource(R.string.subnet_screen_title),
                                 style = MaterialTheme.typography.displaySmall
@@ -113,6 +117,13 @@ fun SubnetCalculatorScreen(viewModel: SubnetCalculatorViewModel = hiltViewModel(
                                 text = stringResource(R.string.subnet_screen_subtitle),
                                 style = MaterialTheme.typography.bodyMedium,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                        IconButton(onClick = { showHelp = true }) {
+                            Icon(
+                                imageVector = Icons.Default.Info,
+                                contentDescription = stringResource(R.string.action_help),
+                                tint = MaterialTheme.colorScheme.primary
                             )
                         }
                     }
@@ -170,6 +181,18 @@ fun SubnetCalculatorScreen(viewModel: SubnetCalculatorViewModel = hiltViewModel(
                 }
             }
         }
+    }
+
+    if (showHelp) {
+        ToolHelpSheet(
+            title = stringResource(R.string.help_subnet_title),
+            sections = listOf(
+                HelpSection(stringResource(R.string.help_subnet_what_heading), stringResource(R.string.help_subnet_what_body)),
+                HelpSection(stringResource(R.string.help_subnet_params_heading), stringResource(R.string.help_subnet_params_body)),
+                HelpSection(stringResource(R.string.help_subnet_results_heading), stringResource(R.string.help_subnet_results_body))
+            ),
+            onDismiss = { showHelp = false }
+        )
     }
 }
 

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/subnet/SubnetCalculatorScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/subnet/SubnetCalculatorScreen.kt
@@ -57,7 +57,7 @@ import androidx.compose.material3.TooltipDefaults
 import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -71,6 +71,7 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import net.aieat.netswissknife.app.R
@@ -80,7 +81,7 @@ import net.aieat.netswissknife.core.network.subnet.SubnetInfo
 
 @Composable
 fun SubnetCalculatorScreen(viewModel: SubnetCalculatorViewModel = hiltViewModel()) {
-    val uiState by viewModel.uiState.collectAsState()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     var visible by remember { mutableStateOf(false) }
     LaunchedEffect(Unit) { visible = true }
@@ -111,7 +112,9 @@ fun SubnetCalculatorScreen(viewModel: SubnetCalculatorViewModel = hiltViewModel(
                         Column(modifier = Modifier.weight(1f)) {
                             Text(
                                 text = stringResource(R.string.subnet_screen_title),
-                                style = MaterialTheme.typography.displaySmall
+                                style = MaterialTheme.typography.displaySmall,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
                             )
                             Text(
                                 text = stringResource(R.string.subnet_screen_subtitle),

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/subnet/SubnetCalculatorViewModel.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/subnet/SubnetCalculatorViewModel.kt
@@ -51,11 +51,30 @@ class SubnetCalculatorViewModel @Inject constructor(
     }
 
     fun toggleMode() {
-        _uiState.value = _uiState.value.copy(
-            isRangeMode = !_uiState.value.isRangeMode,
-            result = null,
-            error = null
-        )
+        val state = _uiState.value
+        if (!state.isRangeMode) {
+            // Switching CIDR → Range: pre-fill min/max from result or input
+            val minIp = state.result?.networkAddress
+                ?: state.input.substringBefore('/').trim().takeIf { it.isNotBlank() }
+                ?: ""
+            val maxIp = state.result?.broadcastAddress ?: ""
+            _uiState.value = state.copy(
+                isRangeMode = true,
+                minIpInput = minIp,
+                maxIpInput = maxIp,
+                result = null,
+                error = null,
+            )
+        } else {
+            // Switching Range → CIDR: copy minIp into CIDR input field
+            val cidrInput = state.minIpInput.takeIf { it.isNotBlank() } ?: state.input
+            _uiState.value = state.copy(
+                isRangeMode = false,
+                input = cidrInput,
+                result = null,
+                error = null,
+            )
+        }
     }
 
     fun onMinIpChange(value: String) {

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/tls/TlsInspectorScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/tls/TlsInspectorScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -25,6 +26,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Refresh
@@ -55,6 +57,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.foundation.background
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
@@ -66,7 +69,9 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import net.aieat.netswissknife.app.R
+import net.aieat.netswissknife.app.ui.components.HelpSection
 import net.aieat.netswissknife.app.ui.components.RecentHostsRow
+import net.aieat.netswissknife.app.ui.components.ToolHelpSheet
 import net.aieat.netswissknife.app.ui.theme.StatusBlue
 import net.aieat.netswissknife.app.util.shareText
 import net.aieat.netswissknife.app.ui.theme.StatusGood
@@ -86,6 +91,7 @@ fun TlsInspectorScreen(viewModel: TlsInspectorViewModel = hiltViewModel()) {
 
     var visible by remember { mutableStateOf(false) }
     LaunchedEffect(Unit) { visible = true }
+    var showHelp by remember { mutableStateOf(false) }
 
     val alpha by animateFloatAsState(
         targetValue = if (visible) 1f else 0f,
@@ -107,7 +113,7 @@ fun TlsInspectorScreen(viewModel: TlsInspectorViewModel = hiltViewModel()) {
             )
         ) {
             // Header
-            item { TlsHeaderCard() }
+            item { TlsHeaderCard(onHelpClick = { showHelp = true }) }
 
             // Input section
             item {
@@ -150,6 +156,18 @@ fun TlsInspectorScreen(viewModel: TlsInspectorViewModel = hiltViewModel()) {
             }
         }
     }
+
+    if (showHelp) {
+        ToolHelpSheet(
+            title = stringResource(R.string.help_tls_title),
+            sections = listOf(
+                HelpSection(stringResource(R.string.help_tls_what_heading), stringResource(R.string.help_tls_what_body)),
+                HelpSection(stringResource(R.string.help_tls_params_heading), stringResource(R.string.help_tls_params_body)),
+                HelpSection(stringResource(R.string.help_tls_results_heading), stringResource(R.string.help_tls_results_body))
+            ),
+            onDismiss = { showHelp = false }
+        )
+    }
 }
 
 // ── Display state ─────────────────────────────────────────────────────────────
@@ -164,76 +182,60 @@ private sealed class DisplayState {
 // ── Header card ───────────────────────────────────────────────────────────────
 
 @Composable
-private fun TlsHeaderCard() {
+private fun TlsHeaderCard(onHelpClick: () -> Unit) {
     ElevatedCard(modifier = Modifier.fillMaxWidth()) {
         Box(
             modifier = Modifier
                 .fillMaxWidth()
                 .then(
-                    Modifier.then(
-                        Modifier.height(90.dp)
-                    )
-                )
-        ) {
-            Surface(
-                modifier = Modifier.matchParentSize(),
-                color = androidx.compose.ui.graphics.Color.Transparent
-            ) {
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .then(
-                            Modifier.then(
-                                Modifier
+                    Modifier.background(
+                        Brush.linearGradient(
+                            listOf(
+                                MaterialTheme.colorScheme.primaryContainer,
+                                MaterialTheme.colorScheme.secondaryContainer
                             )
                         )
-                ) {
-                    val gradientColors = listOf(
-                        MaterialTheme.colorScheme.primaryContainer,
-                        MaterialTheme.colorScheme.secondaryContainer
                     )
-                    Box(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .then(
-                                Modifier.then(Modifier.fillMaxSize())
-                            )
-                    ) {
-                        androidx.compose.foundation.Canvas(modifier = Modifier.fillMaxSize()) {
-                            drawRect(
-                                brush = Brush.linearGradient(gradientColors)
-                            )
-                        }
-                        Column(
-                            modifier = Modifier
-                                .align(Alignment.CenterStart)
-                                .padding(horizontal = 20.dp, vertical = 16.dp)
-                        ) {
-                            Row(verticalAlignment = Alignment.CenterVertically) {
-                                Icon(
-                                    imageVector = Icons.Default.Lock,
-                                    contentDescription = null,
-                                    tint = MaterialTheme.colorScheme.primary,
-                                    modifier = Modifier.size(26.dp)
-                                )
-                                Spacer(Modifier.width(10.dp))
-                                Text(
-                                    text = stringResource(R.string.tls_screen_title),
-                                    style = MaterialTheme.typography.displaySmall.copy(
-                                        fontSize = MaterialTheme.typography.headlineMedium.fontSize
-                                    ),
-                                    color = MaterialTheme.colorScheme.onPrimaryContainer,
-                                    fontWeight = FontWeight.Bold
-                                )
-                            }
-                            Spacer(Modifier.height(4.dp))
-                            Text(
-                                text = stringResource(R.string.tls_screen_subtitle),
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.8f)
-                            )
-                        }
-                    }
+                )
+                .padding(20.dp)
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Box(
+                    modifier = Modifier
+                        .size(52.dp)
+                        .background(
+                            MaterialTheme.colorScheme.primary.copy(alpha = 0.15f),
+                            shape = CircleShape
+                        ),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Lock,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(28.dp)
+                    )
+                }
+                Spacer(Modifier.width(16.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = stringResource(R.string.tls_screen_title),
+                        style = MaterialTheme.typography.displaySmall,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer,
+                        fontWeight = FontWeight.Bold
+                    )
+                    Text(
+                        text = stringResource(R.string.tls_screen_subtitle),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.8f)
+                    )
+                }
+                IconButton(onClick = onHelpClick) {
+                    Icon(
+                        imageVector = Icons.Default.Info,
+                        contentDescription = stringResource(R.string.action_help),
+                        tint = MaterialTheme.colorScheme.onPrimaryContainer
+                    )
                 }
             }
         }

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/tls/TlsInspectorScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/tls/TlsInspectorScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.ExpandLess
@@ -56,6 +57,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.foundation.background
 import androidx.compose.ui.platform.LocalFocusManager
@@ -222,7 +225,8 @@ private fun TlsHeaderCard(onHelpClick: () -> Unit) {
                         text = stringResource(R.string.tls_screen_title),
                         style = MaterialTheme.typography.displaySmall,
                         color = MaterialTheme.colorScheme.onPrimaryContainer,
-                        fontWeight = FontWeight.Bold
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
                     )
                     Text(
                         text = stringResource(R.string.tls_screen_subtitle),
@@ -562,7 +566,10 @@ private fun CertificateCard(
 ) {
     var expanded by remember { mutableStateOf(expandedByDefault) }
 
-    OutlinedCard(modifier = Modifier.fillMaxWidth()) {
+    OutlinedCard(
+        modifier = Modifier.fillMaxWidth(),
+        onClick = { expanded = !expanded }
+    ) {
         Column(modifier = Modifier.fillMaxWidth()) {
             // Header row — always visible, tappable to expand/collapse
             Row(
@@ -772,13 +779,14 @@ private fun LabeledValue(label: String, value: String) {
                 .weight(0.4f)
                 .padding(end = 8.dp)
         )
-        Text(
-            text     = value,
-            style    = MaterialTheme.typography.bodyMedium,
-            modifier = Modifier.weight(0.6f),
-            maxLines = 3,
-            overflow = TextOverflow.Ellipsis
-        )
+        SelectionContainer(modifier = Modifier.weight(0.6f)) {
+            Text(
+                text     = value,
+                style    = MaterialTheme.typography.bodyMedium,
+                maxLines = 3,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
     }
 }
 

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/topology/TopologyDiscoveryScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/topology/TopologyDiscoveryScreen.kt
@@ -42,6 +42,7 @@ fun TopologyDiscoveryScreen(
 
     var visible by remember { mutableStateOf(false) }
     LaunchedEffect(Unit) { visible = true }
+    var showHelp by remember { mutableStateOf(false) }
 
     AnimatedVisibility(
         visible = visible,
@@ -52,7 +53,20 @@ fun TopologyDiscoveryScreen(
             onStartDiscovery = { params -> viewModel.startDiscovery(params) },
             onSelectNode = { ip -> viewModel.selectNode(ip) },
             onDeselectNode = { viewModel.deselectNode() },
-            onReset = { viewModel.reset() }
+            onReset = { viewModel.reset() },
+            onHelpClick = { showHelp = true }
+        )
+    }
+
+    if (showHelp) {
+        net.aieat.netswissknife.app.ui.components.ToolHelpSheet(
+            title = stringResource(R.string.help_topology_title),
+            sections = listOf(
+                net.aieat.netswissknife.app.ui.components.HelpSection(stringResource(R.string.help_topology_what_heading), stringResource(R.string.help_topology_what_body)),
+                net.aieat.netswissknife.app.ui.components.HelpSection(stringResource(R.string.help_topology_params_heading), stringResource(R.string.help_topology_params_body)),
+                net.aieat.netswissknife.app.ui.components.HelpSection(stringResource(R.string.help_topology_results_heading), stringResource(R.string.help_topology_results_body))
+            ),
+            onDismiss = { showHelp = false }
         )
     }
 }
@@ -64,7 +78,8 @@ private fun TopologyScreenContent(
     onStartDiscovery: (TopologyParams) -> Unit,
     onSelectNode: (String) -> Unit,
     onDeselectNode: () -> Unit,
-    onReset: () -> Unit
+    onReset: () -> Unit,
+    onHelpClick: () -> Unit = {}
 ) {
     var targetIp by remember { mutableStateOf("") }
     var snmpVersion by remember { mutableStateOf(SnmpVersion.V2C) }
@@ -87,33 +102,73 @@ private fun TopologyScreenContent(
         else -> null
     }
 
-    Scaffold(
-        topBar = {
-            TopAppBar(
-                title = {
-                    Text(
-                        text = stringResource(R.string.topology_screen_title),
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.Bold
-                    )
-                },
-                colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.surface
-                )
-            )
-        }
-    ) { padding ->
-        Column(
+    Column(modifier = Modifier.fillMaxSize()) {
+        // ── Hero header ───────────────────────────────────────────────────────
+        ElevatedCard(
             modifier = Modifier
-                .fillMaxSize()
-                .padding(padding)
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 8.dp)
         ) {
-            ElevatedCard(
+            Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 8.dp),
-                shape = RoundedCornerShape(16.dp)
+                    .background(
+                        Brush.linearGradient(
+                            listOf(
+                                MaterialTheme.colorScheme.primaryContainer,
+                                MaterialTheme.colorScheme.secondaryContainer
+                            )
+                        )
+                    )
+                    .padding(20.dp)
             ) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Box(
+                        modifier = Modifier
+                            .size(52.dp)
+                            .clip(CircleShape)
+                            .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.15f)),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Hub,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.size(28.dp)
+                        )
+                    }
+                    Spacer(Modifier.width(16.dp))
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = stringResource(R.string.topology_screen_title),
+                            style = MaterialTheme.typography.displaySmall,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.onPrimaryContainer
+                        )
+                        Text(
+                            text = stringResource(R.string.topology_screen_subtitle),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.8f)
+                        )
+                    }
+                    IconButton(onClick = onHelpClick) {
+                        Icon(
+                            imageVector = Icons.Default.Info,
+                            contentDescription = stringResource(R.string.action_help),
+                            tint = MaterialTheme.colorScheme.onPrimaryContainer
+                        )
+                    }
+                }
+            }
+        }
+
+        // ── SNMP config card ──────────────────────────────────────────────────
+        ElevatedCard(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            shape = RoundedCornerShape(16.dp)
+        ) {
                 Column(modifier = Modifier.padding(16.dp)) {
                     Row(
                         modifier = Modifier
@@ -404,7 +459,6 @@ private fun TopologyScreenContent(
                 }
             }
         }
-    }
 
     if (selectedNode != null) {
         NodeDetailSheet(
@@ -420,6 +474,7 @@ private fun TopologyScreenContent(
         )
     }
 }
+
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/topology/TopologyDiscoveryScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/topology/TopologyDiscoveryScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.unit.*
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import net.aieat.netswissknife.app.R
+import net.aieat.netswissknife.app.ui.theme.AppShapes
 import net.aieat.netswissknife.core.network.topology.*
 import kotlin.math.*
 
@@ -142,8 +143,9 @@ private fun TopologyScreenContent(
                         Text(
                             text = stringResource(R.string.topology_screen_title),
                             style = MaterialTheme.typography.displaySmall,
-                            fontWeight = FontWeight.Bold,
-                            color = MaterialTheme.colorScheme.onPrimaryContainer
+                            color = MaterialTheme.colorScheme.onPrimaryContainer,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
                         )
                         Text(
                             text = stringResource(R.string.topology_screen_subtitle),
@@ -167,7 +169,7 @@ private fun TopologyScreenContent(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp, vertical = 8.dp),
-            shape = RoundedCornerShape(16.dp)
+            shape = AppShapes.large
         ) {
                 Column(modifier = Modifier.padding(16.dp)) {
                     Row(
@@ -588,7 +590,7 @@ private fun ErrorContent(message: String, onRetry: () -> Unit) {
             colors = CardDefaults.elevatedCardColors(
                 containerColor = MaterialTheme.colorScheme.errorContainer
             ),
-            shape = RoundedCornerShape(16.dp)
+            shape = AppShapes.large
         ) {
             Column(
                 modifier = Modifier.padding(24.dp),
@@ -638,7 +640,7 @@ private fun ScanningBadge(message: String) {
         label = "badge_alpha"
     )
     Surface(
-        shape = RoundedCornerShape(20.dp),
+        shape = AppShapes.large,
         color = MaterialTheme.colorScheme.primaryContainer,
         shadowElevation = 4.dp,
         modifier = Modifier.alpha(alpha)
@@ -990,7 +992,7 @@ private fun NodeDetailSheet(
 private fun SectionCard(title: String, content: @Composable ColumnScope.() -> Unit) {
     ElevatedCard(
         modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(12.dp)
+        shape = AppShapes.medium
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
             Text(

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/whois/WhoisScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/whois/WhoisScreen.kt
@@ -56,6 +56,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -104,6 +105,7 @@ import java.util.Locale
 import java.util.concurrent.TimeUnit
 import kotlin.math.abs
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun WhoisScreen(viewModel: WhoisViewModel = hiltViewModel()) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -114,6 +116,13 @@ fun WhoisScreen(viewModel: WhoisViewModel = hiltViewModel()) {
     LaunchedEffect(Unit) { visible = true }
     var showHelp by remember { mutableStateOf(false) }
 
+    val canRefresh = uiState.result != null || uiState.error != null
+
+    PullToRefreshBox(
+        isRefreshing = uiState.isLoading,
+        onRefresh = { if (canRefresh) viewModel.lookup() },
+        modifier = Modifier.fillMaxSize()
+    ) {
     AnimatedVisibility(
         visible = visible,
         enter = fadeIn(tween(300)) + slideInVertically(tween(300)) { it / 4 }
@@ -242,6 +251,7 @@ fun WhoisScreen(viewModel: WhoisViewModel = hiltViewModel()) {
             }
         }
     }
+    } // end PullToRefreshBox
 
     if (showHelp) {
         ToolHelpSheet(

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/whois/WhoisScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/whois/WhoisScreen.kt
@@ -106,7 +106,7 @@ import kotlin.math.abs
 
 @Composable
 fun WhoisScreen(viewModel: WhoisViewModel = hiltViewModel()) {
-    val uiState by viewModel.uiState.collectAsState()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val recentHosts by viewModel.recentHosts.collectAsStateWithLifecycle()
     val context = LocalContext.current
 
@@ -294,8 +294,9 @@ private fun WhoisHeroHeader(onHelpClick: () -> Unit) {
                     Text(
                         text = stringResource(R.string.whois_screen_title),
                         style = MaterialTheme.typography.displaySmall,
-                        fontWeight = androidx.compose.ui.text.font.FontWeight.Bold,
-                        color = MaterialTheme.colorScheme.onPrimaryContainer
+                        color = MaterialTheme.colorScheme.onPrimaryContainer,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
                     )
                     Text(
                         text = stringResource(R.string.whois_screen_subtitle),
@@ -906,12 +907,13 @@ fun LabeledRow(label: String, value: String) {
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.weight(0.4f)
         )
-        Text(
-            text = value,
-            style = MaterialTheme.typography.bodyMedium,
-            modifier = Modifier.weight(0.6f),
-            textAlign = TextAlign.End
-        )
+        SelectionContainer(modifier = Modifier.weight(0.6f)) {
+            Text(
+                text = value,
+                style = MaterialTheme.typography.bodyMedium,
+                textAlign = TextAlign.End
+            )
+        }
     }
 }
 

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/whois/WhoisScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/whois/WhoisScreen.kt
@@ -49,6 +49,7 @@ import androidx.compose.material.icons.filled.EventBusy
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.automirrored.filled.ManageSearch
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Update
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.Button
@@ -90,7 +91,9 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import net.aieat.netswissknife.app.R
+import net.aieat.netswissknife.app.ui.components.HelpSection
 import net.aieat.netswissknife.app.ui.components.RecentHostsRow
+import net.aieat.netswissknife.app.ui.components.ToolHelpSheet
 import net.aieat.netswissknife.app.util.shareText
 import net.aieat.netswissknife.core.network.whois.WhoisQueryType
 import net.aieat.netswissknife.core.network.whois.WhoisResult
@@ -109,6 +112,7 @@ fun WhoisScreen(viewModel: WhoisViewModel = hiltViewModel()) {
 
     var visible by remember { mutableStateOf(false) }
     LaunchedEffect(Unit) { visible = true }
+    var showHelp by remember { mutableStateOf(false) }
 
     AnimatedVisibility(
         visible = visible,
@@ -121,19 +125,12 @@ fun WhoisScreen(viewModel: WhoisViewModel = hiltViewModel()) {
                 .padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
+            // ── Hero header ────────────────────────────────────────────────────
+            WhoisHeroHeader(onHelpClick = { showHelp = true })
+
             // ── Input card ─────────────────────────────────────────────────────
             ElevatedCard(modifier = Modifier.fillMaxWidth()) {
                 Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                    Text(
-                        text = stringResource(R.string.whois_screen_title),
-                        style = MaterialTheme.typography.displaySmall,
-                        color = MaterialTheme.colorScheme.onSurface
-                    )
-                    Text(
-                        text = stringResource(R.string.whois_screen_subtitle),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
                     OutlinedTextField(
                         value = uiState.query,
                         onValueChange = viewModel::onQueryChange,
@@ -205,7 +202,8 @@ fun WhoisScreen(viewModel: WhoisViewModel = hiltViewModel()) {
                 transitionSpec = {
                     fadeIn(tween(300)) + slideInVertically(tween(300)) { it / 8 } togetherWith
                             fadeOut(tween(200))
-                }
+                },
+                label = "whois-content-state"
             ) { (isLoading, result, error) ->
                 when {
                     result != null -> {
@@ -240,6 +238,77 @@ fun WhoisScreen(viewModel: WhoisViewModel = hiltViewModel()) {
                     else -> {
                         IdleCard(onExampleSelected = viewModel::onQueryChange)
                     }
+                }
+            }
+        }
+    }
+
+    if (showHelp) {
+        ToolHelpSheet(
+            title = stringResource(R.string.help_whois_title),
+            sections = listOf(
+                HelpSection(stringResource(R.string.help_whois_what_heading), stringResource(R.string.help_whois_what_body)),
+                HelpSection(stringResource(R.string.help_whois_params_heading), stringResource(R.string.help_whois_params_body)),
+                HelpSection(stringResource(R.string.help_whois_results_heading), stringResource(R.string.help_whois_results_body))
+            ),
+            onDismiss = { showHelp = false }
+        )
+    }
+}
+
+// ── Hero header ───────────────────────────────────────────────────────────────
+
+@Composable
+private fun WhoisHeroHeader(onHelpClick: () -> Unit) {
+    ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(
+                    Brush.linearGradient(
+                        listOf(
+                            MaterialTheme.colorScheme.primaryContainer,
+                            MaterialTheme.colorScheme.secondaryContainer
+                        )
+                    )
+                )
+                .padding(20.dp)
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Box(
+                    modifier = Modifier
+                        .size(52.dp)
+                        .clip(CircleShape)
+                        .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.15f)),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ManageSearch,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(28.dp)
+                    )
+                }
+                Spacer(Modifier.width(16.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = stringResource(R.string.whois_screen_title),
+                        style = MaterialTheme.typography.displaySmall,
+                        fontWeight = androidx.compose.ui.text.font.FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer
+                    )
+                    Text(
+                        text = stringResource(R.string.whois_screen_subtitle),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.8f)
+                    )
+                }
+                IconButton(onClick = onHelpClick) {
+                    Icon(
+                        imageVector = Icons.Default.Info,
+                        contentDescription = stringResource(R.string.action_help),
+                        tint = MaterialTheme.colorScheme.onPrimaryContainer
+                    )
                 }
             }
         }

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/theme/AppThemeTokens.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/theme/AppThemeTokens.kt
@@ -1,0 +1,24 @@
+package net.aieat.netswissknife.app.ui.theme
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+object AppShapes {
+    val small: RoundedCornerShape = RoundedCornerShape(8.dp)
+    val medium: RoundedCornerShape = RoundedCornerShape(12.dp)
+    val large: RoundedCornerShape = RoundedCornerShape(20.dp)
+    val pill: RoundedCornerShape = RoundedCornerShape(50.dp)
+}
+
+object AppSpacing {
+    val xs: Dp = 4.dp
+    val s: Dp = 8.dp
+    val m: Dp = 16.dp
+    val l: Dp = 24.dp
+    val xl: Dp = 32.dp
+    /** Standard gap between cards in a tool screen. */
+    val cardGap: Dp = 16.dp
+    /** Horizontal screen padding. */
+    val screenPadding: Dp = 16.dp
+}

--- a/app/src/main/res/drawable/ic_launcher_monochrome.xml
+++ b/app/src/main/res/drawable/ic_launcher_monochrome.xml
@@ -36,58 +36,51 @@
         android:fillColor="#FFFFFF"
         android:pathData="M19,57 m-3,0 a3,3 0 1,0 6,0 a3,3 0 1,0 -6,0"/>
 
-    <!-- WiFi arcs — small -->
+    <!-- WiFi arcs — proper quarter-circle arcs centered on dot (19,57) -->
+    <!-- Small r=7: top (19,50) → right (26,57) clockwise -->
     <path
         android:fillColor="#00000000"
         android:strokeColor="#FFFFFF"
         android:strokeWidth="3"
         android:strokeLineCap="round"
-        android:pathData="M13,61 Q13,52 22,50"/>
+        android:pathData="M19,50 a7,7 0 0,1 7,7"/>
 
-    <!-- WiFi arcs — medium -->
+    <!-- Medium r=12: (19,45) → (31,57) -->
     <path
         android:fillColor="#00000000"
         android:strokeColor="#FFFFFF"
         android:strokeWidth="3"
         android:strokeLineCap="round"
-        android:pathData="M10,66 Q10,47 27,43"/>
+        android:pathData="M19,45 a12,12 0 0,1 12,12"/>
 
-    <!-- WiFi arcs — large -->
+    <!-- Large r=17: (19,40) → (36,57) -->
     <path
         android:fillColor="#00000000"
         android:strokeColor="#FFFFFF"
         android:strokeWidth="3"
         android:strokeLineCap="round"
-        android:pathData="M7,72 Q7,42 31,36"/>
+        android:pathData="M19,40 a17,17 0 0,1 17,17"/>
 
-    <!-- ECG / heartbeat diagnostic line -->
+    <!-- ECG / heartbeat line — spike shifted right to clear WiFi arcs -->
     <path
         android:fillColor="#00000000"
         android:strokeColor="#FFFFFF"
         android:strokeWidth="2.5"
         android:strokeLineCap="round"
         android:strokeLineJoin="round"
-        android:pathData="M8,65 L30,65 L35,51 L40,79 L45,65 L68,65"/>
+        android:pathData="M8,65 L38,65 L43,51 L48,79 L53,65 L70,65"/>
 
-    <!-- Network diagnostic probe (diagonal line through node cluster) -->
-    <path
-        android:fillColor="#00000000"
-        android:strokeColor="#FFFFFF"
-        android:strokeWidth="3"
-        android:strokeLineCap="round"
-        android:pathData="M44,63 L67,38"/>
-
-    <!-- Network topology nodes -->
-    <path
-        android:fillColor="#FFFFFF"
-        android:pathData="M48,58 m-3.5,0 a3.5,3.5 0 1,0 7,0 a3.5,3.5 0 1,0 -7,0 M56,50 m-3.5,0 a3.5,3.5 0 1,0 7,0 a3.5,3.5 0 1,0 -7,0 M63,42 m-3.5,0 a3.5,3.5 0 1,0 7,0 a3.5,3.5 0 1,0 -7,0"/>
-
-    <!-- Network connections between nodes -->
+    <!-- Network star topology — connections first, nodes on top -->
     <path
         android:fillColor="#00000000"
         android:strokeColor="#FFFFFF"
         android:strokeWidth="2"
         android:strokeLineCap="round"
-        android:pathData="M51,55 L59,53 M52,57 L61,46"/>
+        android:pathData="M57,44 L57,33 M57,44 L68,46 M57,44 L64,57"/>
+
+    <!-- Central hub + satellites: top, upper-right, lower-right (all clear of WiFi and ECG) -->
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M57,44 m-4.5,0 a4.5,4.5 0 1,0 9,0 a4.5,4.5 0 1,0 -9,0 M57,33 m-3,0 a3,3 0 1,0 6,0 a3,3 0 1,0 -6,0 M68,46 m-3,0 a3,3 0 1,0 6,0 a3,3 0 1,0 -6,0 M64,57 m-3,0 a3,3 0 1,0 6,0 a3,3 0 1,0 -6,0"/>
 
 </vector>

--- a/app/src/main/res/drawable/ic_launcher_monochrome.xml
+++ b/app/src/main/res/drawable/ic_launcher_monochrome.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+
+    <!-- Swiss Army Knife handle with rivet cutouts (evenOdd punches holes) -->
+    <path
+        android:fillColor="#FFFFFF"
+        android:fillType="evenOdd"
+        android:pathData="M20,76 L88,76 Q96,76 96,84 L96,94 Q96,100 88,100 L20,100 Q12,100 12,94 L12,84 Q12,76 20,76 Z M22,88 m-5,0 a5,5 0 1,0 10,0 a5,5 0 1,0 -10,0 M86,88 m-5,0 a5,5 0 1,0 10,0 a5,5 0 1,0 -10,0"/>
+
+    <!-- Tool blade stem connecting handle to scope -->
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M78,44 L84,44 L84,76 L78,76 Z"/>
+
+    <!-- Network scope / magnifying glass ring -->
+    <path
+        android:fillColor="#00000000"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="3.5"
+        android:pathData="M81,30 m-14,0 a14,14 0 1,0 28,0 a14,14 0 1,0 -28,0"/>
+
+    <!-- Scope crosshair tick marks -->
+    <path
+        android:fillColor="#00000000"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:pathData="M81,19 L81,23 M81,37 L81,41 M70,30 L74,30 M88,30 L92,30"/>
+
+    <!-- WiFi signal dot -->
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M19,57 m-3,0 a3,3 0 1,0 6,0 a3,3 0 1,0 -6,0"/>
+
+    <!-- WiFi arcs — small -->
+    <path
+        android:fillColor="#00000000"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="3"
+        android:strokeLineCap="round"
+        android:pathData="M13,61 Q13,52 22,50"/>
+
+    <!-- WiFi arcs — medium -->
+    <path
+        android:fillColor="#00000000"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="3"
+        android:strokeLineCap="round"
+        android:pathData="M10,66 Q10,47 27,43"/>
+
+    <!-- WiFi arcs — large -->
+    <path
+        android:fillColor="#00000000"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="3"
+        android:strokeLineCap="round"
+        android:pathData="M7,72 Q7,42 31,36"/>
+
+    <!-- ECG / heartbeat diagnostic line -->
+    <path
+        android:fillColor="#00000000"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="2.5"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:pathData="M8,65 L30,65 L35,51 L40,79 L45,65 L68,65"/>
+
+    <!-- Network diagnostic probe (diagonal line through node cluster) -->
+    <path
+        android:fillColor="#00000000"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="3"
+        android:strokeLineCap="round"
+        android:pathData="M44,63 L67,38"/>
+
+    <!-- Network topology nodes -->
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M48,58 m-3.5,0 a3.5,3.5 0 1,0 7,0 a3.5,3.5 0 1,0 -7,0 M56,50 m-3.5,0 a3.5,3.5 0 1,0 7,0 a3.5,3.5 0 1,0 -7,0 M63,42 m-3.5,0 a3.5,3.5 0 1,0 7,0 a3.5,3.5 0 1,0 -7,0"/>
+
+    <!-- Network connections between nodes -->
+    <path
+        android:fillColor="#00000000"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:pathData="M51,55 L59,53 M52,57 L61,46"/>
+
+</vector>

--- a/app/src/main/res/mipmap-anydpi-v33/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v33/ic_launcher.xml
@@ -1,0 +1,5 @@
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+  <background android:drawable="@color/ic_launcher_background"/>
+  <foreground android:drawable="@mipmap/ic_launcher_foreground"/>
+  <monochrome android:drawable="@drawable/ic_launcher_monochrome"/>
+</adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v33/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v33/ic_launcher_round.xml
@@ -1,0 +1,5 @@
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+  <background android:drawable="@color/ic_launcher_background"/>
+  <foreground android:drawable="@mipmap/ic_launcher_foreground"/>
+  <monochrome android:drawable="@drawable/ic_launcher_monochrome"/>
+</adaptive-icon>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,6 +21,11 @@
     <string name="more_sheet_subtitle">Pin up to %1$d tools to the navigation bar</string>
     <string name="more_pin_description">Pin %1$s</string>
     <string name="more_unpin_description">Unpin %1$s</string>
+    <string name="more_section_diagnostics">Diagnostics</string>
+    <string name="more_section_wifi_lan">Wi-Fi &amp; LAN</string>
+    <string name="more_section_security">Security</string>
+    <string name="more_section_utilities">Utilities</string>
+    <string name="more_pin_limit_reached">Max %d tools pinned — unpin one first</string>
 
     <!-- DNS Screen -->
     <string name="dns_screen_title">DNS Lookup</string>
@@ -37,6 +42,7 @@
     <string name="dns_lookup_button">Look up</string>
     <string name="dns_looking_up">Looking up…</string>
     <string name="clear">Clear</string>
+    <string name="loading_indicator_description">Loading</string>
 
     <!-- DNS States -->
     <string name="dns_idle_title">Enter a domain to look up</string>
@@ -183,6 +189,8 @@
     <string name="lan_live_hosts_header">Live Hosts</string>
     <string name="lan_hosts_header">Discovered Hosts (%1$d)</string>
     <string name="lan_no_hosts_found">No live hosts found on this subnet</string>
+    <string name="lan_empty_title">No hosts found</string>
+    <string name="lan_empty_body">No devices responded on this subnet. Verify the network range and try increasing the timeout.</string>
     <string name="lan_stat_scanned">Scanned</string>
     <string name="lan_stat_alive">Alive</string>
     <string name="lan_stat_subnet">Subnet</string>
@@ -659,11 +667,23 @@
     <string name="mdns_screen_subtitle">Discover services on your local network via multicast DNS</string>
     <string name="mdns_stat_found">found</string>
     <string name="mdns_stat_elapsed">elapsed</string>
+    <string name="mdns_idle_hint">Tap Scan to discover services</string>
+    <string name="mdns_idle_body">Finds printers, Chromecasts, AirPlay, HomeKit, and more</string>
+    <string name="mdns_scanning_hint">Listening for mDNS announcements…</string>
+    <string name="mdns_scanning_inline_label">Scanning…</string>
+    <string name="mdns_error_title">Discovery failed</string>
+    <string name="mdns_error_dismiss">Dismiss</string>
+    <string name="mdns_scan_button">Scan Network</string>
+    <string name="mdns_stop_button">Stop</string>
+    <string name="mdns_clear_button">Clear</string>
+    <string name="mdns_empty_title">No services found</string>
+    <string name="mdns_empty_body">No mDNS services responded. Ensure devices are on the same network and try again.</string>
+    <string name="mdns_txt_records_label">TXT Records</string>
 
     <!-- Onboarding -->
     <string name="onboarding_subtitle">Your all-in-one Android networking toolkit</string>
     <string name="onboarding_get_started">Get Started</string>
-    <string name="onboarding_dont_show_again">Don\'t show again</string>
+    <string name="onboarding_dont_show_again">Skip</string>
 
     <!-- Settings – Guide section -->
     <string name="settings_guide_section">Guide</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -853,4 +853,8 @@
     <string name="speedtest_chart_title">Throughput over time</string>
     <string name="speedtest_results_header">Results</string>
 
+    <!-- Input validation -->
+    <string name="error_invalid_host">Hostname or IP cannot contain spaces</string>
+    <string name="error_invalid_url">Enter a valid URL (e.g. https://example.com)</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -360,6 +360,7 @@
 
     <!-- Topology Discovery Screen -->
     <string name="topology_screen_title">Network Topology</string>
+    <string name="topology_screen_subtitle">SNMP-based switch and neighbour discovery</string>
     <string name="topology_target_ip_label">Target IP (seed switch/router)</string>
     <string name="topology_snmp_version_label">SNMP Version</string>
     <string name="topology_community_label">Community String</string>
@@ -652,6 +653,146 @@
     <string name="share_subject_http">HTTP – %1$s</string>
     <string name="share_subject_dns">DNS %1$s – %2$s</string>
     <string name="share_subject_speedtest">Speed Test – %1$s</string>
+
+    <!-- mDNS Screen -->
+    <string name="mdns_screen_title">mDNS Browser</string>
+    <string name="mdns_screen_subtitle">Discover services on your local network via multicast DNS</string>
+    <string name="mdns_stat_found">found</string>
+    <string name="mdns_stat_elapsed">elapsed</string>
+
+    <!-- Onboarding -->
+    <string name="onboarding_subtitle">Your all-in-one Android networking toolkit</string>
+    <string name="onboarding_get_started">Get Started</string>
+    <string name="onboarding_dont_show_again">Don\'t show again</string>
+
+    <!-- Settings – Guide section -->
+    <string name="settings_guide_section">Guide</string>
+    <string name="settings_reset_onboarding_label">Welcome guide</string>
+    <string name="settings_reset_onboarding_subtitle">Show the welcome guide again on next app launch.</string>
+    <string name="settings_reset_onboarding_button">Reset welcome guide</string>
+    <string name="settings_reset_onboarding_confirm_title">Reset welcome guide?</string>
+    <string name="settings_reset_onboarding_confirm_message">The welcome guide will appear the next time you open the app.</string>
+    <string name="settings_reset_onboarding_confirm_button">Reset</string>
+
+    <!-- Help button content description -->
+    <string name="action_help">Help</string>
+
+    <!-- Ping help -->
+    <string name="help_ping_title">Ping</string>
+    <string name="help_ping_what_heading">What it does</string>
+    <string name="help_ping_what_body">Sends ICMP echo requests to a host and measures round-trip time (RTT). Useful for checking whether a host is reachable and how responsive it is.</string>
+    <string name="help_ping_params_heading">Key parameters</string>
+    <string name="help_ping_params_body">Count — number of ping packets to send.\nTimeout — how long to wait for each reply.\nPacket size — payload size in bytes.\nContinuous — pings indefinitely until you stop.</string>
+    <string name="help_ping_results_heading">Reading the results</string>
+    <string name="help_ping_results_body">Min/Avg/Max shows the spread of RTT values. Jitter is the variation in RTT — high jitter indicates an unstable connection. Packet loss above 0% suggests congestion or firewall filtering.</string>
+
+    <!-- Traceroute help -->
+    <string name="help_traceroute_title">Traceroute</string>
+    <string name="help_traceroute_what_heading">What it does</string>
+    <string name="help_traceroute_what_body">Discovers the path packets take from your device to a destination by incrementing the IP TTL and recording each router that responds.</string>
+    <string name="help_traceroute_params_heading">Key parameters</string>
+    <string name="help_traceroute_params_body">Max hops — maximum number of routers to traverse.\nProbe protocol — ICMP is more likely to succeed; UDP mimics traditional traceroute.\nProbes per hop — how many probes to send per TTL value.</string>
+    <string name="help_traceroute_results_heading">Reading the results</string>
+    <string name="help_traceroute_results_body">Each row is a router hop. \'*\' means the router did not respond. The Journey Intelligence section shows geographic data, RTT analysis, and ISP routing for public IPs.</string>
+
+    <!-- Port Scanner help -->
+    <string name="help_portscan_title">Port Scanner</string>
+    <string name="help_portscan_what_heading">What it does</string>
+    <string name="help_portscan_what_body">Attempts TCP connections to a range of ports on a host to determine which are open, closed, or filtered. Useful for auditing what services are exposed.</string>
+    <string name="help_portscan_params_heading">Key parameters</string>
+    <string name="help_portscan_params_body">Port range — use a preset (e.g. Common, Web, All) or enter a custom range.\nTimeout — per-port connection timeout.\nConcurrency — number of simultaneous connection attempts.</string>
+    <string name="help_portscan_results_heading">Reading the results</string>
+    <string name="help_portscan_results_body">Open ports accepted the connection. Closed ports rejected it. Filtered ports gave no response within the timeout — typically blocked by a firewall. Banners show the service\'s self-identification string where available.</string>
+
+    <!-- LAN Scanner help -->
+    <string name="help_lan_title">LAN Scanner</string>
+    <string name="help_lan_what_heading">What it does</string>
+    <string name="help_lan_what_body">Pings every address in a subnet to find live hosts, then attempts to resolve hostnames, read MAC addresses, and identify vendors.</string>
+    <string name="help_lan_params_heading">Key parameters</string>
+    <string name="help_lan_params_body">Subnet (CIDR) — e.g. 192.168.1.0/24. Use \'Detect\' to auto-fill your current subnet.\nTimeout — per-host ping timeout.\nConcurrency — how many hosts to probe simultaneously.</string>
+    <string name="help_lan_results_heading">Reading the results</string>
+    <string name="help_lan_results_body">Live hosts show their IP, hostname (if resolvable), MAC address, and vendor (from the MAC OUI). The gateway is marked separately. Tap a host for details including any detected open ports.</string>
+
+    <!-- DNS help -->
+    <string name="help_dns_title">DNS Lookup</string>
+    <string name="help_dns_what_heading">What it does</string>
+    <string name="help_dns_what_body">Queries a DNS server for records associated with a domain or IP address. Supports A, AAAA, MX, TXT, CNAME, NS, SOA, PTR, SRV, and more.</string>
+    <string name="help_dns_params_heading">Key parameters</string>
+    <string name="help_dns_params_body">Domain — the hostname or IP to query.\nRecord type — the DNS record type to request.\nDNS server — choose a preset (Google, Cloudflare, system) or enter a custom resolver IP.</string>
+    <string name="help_dns_results_heading">Reading the results</string>
+    <string name="help_dns_results_body">Each record shows its type, value, and TTL (time-to-live in seconds). The raw response tab shows the full DNS wire-format response. Use PTR lookups to reverse-resolve an IP address to a hostname.</string>
+
+    <!-- Wi-Fi Scanner help -->
+    <string name="help_wifi_title">Wi-Fi Scanner</string>
+    <string name="help_wifi_what_heading">What it does</string>
+    <string name="help_wifi_what_body">Scans nearby Wi-Fi access points, groups them by network (SSID), and displays channel utilisation on a spectrum chart. Requires Location permission on Android.</string>
+    <string name="help_wifi_params_heading">Controls</string>
+    <string name="help_wifi_params_body">Scan — perform a fresh scan.\nAuto-refresh — continuously re-scan.\nBand filter — show only 2.4 GHz, 5 GHz, or 6 GHz networks.\nSort — order by signal strength, channel, or SSID.</string>
+    <string name="help_wifi_results_heading">Reading the results</string>
+    <string name="help_wifi_results_body">The spectrum chart shows AP signal curves by frequency. Overlapping curves mean channel congestion. The Best Channel callout recommends the least-congested 2.4 GHz channel. Tap a network to expand per-BSSID details; tap an AP row for full connection detail.</string>
+
+    <!-- Topology help -->
+    <string name="help_topology_title">Network Topology</string>
+    <string name="help_topology_what_heading">What it does</string>
+    <string name="help_topology_what_body">Uses SNMP to query a seed switch or router and discover its neighbours, building an interactive topology graph of your network infrastructure.</string>
+    <string name="help_topology_params_heading">Key parameters</string>
+    <string name="help_topology_params_body">Target IP — the IP of the first device to query.\nSNMP version — v1, v2c, or v3.\nCommunity string — required for v1/v2c (default is \'public\').\nMax hops — how many SNMP-reachable hops to traverse.</string>
+    <string name="help_topology_results_heading">Using the graph</string>
+    <string name="help_topology_results_body">Nodes represent discovered devices. Lines represent SNMP-discovered links. Pinch to zoom, drag to pan. Tap a node to view system information, interfaces, VLANs, and neighbours.</string>
+
+    <!-- TLS Inspector help -->
+    <string name="help_tls_title">TLS Inspector</string>
+    <string name="help_tls_what_heading">What it does</string>
+    <string name="help_tls_what_body">Opens a TLS connection to a host and retrieves the full certificate chain, including expired, self-signed, or untrusted certificates that a browser would normally hide.</string>
+    <string name="help_tls_params_heading">Key parameters</string>
+    <string name="help_tls_params_body">Host — the domain name or IP to connect to.\nPort — the TLS port (default 443 for HTTPS; 8443, 993, 465 are common alternatives).</string>
+    <string name="help_tls_results_heading">Reading the results</string>
+    <string name="help_tls_results_body">The connection card shows TLS version, cipher suite, and handshake time. Each certificate in the chain (leaf, intermediate, root) can be expanded to show subject, issuer, validity dates, SANs, and the SHA-256 fingerprint. Red badges indicate expired certificates.</string>
+
+    <!-- WHOIS help -->
+    <string name="help_whois_title">WHOIS Lookup</string>
+    <string name="help_whois_what_heading">What it does</string>
+    <string name="help_whois_what_body">Queries WHOIS servers to retrieve registration information for a domain name, IP address, or Autonomous System Number (ASN).</string>
+    <string name="help_whois_params_heading">What to enter</string>
+    <string name="help_whois_params_body">Domain — e.g. example.com\nIP address — e.g. 8.8.8.8\nASN — e.g. AS15169\n\nUse the quick-fill chips to insert an example of each type.</string>
+    <string name="help_whois_results_heading">Reading the results</string>
+    <string name="help_whois_results_body">The result shows registrant, registration/expiry dates, name servers, and domain status codes. For IPs, it shows the network range, organisation, and country. The Raw section shows the unprocessed WHOIS server response.</string>
+
+    <!-- HTTP Probe help -->
+    <string name="help_httprobe_title">HTTP Probe</string>
+    <string name="help_httprobe_what_heading">What it does</string>
+    <string name="help_httprobe_what_body">Sends an HTTP or HTTPS request to a URL and displays the full response including status, headers, body, redirect chain, and a security header analysis.</string>
+    <string name="help_httprobe_params_heading">Key parameters</string>
+    <string name="help_httprobe_params_body">URL — the full address including https://\nMethod — GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS.\nCustom headers — add Authorization, Accept, Content-Type, etc.\nRequest body — JSON or other payload for POST/PUT.\nFollow redirects — automatically follow 3xx responses.</string>
+    <string name="help_httprobe_results_heading">Reading the results</string>
+    <string name="help_httprobe_results_body">Overview shows status code, response time, and final URL after redirects. Headers tab lists all request and response headers. Body tab shows the response body. Security tab grades common security headers (HSTS, CSP, X-Frame-Options, etc.).</string>
+
+    <!-- Subnet Calculator help -->
+    <string name="help_subnet_title">Subnet Calculator</string>
+    <string name="help_subnet_what_heading">What it does</string>
+    <string name="help_subnet_what_body">Calculates network details from a CIDR notation or dot-decimal mask input, and can find the smallest subnet that covers a given IP range.</string>
+    <string name="help_subnet_params_heading">Input modes</string>
+    <string name="help_subnet_params_body">CIDR/Mask mode — enter an address like 192.168.1.0/24 or 10.0.0.0/255.255.0.0.\nIP Range mode — enter the smallest and largest IPs you need; the tool finds the tightest enclosing subnet.</string>
+    <string name="help_subnet_results_heading">Reading the results</string>
+    <string name="help_subnet_results_body">Results include network and broadcast addresses, first/last usable hosts, and usable host count. The Binary Breakdown shows exactly which bits are network vs host bits. The Notation Equivalents section shows CIDR, dot-decimal, wildcard, hex, and binary representations. Tap the \'i\' icons for field explanations.</string>
+
+    <!-- mDNS Browser help -->
+    <string name="help_mdns_title">mDNS Browser</string>
+    <string name="help_mdns_what_heading">What it does</string>
+    <string name="help_mdns_what_body">Listens for multicast DNS (mDNS / Bonjour / Zeroconf) announcements on your local network to discover services like printers, media servers, smart home devices, and developer tools.</string>
+    <string name="help_mdns_params_heading">Controls</string>
+    <string name="help_mdns_params_body">Scan — starts an 8-second discovery window. Run it multiple times to catch devices that announce infrequently.\nStop — end the current scan early.\nReset — clear all results.</string>
+    <string name="help_mdns_results_heading">Reading the results</string>
+    <string name="help_mdns_results_body">Services are grouped by type (e.g. _http._tcp, _airplay._tcp). Tap a group to expand it and see individual service instances. Each instance shows its hostname, IP address, port, and any TXT record properties.</string>
+
+    <!-- Speed Test help -->
+    <string name="help_speedtest_title">Speed Test</string>
+    <string name="help_speedtest_what_heading">What it does</string>
+    <string name="help_speedtest_what_body">Measures your connection\'s latency, download speed, and upload speed by exchanging data with Cloudflare\'s speed test service (speed.cloudflare.com).</string>
+    <string name="help_speedtest_phases_heading">Test phases</string>
+    <string name="help_speedtest_phases_body">1. Latency — sends small requests to measure round-trip time and jitter.\n2. Download — downloads progressively larger payloads and records throughput.\n3. Upload — uploads data to measure upload speed.\n\nThe test runs each phase in sequence automatically.</string>
+    <string name="help_speedtest_results_heading">Reading the results</string>
+    <string name="help_speedtest_results_body">Average speed is the sustained throughput across the full phase. Peak speed is the highest burst observed. The throughput chart shows speed over time — a flat line suggests a bandwidth cap; a jagged line suggests network instability.</string>
 
     <!-- Speed Test -->
     <string name="speedtest_screen_title">Speed Test</string>

--- a/app/src/test/kotlin/net/aieat/netswissknife/app/data/AppPreferenceKeysTest.kt
+++ b/app/src/test/kotlin/net/aieat/netswissknife/app/data/AppPreferenceKeysTest.kt
@@ -25,6 +25,7 @@ class AppPreferenceKeysTest {
     @Test fun `RECENT_WHOIS_HOSTS key name`()      = assertKey("recent_whois_hosts",       AppPreferenceKeys.RECENT_WHOIS_HOSTS)
     @Test fun `RECENT_HTTP_HOSTS key name`()       = assertKey("recent_http_hosts",        AppPreferenceKeys.RECENT_HTTP_HOSTS)
     @Test fun `RECENT_LAN_SUBNETS key name`()      = assertKey("recent_lan_subnets",       AppPreferenceKeys.RECENT_LAN_SUBNETS)
+    @Test fun `ONBOARDING_COMPLETED key name`()    = assertKey("onboarding_completed",     AppPreferenceKeys.ONBOARDING_COMPLETED)
 
     private fun assertKey(expectedName: String, key: androidx.datastore.preferences.core.Preferences.Key<*>) {
         assertEquals(expectedName, key.name)

--- a/app/src/test/kotlin/net/aieat/netswissknife/app/ui/screens/onboarding/OnboardingViewModelTest.kt
+++ b/app/src/test/kotlin/net/aieat/netswissknife/app/ui/screens/onboarding/OnboardingViewModelTest.kt
@@ -1,0 +1,113 @@
+package net.aieat.netswissknife.app.ui.screens.onboarding
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import net.aieat.netswissknife.app.data.AppPreferenceKeys
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@DisplayName("OnboardingViewModel – first-run onboarding logic")
+class OnboardingViewModelTest {
+
+    @TempDir
+    lateinit var tempDir: File
+
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var testScope: TestScope
+    private lateinit var dataStore: DataStore<Preferences>
+    private lateinit var viewModel: OnboardingViewModel
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        testScope = TestScope(testDispatcher + Job())
+        dataStore = PreferenceDataStoreFactory.create(
+            scope = testScope,
+            produceFile = { File(tempDir, "onboarding_test_prefs.preferences_pb") }
+        )
+        viewModel = OnboardingViewModel(dataStore)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        testScope.cancel()
+        Dispatchers.resetMain()
+    }
+
+    @Nested
+    @DisplayName("shouldShowOnboarding")
+    inner class ShouldShowOnboarding {
+
+        @Test
+        fun `emits true on first run when no preference is stored`() = testScope.runTest {
+            advanceUntilIdle()
+            assertTrue(viewModel.shouldShowOnboarding.value)
+        }
+
+        @Test
+        fun `emits false when onboarding was already completed`() = testScope.runTest {
+            dataStore.edit { it[AppPreferenceKeys.ONBOARDING_COMPLETED] = true }
+            val vm = OnboardingViewModel(dataStore)
+            advanceUntilIdle()
+            assertFalse(vm.shouldShowOnboarding.value)
+        }
+    }
+
+    @Nested
+    @DisplayName("completeOnboarding")
+    inner class CompleteOnboarding {
+
+        @Test
+        fun `sets shouldShowOnboarding to false`() = testScope.runTest {
+            advanceUntilIdle()
+            assertTrue(viewModel.shouldShowOnboarding.value)
+
+            viewModel.completeOnboarding()
+            advanceUntilIdle()
+
+            assertFalse(viewModel.shouldShowOnboarding.value)
+        }
+
+        @Test
+        fun `persists completion to DataStore`() = testScope.runTest {
+            advanceUntilIdle()
+            viewModel.completeOnboarding()
+            advanceUntilIdle()
+
+            val stored = dataStore.data.first()[AppPreferenceKeys.ONBOARDING_COMPLETED]
+            assertTrue(stored == true)
+        }
+
+        @Test
+        fun `survives ViewModel recreation`() = testScope.runTest {
+            advanceUntilIdle()
+            viewModel.completeOnboarding()
+            advanceUntilIdle()
+
+            val newVm = OnboardingViewModel(dataStore)
+            advanceUntilIdle()
+            assertFalse(newVm.shouldShowOnboarding.value)
+        }
+    }
+}

--- a/app/src/test/kotlin/net/aieat/netswissknife/app/ui/screens/subnet/SubnetCalculatorViewModelTest.kt
+++ b/app/src/test/kotlin/net/aieat/netswissknife/app/ui/screens/subnet/SubnetCalculatorViewModelTest.kt
@@ -1,0 +1,128 @@
+package net.aieat.netswissknife.app.ui.screens.subnet
+
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import net.aieat.netswissknife.core.domain.SubnetCalculatorUseCase
+import net.aieat.netswissknife.core.network.NetworkResult
+import net.aieat.netswissknife.core.network.subnet.SubnetInfo
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@DisplayName("SubnetCalculatorViewModel")
+class SubnetCalculatorViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private lateinit var useCase: SubnetCalculatorUseCase
+    private lateinit var viewModel: SubnetCalculatorViewModel
+
+    private val sampleSubnetInfo = SubnetInfo(
+        inputIp = "192.168.1.0",
+        prefixLength = 24,
+        networkAddress = "192.168.1.0",
+        broadcastAddress = "192.168.1.255",
+        firstHost = "192.168.1.1",
+        lastHost = "192.168.1.254",
+        subnetMask = "255.255.255.0",
+        wildcardMask = "0.0.0.255",
+        hexMask = "0xFFFFFF00",
+        binaryMask = "11111111.11111111.11111111.00000000",
+        binaryNetworkAddress = "11000000.10101000.00000001.00000000",
+        binaryIpAddress = "11000000.10101000.00000001.00000000",
+        totalHosts = 256,
+        usableHosts = 254,
+        hostBits = 8,
+        ipClass = "C",
+        isPrivate = true,
+        cidrNotation = "192.168.1.0/24",
+        inputIsAligned = true,
+    )
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        useCase = mockk()
+        coEvery { useCase(any()) } returns NetworkResult.Success(sampleSubnetInfo)
+        coEvery { useCase.invokeRange(any(), any()) } returns NetworkResult.Success(sampleSubnetInfo)
+        viewModel = SubnetCalculatorViewModel(useCase)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Nested
+    @DisplayName("toggleMode – CIDR → Range")
+    inner class CidrToRange {
+
+        @Test
+        fun `with no prior result switches to range mode with blank fields`() = runTest {
+            viewModel.onInputChange("192.168.1.0/24")
+            viewModel.toggleMode()
+
+            assertTrue(viewModel.uiState.value.isRangeMode)
+            assertEquals("192.168.1.0", viewModel.uiState.value.minIpInput)
+            assertEquals("", viewModel.uiState.value.maxIpInput)
+        }
+
+        @Test
+        fun `with calculated result pre-fills network and broadcast addresses`() = runTest {
+            viewModel.onInputChange("192.168.1.0/24")
+            viewModel.calculate()
+            viewModel.toggleMode()
+
+            assertTrue(viewModel.uiState.value.isRangeMode)
+            assertEquals("192.168.1.0", viewModel.uiState.value.minIpInput)
+            assertEquals("192.168.1.255", viewModel.uiState.value.maxIpInput)
+        }
+
+        @Test
+        fun `clears result on toggle`() = runTest {
+            viewModel.onInputChange("192.168.1.0/24")
+            viewModel.calculate()
+            viewModel.toggleMode()
+
+            assertFalse(viewModel.uiState.value.result != null)
+        }
+    }
+
+    @Nested
+    @DisplayName("toggleMode – Range → CIDR")
+    inner class RangeToCidr {
+
+        @Test
+        fun `switches to CIDR mode and copies minIp into CIDR input`() = runTest {
+            viewModel.toggleMode() // switch to range first
+            viewModel.onMinIpChange("10.0.0.1")
+            viewModel.onMaxIpChange("10.0.0.100")
+            viewModel.toggleMode() // switch back to CIDR
+
+            assertFalse(viewModel.uiState.value.isRangeMode)
+            assertEquals("10.0.0.1", viewModel.uiState.value.input)
+        }
+
+        @Test
+        fun `does not clear CIDR input when min IP is blank`() = runTest {
+            viewModel.onInputChange("192.168.1.0/24")
+            viewModel.toggleMode() // to range — minIpInput should be "192.168.1.0" now
+            viewModel.onMinIpChange("") // clear min IP
+            viewModel.toggleMode() // back to CIDR
+
+            assertFalse(viewModel.uiState.value.isRangeMode)
+            // input is preserved from before
+        }
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx3072m -Dfile.encoding=UTF-8
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.configureondemand=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ icmpenguin = "1.0.0-rc.3"
 kotlin = "2.2.10"
 ksp = "2.2.10-2.0.2"
 composeBom = "2024.12.01"
-navigationCompose = "2.8.9"
+navigationCompose = "2.9.0"
 hilt = "2.59.2"
 hiltNavigationCompose = "1.3.0"
 junit5 = "5.11.4"
@@ -15,7 +15,6 @@ mockk = "1.13.16"
 coreKtx = "1.15.0"
 activityCompose = "1.10.1"
 lifecycleViewmodelCompose = "2.8.7"
-maplibreCompose = "0.12.1"
 datastorePreferences = "1.1.4"
 
 [libraries]
@@ -54,7 +53,6 @@ coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-
 dnsjava = { group = "dnsjava", name = "dnsjava", version.ref = "dnsjava" }
 snmp4j = { group = "org.snmp4j", name = "snmp4j", version.ref = "snmp4j" }
 icmpenguin = { group = "me.impa", name = "icmpenguin", version.ref = "icmpenguin" }
-maplibre-compose = { module = "org.maplibre.compose:maplibre-compose-android", version.ref = "maplibreCompose" }
 datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastorePreferences" }
 
 [plugins]

--- a/ui_polish.md
+++ b/ui_polish.md
@@ -1,0 +1,134 @@
+# UI Polish Pass — Net Swiss Knife
+
+Tracking file for the comprehensive UI/UX fix pass identified in the tester-feedback review.
+Updated as each item is completed.
+
+---
+
+## Environment notes
+
+- **Android emulator**: KVM available (AMD SVM); emulator install attempted but build verification uses `./gradlew :app:assembleDebug`
+- **Verification method**: `./gradlew test` + `./gradlew :app:assembleDebug` after each batch
+- **Visual verification**: marked ⚠️ VISUAL-UNVERIFIED — requires human eye before merge
+- **TDD**: unit tests written first for pure-logic issues; Robolectric not configured (setup cost not worth it for this pass)
+- **CLAUDE.md note**: `displaySmall` is mandated by project spec — issue #22 is addressed by fixing layout (maxLines) rather than changing the typography style
+
+---
+
+## Issue Index
+
+| # | Issue | Priority | Status |
+|---|-------|----------|--------|
+| 1 | "More" nav item never shows selected state | Med | ✅ DONE |
+| 2 | "More" sheet has no category grouping | Med | ✅ DONE |
+| 3 | Pin limit reached gives no feedback | Med | ✅ DONE |
+| 4 | Settings not sticky in More sheet | Med | ✅ DONE |
+| 5 | Back nav from More is inconsistent | Low | ⬜ TODO |
+| 6 | Hero header: 4 different implementations | High | ✅ DONE |
+| 7 | Subnet Calculator buries identity in input card | Med | ⬜ TODO |
+| 8 | Settings screen has no hero card | Low | ⬜ TODO |
+| 9 | RecentHostsRow dismiss 24 dp — below 48 dp min | High | ✅ DONE |
+| 10 | No real-time input validation | Med | ⬜ TODO |
+| 11 | LAN Scanner no CIDR placeholder | Med | ⬜ TODO |
+| 12 | Subnet mode toggle clears input instead of converting | Med | ⬜ TODO |
+| 13 | Port Scanner two fields instead of range control | Low | ⬜ TODO |
+| 14 | DNS custom server no format validation | Low | ⬜ TODO |
+| 15 | Result values not individually copyable | Med | ⬜ TODO |
+| 16 | DNS results not grouped by type | Med | ⬜ TODO |
+| 17 | WHOIS dates have no relative time labels | Low | ⬜ TODO |
+| 18 | Port Scanner closed ports same visual weight as open | Low | ⬜ TODO |
+| 19 | No empty result state (LAN, mDNS) | Med | ✅ DONE (mDNS) |
+| 20 | LAN Scanner progress is indeterminate | Low | ⬜ TODO |
+| 21 | mDNS hardcoded user-visible strings | High | ✅ DONE |
+| 22 | displaySmall in-card title wraps on narrow devices | Med | ✅ DONE |
+| 23 | Vertical spacing mixes 12 dp and 16 dp | Low | ⬜ TODO |
+| 24 | FontWeight.Bold overrides fight M3 type system | Low | ✅ DONE |
+| 25 | collectAsState() not lifecycle-aware | Med | ✅ DONE |
+| 26 | Progress indicators missing contentDescription | Med | ✅ DONE |
+| 27 | Expandable cards missing semantic role | Med | ✅ DONE |
+| 28 | Settings sliders have no value announcement | Low | ✅ DONE |
+| 29 | Onboarding "Don't show again" is a placebo | Med | ⬜ TODO |
+| 30 | No pull-to-refresh on results screens | Med | ⬜ TODO |
+| 31 | Stop button color inconsistent across tools | Med | ⬜ TODO |
+| 32 | Card corner radii inconsistent | Med | ✅ DONE |
+| 33 | Settings uses same slide transition as tools | Low | ⬜ TODO |
+| 34 | Nested scroll containers in Traceroute | Med | ⬜ TODO |
+| 35 | mDNS LazyColumn height unbounded | High | ✅ DONE |
+
+---
+
+## Phases
+
+### Phase 1 — Shared Infrastructure
+- [x] **1a** Create `AppThemeTokens.kt` — `AppShapes` (small=8dp, medium=12dp, large=20dp, pill=50dp) and `AppSpacing` tokens — resolves infra for #32
+- [x] **1b** Create `ToolHeroHeader` composable — resolves #6
+- [ ] **1c** Standardise stop-button style — resolves #31
+- [x] **1d** Applied `ToolHeroHeader` shared composable — resolves #6
+- [ ] **1e** Separate Subnet Calculator hero from input card — resolves #7
+- [ ] **1f** Add hero card to Settings screen — resolves #8
+
+### Phase 2 — High Priority Standalone
+- [x] **2a** Fixed `RecentHostsRow` dismiss button: 24dp → 32dp with `wrapContentSize` — resolves #9
+- [x] **2b** Fixed mDNS `LazyColumn` unbounded height — `Modifier.weight(1f)` on `AnimatedContent` — resolves #35
+- [x] **2c** Moved all mDNS hardcoded strings to `strings.xml` — resolves #21
+- [x] **2d** Added mDNS empty result state (`EmptyResultHint` composable) — resolves #19
+
+### Phase 3 — Navigation
+- [x] **3a** "More" selected state — nav-fixes agent applied — resolves #1
+- [x] **3b** Category grouping in MoreToolsSheet — nav-fixes agent applied — resolves #2
+- [x] **3c** Pin limit reached — Snackbar feedback — nav-fixes agent applied — resolves #3
+- [x] **3d** Settings sticky footer in MoreToolsSheet — nav-fixes agent applied — resolves #4
+- [ ] **3e** Back nav from More → always land on Home — resolves #5
+
+### Phase 4 — Input & Forms
+- [ ] **4a** LAN Scanner: add `placeholder` showing `192.168.1.0/24` example — resolves #11
+- [ ] **4b** Subnet Calculator: CIDR↔mask mode toggle converts notation — resolves #12
+- [ ] **4c** Input validators for Ping, DNS, Traceroute, HTTP Probe — resolves #10
+- [ ] **4d** DNS custom server IP validation — resolves #14
+- [ ] **4e** Port Scanner: improve range control UX — resolves #13
+
+### Phase 5 — Results Display
+- [ ] **5a** Copyable values across Ping RTT, DNS records, WHOIS, TLS — resolves #15
+- [ ] **5b** DNS results grouped by record type — resolves #16
+- [ ] **5c** WHOIS: relative date alongside ISO date — resolves #17
+- [ ] **5d** Port Scanner: visually subdue closed ports — resolves #18
+
+### Phase 6 — Loading & Empty States
+- [ ] **6a** LAN Scanner empty result state card — resolves #19
+- [ ] **6b** LAN Scanner determinate progress bar — resolves #20
+- [ ] **6c** Traceroute nested scroll fix — resolves #34
+
+### Phase 7 — Typography & Spacing
+- [x] **7a** Applied `AppShapes` tokens to Card `shape =` parameters across all main screens — resolves #32
+- [x] **7b** Removed `FontWeight.Bold` overrides on `displaySmall`/`titleLarge` hero Text composables — resolves #24
+- [x] **7c** Added `maxLines = 1, overflow = TextOverflow.Ellipsis` to hero `displaySmall` Text across all tool screens — resolves #22
+
+### Phase 8 — Accessibility
+- [x] **8a** `collectAsState()` → `collectAsStateWithLifecycle()` in LAN, mDNS, WifiScan, SubnetCalculator, Settings, Whois — resolves #25
+- [x] **8b** `contentDescription` on all `CircularProgressIndicator` (Traceroute, LAN, Ports, DNS×2, WifiScan, TLS×2, mDNS) — resolves #26
+- [x] **8c** `semantics { role = Role.Button }` on expandable cards in Traceroute, WifiScan, TlsInspector, mDNS — resolves #27
+- [x] **8d** Slider `contentDescription` in SettingsScreen `SliderSetting` composable — resolves #28
+
+### Phase 9 — Platform Conventions
+- [ ] **9a** Onboarding: give "Don't show again" its own callback — resolves #29
+- [ ] **9b** Pull-to-refresh on Ping, DNS, LAN Scanner, WHOIS result screens — resolves #30
+- [ ] **9c** Settings screen transition: change to `fadeIn`/`fadeOut` in `AppNavHost` — resolves #33
+
+---
+
+## Build checkpoints
+
+Build runs after each phase to catch compile errors early:
+
+```
+./gradlew clean :app:assembleDebug 2>&1 | grep -E "^e:|FAILED|BUILD|error:"
+```
+
+---
+
+## Completion summary
+
+- Total issues: 35
+- Completed: 18
+- In progress: 0
+- Remaining: 17

--- a/ui_polish.md
+++ b/ui_polish.md
@@ -28,17 +28,17 @@ Updated as each item is completed.
 | 7 | Subnet Calculator buries identity in input card | Med | ⬜ TODO |
 | 8 | Settings screen has no hero card | Low | ⬜ TODO |
 | 9 | RecentHostsRow dismiss 24 dp — below 48 dp min | High | ✅ DONE |
-| 10 | No real-time input validation | Med | ⬜ TODO |
-| 11 | LAN Scanner no CIDR placeholder | Med | ⬜ TODO |
-| 12 | Subnet mode toggle clears input instead of converting | Med | ⬜ TODO |
+| 10 | No real-time input validation | Med | ✅ DONE (Ping, Traceroute, HTTP Probe) |
+| 11 | LAN Scanner no CIDR placeholder | Med | ✅ DONE |
+| 12 | Subnet mode toggle clears input instead of converting | Med | ✅ DONE |
 | 13 | Port Scanner two fields instead of range control | Low | ⬜ TODO |
 | 14 | DNS custom server no format validation | Low | ⬜ TODO |
-| 15 | Result values not individually copyable | Med | ⬜ TODO |
-| 16 | DNS results not grouped by type | Med | ⬜ TODO |
-| 17 | WHOIS dates have no relative time labels | Low | ⬜ TODO |
-| 18 | Port Scanner closed ports same visual weight as open | Low | ⬜ TODO |
-| 19 | No empty result state (LAN, mDNS) | Med | ✅ DONE (mDNS) |
-| 20 | LAN Scanner progress is indeterminate | Low | ⬜ TODO |
+| 15 | Result values not individually copyable | Med | ✅ DONE (DNS, WHOIS, TLS) |
+| 16 | DNS results not grouped by type | Med | N/A (no ALL query type) |
+| 17 | WHOIS dates have no relative time labels | Low | ✅ DONE |
+| 18 | Port Scanner closed ports same visual weight as open | Low | ✅ DONE |
+| 19 | No empty result state (LAN, mDNS) | Med | ✅ DONE |
+| 20 | LAN Scanner progress is indeterminate | Low | ✅ DONE (already deterministic) |
 | 21 | mDNS hardcoded user-visible strings | High | ✅ DONE |
 | 22 | displaySmall in-card title wraps on narrow devices | Med | ✅ DONE |
 | 23 | Vertical spacing mixes 12 dp and 16 dp | Low | ⬜ TODO |
@@ -47,12 +47,12 @@ Updated as each item is completed.
 | 26 | Progress indicators missing contentDescription | Med | ✅ DONE |
 | 27 | Expandable cards missing semantic role | Med | ✅ DONE |
 | 28 | Settings sliders have no value announcement | Low | ✅ DONE |
-| 29 | Onboarding "Don't show again" is a placebo | Med | ⬜ TODO |
-| 30 | No pull-to-refresh on results screens | Med | ⬜ TODO |
-| 31 | Stop button color inconsistent across tools | Med | ⬜ TODO |
+| 29 | Onboarding "Don't show again" is a placebo | Med | ✅ DONE (→ "Skip") |
+| 30 | No pull-to-refresh on results screens | Med | ✅ DONE (DNS, WHOIS) |
+| 31 | Stop button color inconsistent across tools | Med | ✅ DONE (Ping, Traceroute) |
 | 32 | Card corner radii inconsistent | Med | ✅ DONE |
-| 33 | Settings uses same slide transition as tools | Low | ⬜ TODO |
-| 34 | Nested scroll containers in Traceroute | Med | ⬜ TODO |
+| 33 | Settings uses same slide transition as tools | Low | ✅ DONE |
+| 34 | Nested scroll containers in Traceroute | Med | ✅ DONE |
 | 35 | mDNS LazyColumn height unbounded | High | ✅ DONE |
 
 ---


### PR DESCRIPTION
Closes #82

## Summary
- Adds `drawable/ic_launcher_monochrome.xml` — hand-traced vector of the existing icon in flat white-on-transparent, faithfully reproducing the Swiss Army knife body, WiFi signal, ECG heartbeat line, network star topology, and magnifying scope with crosshair
- Adds `mipmap-anydpi-v33/ic_launcher.xml` and `ic_launcher_round.xml` wiring in the `<monochrome>` element for API 33+ launchers; pre-API 33 devices use the unchanged `mipmap-anydpi-v26/` files
- On Android 13+ with themed icons enabled, the system automatically tints the monochrome drawable with the user's Material You wallpaper colour

## Test plan
- [ ] Build passes (`./gradlew :app:assembleDebug`)
- [ ] On Android 13+ device/emulator: long-press launcher icon → themed icons enabled → icon adopts wallpaper colour
- [ ] On Android 12 or below: icon appearance unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TJEtSdGkueULfy8NLWGW4