### PR TITLE
feat: animation polish across 5 screens

### DIFF
--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/PortsScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/PortsScreen.kt
@@ -865,6 +865,14 @@ private fun StatChip(
 
 @Composable
 private fun PortResultRow(result: PortScanResult) {
+    var targetAlpha by remember { mutableStateOf(0f) }
+    LaunchedEffect(Unit) { targetAlpha = 1f }
+    val animatedAlpha by animateFloatAsState(
+        targetValue = targetAlpha,
+        animationSpec = spring(stiffness = Spring.StiffnessLow),
+        label = "port_row_alpha"
+    )
+
     val statusColor = when (result.status) {
         PortStatus.OPEN     -> MaterialTheme.colorScheme.primary
         PortStatus.CLOSED   -> MaterialTheme.colorScheme.onSurfaceVariant
@@ -875,7 +883,7 @@ private fun PortResultRow(result: PortScanResult) {
         PortStatus.CLOSED   -> R.string.ports_closed_label
         PortStatus.FILTERED -> R.string.ports_filtered_label
     }
-    val cardAlpha = when (result.status) {
+    val statusAlpha = when (result.status) {
         PortStatus.OPEN -> 1f
         else -> 0.65f
     }
@@ -884,7 +892,7 @@ private fun PortResultRow(result: PortScanResult) {
         modifier = Modifier
             .fillMaxWidth()
             .padding(vertical = 2.dp)
-            .alpha(cardAlpha)
+            .alpha(animatedAlpha * statusAlpha)
     ) {
         Row(
             modifier = Modifier.padding(12.dp),

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/onboarding/OnboardingSheet.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/onboarding/OnboardingSheet.kt
@@ -37,9 +37,11 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import kotlinx.coroutines.delay
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -71,6 +73,17 @@ fun OnboardingSheet(onDismiss: () -> Unit) {
         OnboardingFeature(Icons.Default.Speed,        "Speed Test",     "Measure download, upload, and latency against Cloudflare's global network."),
         OnboardingFeature(Icons.Default.Language,     "DNS & Subnet",   "Resolve DNS records, calculate subnets, and browse mDNS services.")
     )
+
+    // Stagger: -1 = nothing visible yet, then each index becomes visible in turn
+    var visibleUpTo by remember { mutableIntStateOf(-1) }
+    LaunchedEffect(contentVisible) {
+        if (contentVisible) {
+            features.indices.forEach { i ->
+                delay(if (i == 0) 200L else 80L)
+                visibleUpTo = i
+            }
+        }
+    }
 
     ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
         AnimatedVisibility(
@@ -125,9 +138,16 @@ fun OnboardingSheet(onDismiss: () -> Unit) {
 
                 Spacer(Modifier.height(24.dp))
 
-                features.forEach { feature ->
-                    OnboardingFeatureRow(feature)
-                    Spacer(Modifier.height(12.dp))
+                features.forEachIndexed { index, feature ->
+                    AnimatedVisibility(
+                        visible = index <= visibleUpTo,
+                        enter = fadeIn(tween(250)) + slideInVertically(tween(250)) { it / 3 },
+                    ) {
+                        Column {
+                            OnboardingFeatureRow(feature)
+                            Spacer(Modifier.height(12.dp))
+                        }
+                    }
                 }
 
                 Spacer(Modifier.height(8.dp))

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/settings/SettingsScreen.kt
@@ -50,9 +50,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import kotlinx.coroutines.delay
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -78,6 +80,13 @@ fun SettingsScreen(
     var visible by remember { mutableStateOf(false) }
     LaunchedEffect(Unit) { visible = true }
 
+    var visibleSections by remember { mutableIntStateOf(0) }
+    LaunchedEffect(visible) {
+        if (visible) {
+            repeat(8) { delay(60L); visibleSections++ }
+        }
+    }
+
     AnimatedVisibility(
         visible = visible,
         enter = fadeIn(tween(300)) + slideInVertically(tween(300)) { it / 8 }
@@ -90,23 +99,37 @@ fun SettingsScreen(
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             SettingsHeader()
-            ThemeSection(
-                themeOverride = themeOverride,
-                onThemeChange = viewModel::setThemeOverride
-            )
-            DefaultsSection(
-                pingCount = defaultPingCount,
-                timeoutMs = defaultTimeoutMs,
-                concurrency = defaultConcurrency,
-                onPingCountChange = viewModel::setDefaultPingCount,
-                onTimeoutChange = viewModel::setDefaultTimeoutMs,
-                onConcurrencyChange = viewModel::setDefaultConcurrency
-            )
-            DataSection(onClearRecents = viewModel::clearAllRecentHosts)
-            OnboardingResetSection(onReset = viewModel::resetOnboarding)
-            AboutSection()
-            AttributionsSection()
-            LicensesSection()
+            AnimatedVisibility(visible = visibleSections >= 1, enter = fadeIn(tween(250)) + slideInVertically(tween(250)) { it / 3 }) {
+                ThemeSection(
+                    themeOverride = themeOverride,
+                    onThemeChange = viewModel::setThemeOverride
+                )
+            }
+            AnimatedVisibility(visible = visibleSections >= 2, enter = fadeIn(tween(250)) + slideInVertically(tween(250)) { it / 3 }) {
+                DefaultsSection(
+                    pingCount = defaultPingCount,
+                    timeoutMs = defaultTimeoutMs,
+                    concurrency = defaultConcurrency,
+                    onPingCountChange = viewModel::setDefaultPingCount,
+                    onTimeoutChange = viewModel::setDefaultTimeoutMs,
+                    onConcurrencyChange = viewModel::setDefaultConcurrency
+                )
+            }
+            AnimatedVisibility(visible = visibleSections >= 3, enter = fadeIn(tween(250)) + slideInVertically(tween(250)) { it / 3 }) {
+                DataSection(onClearRecents = viewModel::clearAllRecentHosts)
+            }
+            AnimatedVisibility(visible = visibleSections >= 4, enter = fadeIn(tween(250)) + slideInVertically(tween(250)) { it / 3 }) {
+                OnboardingResetSection(onReset = viewModel::resetOnboarding)
+            }
+            AnimatedVisibility(visible = visibleSections >= 5, enter = fadeIn(tween(250)) + slideInVertically(tween(250)) { it / 3 }) {
+                AboutSection()
+            }
+            AnimatedVisibility(visible = visibleSections >= 6, enter = fadeIn(tween(250)) + slideInVertically(tween(250)) { it / 3 }) {
+                AttributionsSection()
+            }
+            AnimatedVisibility(visible = visibleSections >= 7, enter = fadeIn(tween(250)) + slideInVertically(tween(250)) { it / 3 }) {
+                LicensesSection()
+            }
             Spacer(Modifier.height(8.dp))
         }
     }

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/speedtest/SpeedTestScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/speedtest/SpeedTestScreen.kt
@@ -56,10 +56,12 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.LaunchedEffect
+import kotlinx.coroutines.delay
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
@@ -668,6 +670,11 @@ private fun SpeedTestResultContent(
     onRetry: () -> Unit,
     onShare: () -> Unit
 ) {
+    var visibleCards by remember { mutableIntStateOf(0) }
+    LaunchedEffect(Unit) {
+        listOf(80L, 120L, 120L).forEach { d -> delay(d); visibleCards++ }
+    }
+
     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
         Text(
             text = stringResource(R.string.speedtest_results_header),
@@ -675,19 +682,25 @@ private fun SpeedTestResultContent(
             fontWeight = FontWeight.SemiBold
         )
 
-        LatencyResultCard(result.latency)
-        ThroughputResultCard(
-            title = stringResource(R.string.speedtest_download_header),
-            icon = Icons.Default.ArrowDownward,
-            accentColor = MaterialTheme.colorScheme.primary,
-            result = result.download
-        )
-        ThroughputResultCard(
-            title = stringResource(R.string.speedtest_upload_header),
-            icon = Icons.Default.ArrowUpward,
-            accentColor = MaterialTheme.colorScheme.tertiary,
-            result = result.upload
-        )
+        AnimatedVisibility(visible = visibleCards >= 1, enter = fadeIn(tween(300)) + slideInVertically(tween(300)) { it / 4 }) {
+            LatencyResultCard(result.latency)
+        }
+        AnimatedVisibility(visible = visibleCards >= 2, enter = fadeIn(tween(300)) + slideInVertically(tween(300)) { it / 4 }) {
+            ThroughputResultCard(
+                title = stringResource(R.string.speedtest_download_header),
+                icon = Icons.Default.ArrowDownward,
+                accentColor = MaterialTheme.colorScheme.primary,
+                result = result.download
+            )
+        }
+        AnimatedVisibility(visible = visibleCards >= 3, enter = fadeIn(tween(300)) + slideInVertically(tween(300)) { it / 4 }) {
+            ThroughputResultCard(
+                title = stringResource(R.string.speedtest_upload_header),
+                icon = Icons.Default.ArrowUpward,
+                accentColor = MaterialTheme.colorScheme.tertiary,
+                result = result.upload
+            )
+        }
 
         Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
             OutlinedButton(onClick = onShare, modifier = Modifier.weight(1f)) {

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/tls/TlsInspectorScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/tls/TlsInspectorScreen.kt
@@ -4,8 +4,10 @@ import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
+import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.Arrangement
@@ -624,7 +626,11 @@ private fun CertificateCard(
             }
 
             // Expanded body
-            AnimatedVisibility(visible = expanded) {
+            AnimatedVisibility(
+                visible = expanded,
+                enter = expandVertically(tween(200)) + fadeIn(tween(200)),
+                exit  = shrinkVertically(tween(200)) + fadeOut(tween(150)),
+            ) {
                 Column(modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 16.dp)) {
                     HorizontalDivider(modifier = Modifier.padding(bottom = 12.dp))
                     CertificateDetails(cert)


### PR DESCRIPTION
## Summary

Five targeted animation improvements identified from a full UI audit:

**Port Scanner** — `PortResultRow` now fades in with a spring animation as each port is discovered during a live scan (same `LaunchedEffect + animateFloatAsState` pattern as PingScreen's `PacketRow`). Previously ports snapped into the list with no visual feedback.

**TLS Inspector** — `CertificateCard` expand/collapse now uses `expandVertically + fadeIn` / `shrinkVertically + fadeOut` instead of snapping open/closed instantly.

**Onboarding** — Feature rows cascade in with an 80ms stagger so each capability card appears in sequence rather than all five at once. First impression on a fresh install is now noticeably more polished.

**Speed Test** — Latency / Download / Upload result cards stagger in (80 → 120 → 120ms delays) so results feel like they're being revealed rather than appearing all at once.

**Settings** — Section cards stagger in at 60ms intervals on screen enter, matching the cascading pattern already used on the Home screen tool grid.

## Test plan

- [ ] Port scan: start a scan against a subnet — open ports fade in as discovered
- [ ] TLS: expand/collapse a cert chain entry — smooth expand/collapse
- [ ] Onboarding: clear onboarding state, relaunch — feature rows cascade in
- [ ] Speed test: complete a test — three result cards stagger in sequentially
- [ ] Settings: open Settings — section cards appear in sequence
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TJEtSdGkueULfy8NLWGW4