### PR TITLE
fix: deflake LanScanViewModelTest dispatcher teardown race

### DIFF
--- a/app/src/test/kotlin/net/aieat/netswissknife/app/ui/screens/lan/LanScanViewModelTest.kt
+++ b/app/src/test/kotlin/net/aieat/netswissknife/app/ui/screens/lan/LanScanViewModelTest.kt
@@ -3,10 +3,14 @@ package net.aieat.netswissknife.app.ui.screens.lan
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.emptyPreferences
+import androidx.lifecycle.viewModelScope
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.job
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
@@ -71,7 +75,11 @@ class LanScanViewModelTest {
     }
 
     @AfterEach
-    fun tearDown() {
+    fun tearDown() = runBlocking {
+        // The scan pipeline hops through Dispatchers.IO; its final resumption lands on
+        // Main. Cancel and join before resetMain() so no coroutine touches Main after
+        // the test dispatcher is gone (flaky Looper IllegalStateException otherwise).
+        viewModel.viewModelScope.coroutineContext.job.cancelAndJoin()
         Dispatchers.resetMain()
     }
 


### PR DESCRIPTION
## Summary
`LanScanViewModel`'s scan pipeline uses `withContext(Dispatchers.IO)` inside `viewModelScope` (Main). When a test observed the terminal UI state and returned before the coroutine's final resumption dispatched back onto Main, `tearDown()`'s `Dispatchers.resetMain()` won the race and the resumption crashed with `IllegalStateException` (`Looper` not mocked). This is the failure that broke the `v2026.07.18.1` release run's unit-test step while the same commit passed CI.

Fix: `tearDown` now cancels-and-joins the `viewModelScope` job before `resetMain()`, so nothing can touch `Dispatchers.Main` after the test dispatcher is removed.

Audited the other 11 ViewModel test classes using `setMain`/`resetMain`: only `LanScanViewModel` hops off Main internally, so this is the only class needing the drain.

## Testing
- `:app:testDebugUnitTest --tests LanScanViewModelTest` — passed 4 consecutive runs (`--rerun`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYYL3R6AirzP37MGvP5hYm