### PR TITLE
Local network permission on Android 16 + leaner release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -260,31 +260,12 @@ jobs:
             ${{ steps.rename.outputs.aab_named }}
             ${{ steps.rename.outputs.symbols_named }}
           body: |
-            ## Net Swiss Knife ${{ steps.version.outputs.name }}
-
-            ### Installation
-
-            **Direct install (sideload)**
-            1. Download `NetSwissKnife-${{ steps.version.outputs.name }}.apk`
-            2. Enable *Install from unknown sources* in Android settings
-            3. Open the APK to install
-
-            **Play Store (AAB)**
-            The `.aab` bundle is intended for Google Play internal testing / production upload.
-
-            **Native debug symbols**
-            Download `native-debug-symbols-${{ steps.version.outputs.name }}.zip` and upload it
-            in Play Console → App bundle explorer → select this release → Native debug symbols.
-            This clears the "no debug symbols" advisory warning. Note: these symbols contain
-            only exported function names (.dynsym); upstream deps ship pre-stripped AARs without
-            full debug info.
-
-            ### Requirements
-            - Android 8.0 (API 26) or higher
-
             ### Build info
             - Version code: `${{ steps.version.outputs.code }}`
             - Commit: `${{ github.sha }}`
             - Signed: ${{ steps.signing.outputs.has_keystore == 'true' && 'Yes (release key)' || 'Debug key (sideload only – not for Play Store)' }}
+            - Requires Android 8.0 (API 26) or higher
+
+            Install `NetSwissKnife-${{ steps.version.outputs.name }}.apk` directly, or use the `.aab` for Play Store upload. Native debug symbols zip is for Play Console → Native debug symbols (optional).
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,7 +24,7 @@ android {
     defaultConfig {
         applicationId = "net.aieat.netswissknife"
         minSdk        = 26
-        targetSdk     = 35
+        targetSdk     = 36
         versionCode   = ciVersionCode ?: (System.currentTimeMillis() / 1000).toInt()
         versionName   = ciVersionName ?: "1.0.0"
     }

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/components/LocalNetworkPermission.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/components/LocalNetworkPermission.kt
@@ -1,0 +1,46 @@
+package net.aieat.netswissknife.app.ui.components
+
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.ContextCompat
+
+/**
+ * Android 16 (API 36) gates LAN sockets, mDNS/NSD, and broadcast traffic behind
+ * `NEARBY_WIFI_DEVICES` under Local Network Protections (currently opt-in via
+ * `adb shell am compat enable RESTRICT_LOCAL_NETWORK`, enforcement lands in a
+ * future release; confirmed against the android-36 SDK, no separate permission
+ * constant exists). Tools that talk to local-network addresses call this once
+ * on entry so the permission is already granted before enforcement ships;
+ * denial isn't fatal today; the underlying socket call will surface as the
+ * tool's existing error state.
+ *
+ * Gated on API 36+, not 33+ (`NEARBY_WIFI_DEVICES` also exists since 33 for
+ * Wi-Fi scanning, but LNP itself only applies on 36+) so 13-15 devices don't
+ * see an irrelevant permission prompt.
+ */
+@Composable
+fun rememberLocalNetworkPermissionRequester(): () -> Unit {
+    val context = LocalContext.current
+    val launcher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission()
+    ) { /* no-op: absence surfaces via the tool's normal error path */ }
+
+    return remember(context) {
+        {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.BAKLAVA &&
+                ContextCompat.checkSelfPermission(
+                    context,
+                    Manifest.permission.NEARBY_WIFI_DEVICES
+                ) != PackageManager.PERMISSION_GRANTED
+            ) {
+                launcher.launch(Manifest.permission.NEARBY_WIFI_DEVICES)
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/PingScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/PingScreen.kt
@@ -120,6 +120,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import net.aieat.netswissknife.app.ui.components.ToolHeroHeader
+import net.aieat.netswissknife.app.ui.components.rememberLocalNetworkPermissionRequester
 import net.aieat.netswissknife.app.ui.components.ToolStopButton
 import net.aieat.netswissknife.app.ui.components.hapticAction
 import net.aieat.netswissknife.app.R
@@ -138,6 +139,9 @@ import net.aieat.netswissknife.core.network.ping.PingStatus
 fun PingScreen(
     viewModel: PingViewModel = hiltViewModel()
 ) {
+    val requestLocalNetworkPermission = rememberLocalNetworkPermissionRequester()
+    LaunchedEffect(Unit) { requestLocalNetworkPermission() }
+
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val host by viewModel.host.collectAsStateWithLifecycle()
     val count by viewModel.count.collectAsStateWithLifecycle()

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/PortsScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/PortsScreen.kt
@@ -103,6 +103,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.launch
 import net.aieat.netswissknife.app.ui.components.ToolHeroHeader
+import net.aieat.netswissknife.app.ui.components.rememberLocalNetworkPermissionRequester
 import net.aieat.netswissknife.app.ui.components.ToolStopButton
 import net.aieat.netswissknife.app.ui.components.hapticAction
 import net.aieat.netswissknife.app.R
@@ -120,6 +121,9 @@ import net.aieat.netswissknife.core.network.portscan.PortStatus
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
 fun PortsScreen(viewModel: PortScanViewModel = hiltViewModel()) {
+    val requestLocalNetworkPermission = rememberLocalNetworkPermissionRequester()
+    LaunchedEffect(Unit) { requestLocalNetworkPermission() }
+
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val host by viewModel.host.collectAsStateWithLifecycle()
     val selectedPreset by viewModel.selectedPreset.collectAsStateWithLifecycle()

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/TracerouteScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/TracerouteScreen.kt
@@ -92,6 +92,7 @@ import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import net.aieat.netswissknife.app.ui.components.ToolHeroHeader
+import net.aieat.netswissknife.app.ui.components.rememberLocalNetworkPermissionRequester
 import net.aieat.netswissknife.app.ui.components.ToolStopButton
 import net.aieat.netswissknife.app.ui.components.hapticAction
 import net.aieat.netswissknife.app.ui.theme.StatusBad
@@ -134,6 +135,9 @@ import kotlin.math.sqrt
 
 @Composable
 fun TracerouteScreen(viewModel: TracerouteViewModel = hiltViewModel()) {
+    val requestLocalNetworkPermission = rememberLocalNetworkPermissionRequester()
+    LaunchedEffect(Unit) { requestLocalNetworkPermission() }
+
     val uiState      by viewModel.uiState.collectAsStateWithLifecycle()
     val host         by viewModel.host.collectAsStateWithLifecycle()
     val maxHops      by viewModel.maxHops.collectAsStateWithLifecycle()

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/lan/LanScanScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/lan/LanScanScreen.kt
@@ -110,6 +110,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import net.aieat.netswissknife.app.ui.components.ToolHeroHeader
+import net.aieat.netswissknife.app.ui.components.rememberLocalNetworkPermissionRequester
 import net.aieat.netswissknife.app.ui.components.ToolStopButton
 import net.aieat.netswissknife.app.ui.components.hapticAction
 import net.aieat.netswissknife.app.R
@@ -125,6 +126,9 @@ import net.aieat.netswissknife.core.network.lan.LanScanSummary
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun LanScreen(viewModel: LanScanViewModel = hiltViewModel()) {
+    val requestLocalNetworkPermission = rememberLocalNetworkPermissionRequester()
+    LaunchedEffect(Unit) { requestLocalNetworkPermission() }
+
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val subnet by viewModel.subnet.collectAsStateWithLifecycle()
     val timeoutMs by viewModel.timeoutMs.collectAsStateWithLifecycle()

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/mdns/MdnsDiscoveryScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/mdns/MdnsDiscoveryScreen.kt
@@ -87,6 +87,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import net.aieat.netswissknife.app.ui.components.HeroTitleText
+import net.aieat.netswissknife.app.ui.components.rememberLocalNetworkPermissionRequester
 import net.aieat.netswissknife.app.ui.components.ToolStopButton
 import net.aieat.netswissknife.app.ui.components.hapticAction
 import net.aieat.netswissknife.app.R
@@ -98,6 +99,9 @@ import net.aieat.netswissknife.core.network.mdns.DiscoveredService
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MdnsDiscoveryScreen(viewModel: MdnsDiscoveryViewModel = hiltViewModel()) {
+    val requestLocalNetworkPermission = rememberLocalNetworkPermissionRequester()
+    LaunchedEffect(Unit) { requestLocalNetworkPermission() }
+
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     var visible by remember { mutableStateOf(false) }

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/wol/WakeOnLanScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/wol/WakeOnLanScreen.kt
@@ -68,6 +68,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import net.aieat.netswissknife.app.R
 import net.aieat.netswissknife.app.ui.components.HelpSection
+import net.aieat.netswissknife.app.ui.components.rememberLocalNetworkPermissionRequester
 import net.aieat.netswissknife.app.ui.components.ToolHelpSheet
 import net.aieat.netswissknife.app.ui.components.ToolHeroHeader
 import net.aieat.netswissknife.app.ui.components.hapticAction
@@ -80,6 +81,9 @@ import net.aieat.netswissknife.core.network.wol.WolSendReport
 
 @Composable
 fun WakeOnLanScreen(viewModel: WakeOnLanViewModel = hiltViewModel()) {
+    val requestLocalNetworkPermission = rememberLocalNetworkPermissionRequester()
+    LaunchedEffect(Unit) { requestLocalNetworkPermission() }
+
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val macAddress by viewModel.macAddress.collectAsStateWithLifecycle()
     val broadcastAddress by viewModel.broadcastAddress.collectAsStateWithLifecycle()


### PR DESCRIPTION
## Summary
- Request `NEARBY_WIFI_DEVICES` on entry to each local-network tool screen (Ping, Ports, Traceroute, LAN Scan, mDNS, WoL) ahead of Android 16 Local Network Protections enforcement; bump `targetSdk` to 36.
- Trim the release workflow's manual notes body — deploy instructions were burying GitHub's auto-generated "What's Changed" changelog. Body is now a short build-info block; `generate_release_notes: true` still supplies the actual change list.

## Test plan
- [x] `./gradlew test`
- [x] `./gradlew :app:assembleDebug`
- [ ] CI green on this PR
- [ ] `./gradlew :app:assembleRelease` / release workflow run to confirm new notes format

🤖 Generated with [Claude Code](https://claude.com/claude-code)