### PR TITLE
feat: LAN host fade-in, WiFi icon spin, Ping stats roll-up

### DIFF
--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/PingScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/PingScreen.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.view.WindowManager
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.Spring
@@ -837,6 +838,25 @@ private fun PingErrorPanel(
 
 @Composable
 private fun StatsCard(stats: PingStats, host: String) {
+    var targetLoss   by remember { mutableStateOf(0f) }
+    var targetMin    by remember { mutableStateOf(0f) }
+    var targetAvg    by remember { mutableStateOf(0f) }
+    var targetMax    by remember { mutableStateOf(0f) }
+    var targetJitter by remember { mutableStateOf(0f) }
+    LaunchedEffect(stats) {
+        targetLoss   = stats.lossPercent
+        targetMin    = stats.minMs.toFloat()
+        targetAvg    = stats.avgMs.toFloat()
+        targetMax    = stats.maxMs.toFloat()
+        targetJitter = stats.jitterMs.toFloat()
+    }
+    val animSpec = tween<Float>(700, easing = FastOutSlowInEasing)
+    val animLoss    by animateFloatAsState(targetLoss,   animSpec, label = "stat_loss")
+    val animMin     by animateFloatAsState(targetMin,    animSpec, label = "stat_min")
+    val animAvg     by animateFloatAsState(targetAvg,    animSpec, label = "stat_avg")
+    val animMax     by animateFloatAsState(targetMax,    animSpec, label = "stat_max")
+    val animJitter  by animateFloatAsState(targetJitter, animSpec, label = "stat_jitter")
+
     ElevatedCard(modifier = Modifier.fillMaxWidth()) {
         Column(
             modifier = Modifier
@@ -883,7 +903,7 @@ private fun StatsCard(stats: PingStats, host: String) {
                 )
                 StatItem(
                     label = stringResource(R.string.ping_packet_loss),
-                    value = "${"%.0f".format(stats.lossPercent)}%",
+                    value = "${"%.0f".format(animLoss)}%",
                     color = if (stats.lossPercent == 0f)
                         MaterialTheme.colorScheme.tertiary
                     else
@@ -901,25 +921,25 @@ private fun StatsCard(stats: PingStats, host: String) {
                 ) {
                     StatItem(
                         label = stringResource(R.string.ping_rtt_min),
-                        value = "${stats.minMs}",
+                        value = "${animMin.toLong()}",
                         unit = stringResource(R.string.ping_ms_suffix),
                         color = MaterialTheme.colorScheme.onTertiaryContainer
                     )
                     StatItem(
                         label = stringResource(R.string.ping_rtt_avg),
-                        value = "${"%.1f".format(stats.avgMs)}",
+                        value = "${"%.1f".format(animAvg)}",
                         unit = stringResource(R.string.ping_ms_suffix),
                         color = MaterialTheme.colorScheme.onTertiaryContainer
                     )
                     StatItem(
                         label = stringResource(R.string.ping_rtt_max),
-                        value = "${stats.maxMs}",
+                        value = "${animMax.toLong()}",
                         unit = stringResource(R.string.ping_ms_suffix),
                         color = MaterialTheme.colorScheme.onTertiaryContainer
                     )
                     StatItem(
                         label = stringResource(R.string.ping_rtt_jitter),
-                        value = "${"%.1f".format(stats.jitterMs)}",
+                        value = "${"%.1f".format(animJitter)}",
                         unit = stringResource(R.string.ping_ms_suffix),
                         color = MaterialTheme.colorScheme.onTertiaryContainer
                     )

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/WifiScanScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/WifiScanScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.animation.togetherWith
 import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.animateFloatAsState
@@ -83,6 +84,7 @@ import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Brush
@@ -435,6 +437,13 @@ fun WifiScanScreen(
     val gradient = Brush.linearGradient(
         listOf(MaterialTheme.colorScheme.primaryContainer, MaterialTheme.colorScheme.tertiaryContainer)
     )
+    val spinTransition = rememberInfiniteTransition(label = "refresh_spin")
+    val spinAngle by spinTransition.animateFloat(
+        initialValue = 0f,
+        targetValue = 360f,
+        animationSpec = infiniteRepeatable(tween(2000, easing = LinearEasing)),
+        label = "spin_angle"
+    )
     ElevatedCard(Modifier.fillMaxWidth()) {
         Box(Modifier.background(gradient)) {
             Column(Modifier.padding(20.dp).fillMaxWidth()) {
@@ -471,7 +480,13 @@ fun WifiScanScreen(
                 }
                 Spacer(Modifier.height(8.dp))
                 FilledTonalIconButton(onClick = onScan) {
-                    Icon(Icons.Default.Refresh, contentDescription = stringResource(R.string.wifi_scan_button))
+                    Icon(
+                        Icons.Default.Refresh,
+                        contentDescription = stringResource(R.string.wifi_scan_button),
+                        modifier = Modifier.graphicsLayer {
+                            rotationZ = if (autoRefresh) spinAngle else 0f
+                        }
+                    )
                 }
             }
         }

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/lan/LanScanScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/lan/LanScanScreen.kt
@@ -86,11 +86,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 // collectAsState replaced by collectAsStateWithLifecycle below
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.geometry.Offset
@@ -530,7 +532,18 @@ private fun LanScanningContent(state: LanScanUiState.Scanning) {
                 modifier = Modifier.padding(horizontal = 4.dp),
             )
             state.hosts.forEach { host ->
-                HostCard(host = host, expanded = false, onClick = {})
+                key(host.ip) {
+                    var targetAlpha by remember { mutableStateOf(0f) }
+                    LaunchedEffect(Unit) { targetAlpha = 1f }
+                    val rowAlpha by animateFloatAsState(
+                        targetValue = targetAlpha,
+                        animationSpec = spring(stiffness = Spring.StiffnessLow),
+                        label = "host_alpha"
+                    )
+                    Box(Modifier.alpha(rowAlpha)) {
+                        HostCard(host = host, expanded = false, onClick = {})
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

- **LAN scan**: Each host card fades in smoothly via `key(host.ip)` + `LaunchedEffect` + `animateFloatAsState` (spring) as it's discovered during a live scan
- **WiFi**: The refresh icon in the header spins continuously via `infiniteRepeatable` tween while auto-refresh is enabled, giving clear visual feedback that periodic scanning is active
- **Ping stats**: All numeric values in `StatsCard` (loss %, min/avg/max RTT, jitter) count up from 0 when the card first appears, using `animateFloatAsState` with a 700ms ease-out

## Test plan

- [ ] LAN Scan: start a scan, watch host cards slide/fade in one by one as hosts are discovered
- [ ] WiFi: enable auto-refresh toggle, confirm the refresh button icon rotates continuously; disable it, confirm it stops
- [ ] Ping: run a ping to completion, confirm numeric stats animate from 0 to their final values on the results card

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TJEtSdGkueULfy8NLWGW4