### PR TITLE
fix: pull-to-refresh for WiFi/LAN/mDNS screens; fix bottom spacing

### DIFF
--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/WifiScanScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/WifiScanScreen.kt
@@ -76,6 +76,7 @@ import androidx.compose.material3.Badge
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.ui.graphics.nativeCanvas
@@ -132,6 +133,7 @@ private fun networkColor(colorIndex: Int): Color =
 
 // ── Screen root ───────────────────────────────────────────────────────────────
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun WifiScanScreen(
     viewModel: WifiScanViewModel = hiltViewModel()
@@ -172,36 +174,45 @@ fun WifiScanScreen(
         label = "screen-alpha"
     )
 
-    AnimatedContent(
-        targetState = uiState,
-        transitionSpec = { fadeIn() togetherWith fadeOut() },
-        contentKey = { it::class },
-        modifier = Modifier.fillMaxSize().alpha(screenAlpha),
-        label = "wifi_state"
-    ) { state ->
-        when (state) {
-            is WifiScanUiState.Idle         -> WifiIdleScreen()
-            is WifiScanUiState.NoPermission -> WifiNoPermissionScreen(
-                onRequest = { permissionLauncher.launch(requiredPermissions) }
-            )
-            is WifiScanUiState.NotSupported -> WifiNotSupportedScreen()
-            is WifiScanUiState.WifiDisabled -> WifiDisabledScreen(onRetry = { viewModel.startScan() })
-            is WifiScanUiState.Scanning     -> WifiScanningScreen()
-            is WifiScanUiState.Success      -> WifiSuccessScreen(
-                state               = state,
-                autoRefresh         = autoRefresh,
-                expandedNetworks    = expandedNetworks,
-                onScan              = { viewModel.startScan() },
-                onToggleAutoRefresh = { viewModel.toggleAutoRefresh() },
-                onBandFilter        = { viewModel.setBandFilter(it) },
-                onSortOrder         = { viewModel.setSortOrder(it) },
-                onSelectAp          = { viewModel.selectAccessPoint(it) },
-                onToggleNetworkExpanded = { viewModel.toggleNetworkExpanded(it) }
-            )
-            is WifiScanUiState.Error        -> WifiErrorScreen(
-                message = state.message,
-                onRetry = { viewModel.onRetry(); permissionLauncher.launch(requiredPermissions) }
-            )
+    val isRefreshing = uiState is WifiScanUiState.Scanning
+    val canRefresh = uiState is WifiScanUiState.Success || uiState is WifiScanUiState.Error
+
+    PullToRefreshBox(
+        isRefreshing = isRefreshing,
+        onRefresh = { if (canRefresh) viewModel.startScan() },
+        modifier = Modifier.fillMaxSize().alpha(screenAlpha)
+    ) {
+        AnimatedContent(
+            targetState = uiState,
+            transitionSpec = { fadeIn() togetherWith fadeOut() },
+            contentKey = { it::class },
+            modifier = Modifier.fillMaxSize(),
+            label = "wifi_state"
+        ) { state ->
+            when (state) {
+                is WifiScanUiState.Idle         -> WifiIdleScreen()
+                is WifiScanUiState.NoPermission -> WifiNoPermissionScreen(
+                    onRequest = { permissionLauncher.launch(requiredPermissions) }
+                )
+                is WifiScanUiState.NotSupported -> WifiNotSupportedScreen()
+                is WifiScanUiState.WifiDisabled -> WifiDisabledScreen(onRetry = { viewModel.startScan() })
+                is WifiScanUiState.Scanning     -> WifiScanningScreen()
+                is WifiScanUiState.Success      -> WifiSuccessScreen(
+                    state               = state,
+                    autoRefresh         = autoRefresh,
+                    expandedNetworks    = expandedNetworks,
+                    onScan              = { viewModel.startScan() },
+                    onToggleAutoRefresh = { viewModel.toggleAutoRefresh() },
+                    onBandFilter        = { viewModel.setBandFilter(it) },
+                    onSortOrder         = { viewModel.setSortOrder(it) },
+                    onSelectAp          = { viewModel.selectAccessPoint(it) },
+                    onToggleNetworkExpanded = { viewModel.toggleNetworkExpanded(it) }
+                )
+                is WifiScanUiState.Error        -> WifiErrorScreen(
+                    message = state.message,
+                    onRetry = { viewModel.onRetry(); permissionLauncher.launch(requiredPermissions) }
+                )
+            }
         }
     }
 }

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/lan/LanScanScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/lan/LanScanScreen.kt
@@ -79,7 +79,9 @@ import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 // collectAsState replaced by collectAsStateWithLifecycle below
@@ -115,6 +117,7 @@ import net.aieat.netswissknife.core.network.lan.LanScanSummary
 
 // ── Entry point ───────────────────────────────────────────────────────────────
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun LanScreen(viewModel: LanScanViewModel = hiltViewModel()) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -129,6 +132,14 @@ fun LanScreen(viewModel: LanScanViewModel = hiltViewModel()) {
     LaunchedEffect(Unit) { visible = true }
     var showHelp by remember { mutableStateOf(false) }
 
+    val isRefreshing = uiState is LanScanUiState.Scanning
+    val canRefresh = uiState is LanScanUiState.Finished || uiState is LanScanUiState.Error
+
+    PullToRefreshBox(
+        isRefreshing = isRefreshing,
+        onRefresh = { if (canRefresh) viewModel.startScan() },
+        modifier = Modifier.fillMaxSize()
+    ) {
     AnimatedVisibility(
         visible = visible,
         enter = fadeIn(tween(400)) + slideInVertically(tween(400)) { it / 6 },
@@ -189,6 +200,7 @@ fun LanScreen(viewModel: LanScanViewModel = hiltViewModel()) {
             }
         }
     }
+    } // end PullToRefreshBox
 
     if (showHelp) {
         ToolHelpSheet(

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/mdns/MdnsDiscoveryScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/mdns/MdnsDiscoveryScreen.kt
@@ -75,7 +75,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.material.icons.filled.Info
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
@@ -90,6 +92,7 @@ import net.aieat.netswissknife.app.ui.components.HelpSection
 import net.aieat.netswissknife.app.ui.components.ToolHelpSheet
 import net.aieat.netswissknife.core.network.mdns.DiscoveredService
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MdnsDiscoveryScreen(viewModel: MdnsDiscoveryViewModel = hiltViewModel()) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -98,6 +101,11 @@ fun MdnsDiscoveryScreen(viewModel: MdnsDiscoveryViewModel = hiltViewModel()) {
     LaunchedEffect(Unit) { visible = true }
     var showHelp by remember { mutableStateOf(false) }
 
+    PullToRefreshBox(
+        isRefreshing = uiState.isScanning,
+        onRefresh = { viewModel.startScan(8_000L) },
+        modifier = Modifier.fillMaxSize()
+    ) {
     AnimatedVisibility(
         visible = visible,
         enter = fadeIn(tween(400)) + slideInVertically(tween(400)) { 40 }
@@ -145,6 +153,7 @@ fun MdnsDiscoveryScreen(viewModel: MdnsDiscoveryViewModel = hiltViewModel()) {
             }
         }
     }
+    } // end PullToRefreshBox
 
     if (showHelp) {
         ToolHelpSheet(
@@ -459,7 +468,7 @@ private fun ServiceList(
             }
         }
 
-        item { Spacer(Modifier.height(80.dp)) }
+        item { Spacer(Modifier.height(16.dp)) }
     }
 }
 


### PR DESCRIPTION
## Summary

- **Pull-to-refresh on WiFi Scanner**: wrapped `AnimatedContent` with `PullToRefreshBox` — swipe down triggers a new scan, spinner shows while `Scanning` state is active; only activates in Success/Error states so it doesn't interfere with permission/disabled flows
- **Pull-to-refresh on LAN Scanner**: wraps the entire screen with `PullToRefreshBox`, triggers `startScan()` with current VM parameters; guard ensures it only fires in Finished/Error states
- **Pull-to-refresh on mDNS Discovery**: wraps screen with `PullToRefreshBox`, triggers `startScan(8000ms)`; `isRefreshing` tied to `uiState.isScanning`
- **Fix huge bottom spacing on mDNS screen**: `Spacer(height(80.dp))` at the bottom of the service list `LazyColumn` was causing double-padding (Scaffold `innerPadding` already handles nav bar clearance); reduced to `16.dp`

DNS and WHOIS screens already had `PullToRefreshBox` — these three are now consistent with that pattern.

## Test plan

- [ ] WiFi Scanner: pull down while viewing networks → spinner appears → new scan runs → results update
- [ ] LAN Scanner: pull down after a scan completes → re-scans with same subnet/timeout/concurrency settings
- [ ] mDNS Discovery: pull down after scan → re-runs 8 second discovery
- [ ] mDNS screen: bottom of service list no longer has excessive empty space
- [ ] Pull-to-refresh does not trigger during active scanning (guarded by `canRefresh` check)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TJEtSdGkueULfy8NLWGW4