### PR TITLE
fix: scale monochrome icon to safe zone (prevents zoomed-in on device)

### DIFF
--- a/app/src/main/res/drawable/ic_launcher_monochrome.xml
+++ b/app/src/main/res/drawable/ic_launcher_monochrome.xml
@@ -5,82 +5,94 @@
     android:viewportWidth="108"
     android:viewportHeight="108">
 
-    <!-- Swiss Army Knife handle with rivet cutouts (evenOdd punches holes) -->
-    <path
-        android:fillColor="#FFFFFF"
-        android:fillType="evenOdd"
-        android:pathData="M20,76 L88,76 Q96,76 96,84 L96,94 Q96,100 88,100 L20,100 Q12,100 12,94 L12,84 Q12,76 20,76 Z M22,88 m-5,0 a5,5 0 1,0 10,0 a5,5 0 1,0 -10,0 M86,88 m-5,0 a5,5 0 1,0 10,0 a5,5 0 1,0 -10,0"/>
+    <!--
+        Content is wrapped in a group scaled to 0.7× and centered.
+        This fits all artwork within the adaptive icon safe zone (21–87dp),
+        preventing the "zoomed in" appearance on themed icon launchers.
+        Without this, content spanning the full 108dp canvas is clipped by
+        the adaptive icon mask and appears oversized.
+    -->
+    <group
+        android:translateX="18"
+        android:translateY="13"
+        android:scaleX="0.7"
+        android:scaleY="0.7">
 
-    <!-- Tool blade stem connecting handle to scope -->
-    <path
-        android:fillColor="#FFFFFF"
-        android:pathData="M78,44 L84,44 L84,76 L78,76 Z"/>
+        <!-- Swiss Army Knife handle with rivet cutouts (evenOdd punches holes) -->
+        <path
+            android:fillColor="#FFFFFF"
+            android:fillType="evenOdd"
+            android:pathData="M20,76 L88,76 Q96,76 96,84 L96,94 Q96,100 88,100 L20,100 Q12,100 12,94 L12,84 Q12,76 20,76 Z M22,88 m-5,0 a5,5 0 1,0 10,0 a5,5 0 1,0 -10,0 M86,88 m-5,0 a5,5 0 1,0 10,0 a5,5 0 1,0 -10,0"/>
 
-    <!-- Network scope / magnifying glass ring -->
-    <path
-        android:fillColor="#00000000"
-        android:strokeColor="#FFFFFF"
-        android:strokeWidth="3.5"
-        android:pathData="M81,30 m-14,0 a14,14 0 1,0 28,0 a14,14 0 1,0 -28,0"/>
+        <!-- Tool blade stem connecting handle to scope -->
+        <path
+            android:fillColor="#FFFFFF"
+            android:pathData="M78,44 L84,44 L84,76 L78,76 Z"/>
 
-    <!-- Scope crosshair tick marks -->
-    <path
-        android:fillColor="#00000000"
-        android:strokeColor="#FFFFFF"
-        android:strokeWidth="2"
-        android:strokeLineCap="round"
-        android:pathData="M81,19 L81,23 M81,37 L81,41 M70,30 L74,30 M88,30 L92,30"/>
+        <!-- Network scope / magnifying glass ring -->
+        <path
+            android:fillColor="#00000000"
+            android:strokeColor="#FFFFFF"
+            android:strokeWidth="3.5"
+            android:pathData="M81,30 m-14,0 a14,14 0 1,0 28,0 a14,14 0 1,0 -28,0"/>
 
-    <!-- WiFi signal dot -->
-    <path
-        android:fillColor="#FFFFFF"
-        android:pathData="M19,57 m-3,0 a3,3 0 1,0 6,0 a3,3 0 1,0 -6,0"/>
+        <!-- Scope crosshair tick marks -->
+        <path
+            android:fillColor="#00000000"
+            android:strokeColor="#FFFFFF"
+            android:strokeWidth="2"
+            android:strokeLineCap="round"
+            android:pathData="M81,19 L81,23 M81,37 L81,41 M70,30 L74,30 M88,30 L92,30"/>
 
-    <!-- WiFi arcs — proper quarter-circle arcs centered on dot (19,57) -->
-    <!-- Small r=7: top (19,50) → right (26,57) clockwise -->
-    <path
-        android:fillColor="#00000000"
-        android:strokeColor="#FFFFFF"
-        android:strokeWidth="3"
-        android:strokeLineCap="round"
-        android:pathData="M19,50 a7,7 0 0,1 7,7"/>
+        <!-- WiFi signal dot -->
+        <path
+            android:fillColor="#FFFFFF"
+            android:pathData="M19,57 m-3,0 a3,3 0 1,0 6,0 a3,3 0 1,0 -6,0"/>
 
-    <!-- Medium r=12: (19,45) → (31,57) -->
-    <path
-        android:fillColor="#00000000"
-        android:strokeColor="#FFFFFF"
-        android:strokeWidth="3"
-        android:strokeLineCap="round"
-        android:pathData="M19,45 a12,12 0 0,1 12,12"/>
+        <!-- WiFi arcs — concentric quarter-circles centered on dot (19,57) -->
+        <path
+            android:fillColor="#00000000"
+            android:strokeColor="#FFFFFF"
+            android:strokeWidth="3"
+            android:strokeLineCap="round"
+            android:pathData="M19,50 a7,7 0 0,1 7,7"/>
 
-    <!-- Large r=17: (19,40) → (36,57) -->
-    <path
-        android:fillColor="#00000000"
-        android:strokeColor="#FFFFFF"
-        android:strokeWidth="3"
-        android:strokeLineCap="round"
-        android:pathData="M19,40 a17,17 0 0,1 17,17"/>
+        <path
+            android:fillColor="#00000000"
+            android:strokeColor="#FFFFFF"
+            android:strokeWidth="3"
+            android:strokeLineCap="round"
+            android:pathData="M19,45 a12,12 0 0,1 12,12"/>
 
-    <!-- ECG / heartbeat line — spike shifted right to clear WiFi arcs -->
-    <path
-        android:fillColor="#00000000"
-        android:strokeColor="#FFFFFF"
-        android:strokeWidth="2.5"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M8,65 L38,65 L43,51 L48,79 L53,65 L70,65"/>
+        <path
+            android:fillColor="#00000000"
+            android:strokeColor="#FFFFFF"
+            android:strokeWidth="3"
+            android:strokeLineCap="round"
+            android:pathData="M19,40 a17,17 0 0,1 17,17"/>
 
-    <!-- Network star topology — connections first, nodes on top -->
-    <path
-        android:fillColor="#00000000"
-        android:strokeColor="#FFFFFF"
-        android:strokeWidth="2"
-        android:strokeLineCap="round"
-        android:pathData="M57,44 L57,33 M57,44 L68,46 M57,44 L64,57"/>
+        <!-- ECG / heartbeat line -->
+        <path
+            android:fillColor="#00000000"
+            android:strokeColor="#FFFFFF"
+            android:strokeWidth="2.5"
+            android:strokeLineCap="round"
+            android:strokeLineJoin="round"
+            android:pathData="M8,65 L38,65 L43,51 L48,79 L53,65 L70,65"/>
 
-    <!-- Central hub + satellites: top, upper-right, lower-right (all clear of WiFi and ECG) -->
-    <path
-        android:fillColor="#FFFFFF"
-        android:pathData="M57,44 m-4.5,0 a4.5,4.5 0 1,0 9,0 a4.5,4.5 0 1,0 -9,0 M57,33 m-3,0 a3,3 0 1,0 6,0 a3,3 0 1,0 -6,0 M68,46 m-3,0 a3,3 0 1,0 6,0 a3,3 0 1,0 -6,0 M64,57 m-3,0 a3,3 0 1,0 6,0 a3,3 0 1,0 -6,0"/>
+        <!-- Network star topology — connections first, nodes on top -->
+        <path
+            android:fillColor="#00000000"
+            android:strokeColor="#FFFFFF"
+            android:strokeWidth="2"
+            android:strokeLineCap="round"
+            android:pathData="M57,44 L57,33 M57,44 L68,46 M57,44 L64,57"/>
+
+        <!-- Central hub + satellites: top, upper-right, lower-right -->
+        <path
+            android:fillColor="#FFFFFF"
+            android:pathData="M57,44 m-4.5,0 a4.5,4.5 0 1,0 9,0 a4.5,4.5 0 1,0 -9,0 M57,33 m-3,0 a3,3 0 1,0 6,0 a3,3 0 1,0 -6,0 M68,46 m-3,0 a3,3 0 1,0 6,0 a3,3 0 1,0 -6,0 M64,57 m-3,0 a3,3 0 1,0 6,0 a3,3 0 1,0 -6,0"/>
+
+    </group>
 
 </vector>


### PR DESCRIPTION
Fixes #82

## Summary
- Wraps all monochrome vector paths in a `<group scaleX="0.7" scaleY="0.7" translateX="18" translateY="13">` so artwork sits within the 66dp adaptive icon safe zone rather than filling the full 108dp canvas
- Without this, the adaptive icon mask clips content near the edges and the icon renders oversized on themed launchers on device

## Test plan
- [ ] Build passes
- [ ] On Android 13+ with themed icons: monochrome icon is correctly proportioned (not zoomed in)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TJEtSdGkueULfy8NLWGW4