### PR TITLE
fix: whois chain alignment, main-thread DNS in host validation, lazy list keys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,5 +36,8 @@ jobs:
       - name: Run unit tests
         run: ./gradlew test
 
+      - name: Verify coverage gate
+        run: ./gradlew :app:koverVerify
+
       - name: Build debug APK
         run: ./gradlew :app:assembleDebug

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,7 +176,16 @@ REFACTOR: Clean up → ./gradlew test (all pass)
 
 # Clean
 ./gradlew clean
+
+# Coverage (Kover)
+./gradlew :app:koverVerify        # enforce 100% on pure, non-Compose app logic
+./gradlew :app:koverHtmlReport    # scoped :app report
+./gradlew :core-network:koverHtmlReport :core-domain:koverHtmlReport
 ```
+
+> Run only one Gradle invocation at a time on memory-constrained hosts.
+> Concurrent builds share `org.gradle.jvmargs=-Xmx1536m` and make test workers
+> time out or crash in ways that look like real test failures.
 
 ---
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
+    alias(libs.plugins.kover)
 }
 
 // ── CI-supplied properties ────────────────────────────────────────────────────
@@ -147,4 +148,35 @@ tasks.withType<Test> {
     // GC thrashing severe enough to look like a hung build.
     maxParallelForks = 1
     maxHeapSize = "512m"
+}
+
+// ── Coverage ──────────────────────────────────────────────────────────────────
+// Newly added, non-Compose logic must stay fully covered. The :app report is
+// deliberately scoped to that logic: the module's other ~17 Compose screens
+// cannot be exercised by plain JVM unit tests, so measuring them here would
+// only dilute the gate. Coverage for the pure-Kotlin modules is reported
+// unfiltered by :core-network and :core-domain.
+//
+//   ./gradlew :app:koverVerify        -- enforce the gate
+//   ./gradlew :app:koverHtmlReport    -- browse the scoped report
+kover {
+    reports {
+        filters {
+            includes {
+                classes(
+                    "net.aieat.netswissknife.app.ui.screens.whois.RelayChainGeometry",
+                    "net.aieat.netswissknife.app.ui.screens.whois.ConnectorSegment"
+                )
+            }
+            excludes {
+                androidGeneratedClasses()
+                annotatedBy("androidx.compose.runtime.Composable")
+            }
+        }
+        verify {
+            rule("Pure layout logic is fully covered") {
+                minBound(100)
+            }
+        }
+    }
 }

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/components/RecentHostsRow.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/components/RecentHostsRow.kt
@@ -56,7 +56,7 @@ fun RecentHostsRow(
                 modifier = Modifier.weight(1f),
                 horizontalArrangement = Arrangement.spacedBy(4.dp)
             ) {
-                items(recentHosts) { host ->
+                items(recentHosts, key = { it }) { host ->
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         SuggestionChip(
                             onClick = { onHostSelected(host) },

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/PingScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/PingScreen.kt
@@ -642,7 +642,7 @@ private fun PingRunningPanel(state: PingUiState.Running) {
                     )
                     Spacer(modifier = Modifier.height(8.dp))
                     LazyColumn(modifier = Modifier.heightIn(max = 320.dp)) {
-                        items(displayPackets) { packet -> PacketRow(packet) }
+                        items(displayPackets, key = { it.sequence }) { packet -> PacketRow(packet) }
                     }
                 }
             }

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/PortsScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/PortsScreen.kt
@@ -246,7 +246,7 @@ fun PortsScreen(viewModel: PortScanViewModel = hiltViewModel()) {
                             modifier = Modifier.padding(vertical = 4.dp)
                         )
                     }
-                    items(openPorts) { portResult ->
+                    items(openPorts, key = { it.port }) { portResult ->
                         PortResultRow(portResult)
                     }
                 }
@@ -274,7 +274,7 @@ fun PortsScreen(viewModel: PortScanViewModel = hiltViewModel()) {
                         }
                     }
                     if (showAll) {
-                        items(allNonOpen) { portResult ->
+                        items(allNonOpen, key = { it.port }) { portResult ->
                             PortResultRow(portResult)
                         }
                     }
@@ -313,7 +313,7 @@ fun PortsScreen(viewModel: PortScanViewModel = hiltViewModel()) {
                             modifier = Modifier.padding(vertical = 4.dp)
                         )
                     }
-                    items(openLive) { portResult ->
+                    items(openLive, key = { it.port }) { portResult ->
                         PortResultRow(portResult)
                     }
                 }

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/WifiScanScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/WifiScanScreen.kt
@@ -392,9 +392,12 @@ fun WifiScanScreen(
         }
 
         // Network cards (SSID grouped, expandable)
-        items(networks.size) { i ->
+        items(
+            count = networks.size,
+            key = { i -> networks[i].id }
+        ) { i ->
             val network = networks[i]
-            val networkId = "${network.ssid}|${network.security.name}"
+            val networkId = network.id
             WifiNetworkCard(
                 network = network,
                 expanded = networkId in expandedNetworks,

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/whois/RelayChainGeometry.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/whois/RelayChainGeometry.kt
@@ -1,0 +1,47 @@
+package net.aieat.netswissknife.app.ui.screens.whois
+
+/**
+ * A single horizontal connector drawn between two adjacent relay-chain nodes.
+ * Coordinates are pixels in the connector canvas' own coordinate space.
+ */
+data class ConnectorSegment(val startX: Float, val endX: Float)
+
+/**
+ * Layout maths for the WHOIS relay-chain visualiser, kept free of Compose so the
+ * node/connector alignment is unit-testable.
+ *
+ * The node row lays `nodeCount` equally weighted cells across the full canvas
+ * width with no arrangement spacing and no padding, so cell `i` spans
+ * `[i * w/n, (i + 1) * w/n)` and its node is centred within that cell. The
+ * connector canvas must use exactly these positions, otherwise the line and the
+ * circles drift apart.
+ */
+object RelayChainGeometry {
+
+    /** Centre X of node [index] when [nodeCount] nodes share [width] pixels. */
+    fun nodeCenterX(index: Int, nodeCount: Int, width: Float): Float {
+        require(nodeCount > 0) { "nodeCount must be positive" }
+        require(index in 0 until nodeCount) { "index $index out of bounds for $nodeCount nodes" }
+        val cell = width / nodeCount
+        return cell * index + cell / 2f
+    }
+
+    /**
+     * Connector segments joining consecutive node edges. Returns an empty list
+     * when there is nothing to join, when the canvas has no width, or when the
+     * nodes are packed so tightly that their circles already touch (in which
+     * case a segment would render backwards).
+     */
+    fun connectorSegments(
+        nodeCount: Int,
+        width: Float,
+        nodeRadius: Float
+    ): List<ConnectorSegment> {
+        if (nodeCount < 2 || width <= 0f || nodeRadius < 0f) return emptyList()
+        return (0 until nodeCount - 1).mapNotNull { i ->
+            val start = nodeCenterX(i, nodeCount, width) + nodeRadius
+            val end = nodeCenterX(i + 1, nodeCount, width) - nodeRadius
+            if (end > start) ConnectorSegment(start, end) else null
+        }
+    }
+}

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/whois/WhoisScreen.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/screens/whois/WhoisScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.InfiniteTransition
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
@@ -25,6 +26,7 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -282,50 +284,71 @@ private fun WhoisHeroHeader(onHelpClick: () -> Unit) {
 
 // ── Relay Chain Visualiser ────────────────────────────────────────────────────
 
+private val HopNodeSize = 40.dp
+private val HopNodeRadius = HopNodeSize / 2
+private val HopConnectorStroke = 2.dp
+
 @Composable
 fun RelayChainVisualiser(hopStates: List<HopUiState>) {
     if (hopStates.isEmpty()) return
 
     val infiniteTransition = rememberInfiniteTransition(label = "pulse")
+    val connectorColor = MaterialTheme.colorScheme.outlineVariant
 
-    Box(
+    Column(
         modifier = Modifier
             .fillMaxWidth()
-            .height(100.dp)
+            .padding(vertical = 12.dp),
+        // The querying node pulses to 1.1x, so leave room for the enlarged
+        // circle rather than letting it touch the labels below.
+        verticalArrangement = Arrangement.spacedBy(4.dp)
     ) {
-        // Canvas for lines and travelling dots
-        Canvas(modifier = Modifier.matchParentSize()) {
-            if (hopStates.size < 2) return@Canvas
-            val nodeRadius = 20.dp.toPx()
-            val totalWidth = size.width
-            val spacing = totalWidth / hopStates.size
-            val nodeY = size.height / 2f
+        // The circles get their own fixed-height row so the connector canvas can
+        // use size.height / 2 as the node centre. Drawing circles and labels in
+        // one row made the line drift downwards as per-hop timings appeared
+        // mid-scan and grew the row.
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(HopNodeSize)
+        ) {
+            Canvas(modifier = Modifier.matchParentSize()) {
+                val centerY = size.height / 2f
+                val stroke = HopConnectorStroke.toPx()
+                RelayChainGeometry
+                    .connectorSegments(hopStates.size, size.width, HopNodeRadius.toPx())
+                    .forEach { segment ->
+                        drawLine(
+                            color = connectorColor,
+                            start = Offset(segment.startX, centerY),
+                            end = Offset(segment.endX, centerY),
+                            strokeWidth = stroke
+                        )
+                    }
+            }
 
-            for (i in 0 until hopStates.size - 1) {
-                val startX = spacing * i + spacing / 2f
-                val endX = spacing * (i + 1) + spacing / 2f
-                drawLine(
-                    color = Color.Gray.copy(alpha = 0.3f),
-                    start = Offset(startX + nodeRadius, nodeY),
-                    end = Offset(endX - nodeRadius, nodeY),
-                    strokeWidth = 2.dp.toPx()
-                )
+            // Equal-weight cells, no arrangement spacing and no padding: this must
+            // stay in lockstep with RelayChainGeometry.nodeCenterX.
+            Row(modifier = Modifier.fillMaxSize()) {
+                hopStates.forEach { hop ->
+                    HopNodeCircle(
+                        hop = hop,
+                        infiniteTransition = infiniteTransition,
+                        modifier = Modifier
+                            .weight(1f)
+                            .fillMaxHeight()
+                    )
+                }
             }
         }
 
-        // Node composables in a Row
-        Row(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(horizontal = 4.dp),
-            horizontalArrangement = Arrangement.SpaceEvenly,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
+        Row(modifier = Modifier.fillMaxWidth()) {
             hopStates.forEach { hop ->
-                HopNode(
+                HopNodeLabels(
                     hop = hop,
-                    infiniteTransition = infiniteTransition,
-                    modifier = Modifier.weight(1f)
+                    modifier = Modifier
+                        .weight(1f)
+                        .padding(horizontal = 2.dp)
                 )
             }
         }
@@ -333,23 +356,13 @@ fun RelayChainVisualiser(hopStates: List<HopUiState>) {
 }
 
 @Composable
-fun HopNode(
+private fun HopNodeCircle(
     hop: HopUiState,
-    infiniteTransition: androidx.compose.animation.core.InfiniteTransition,
+    infiniteTransition: InfiniteTransition,
     modifier: Modifier = Modifier
 ) {
-    val roleColor = when (hop.server.role) {
-        WhoisServerRole.IANA -> MaterialTheme.colorScheme.tertiaryContainer
-        WhoisServerRole.REGISTRY -> MaterialTheme.colorScheme.primaryContainer
-        WhoisServerRole.REGISTRAR -> MaterialTheme.colorScheme.secondaryContainer
-        WhoisServerRole.RIR -> MaterialTheme.colorScheme.secondaryContainer
-    }
-    val roleOnColor = when (hop.server.role) {
-        WhoisServerRole.IANA -> MaterialTheme.colorScheme.onTertiaryContainer
-        WhoisServerRole.REGISTRY -> MaterialTheme.colorScheme.onPrimaryContainer
-        WhoisServerRole.REGISTRAR -> MaterialTheme.colorScheme.onSecondaryContainer
-        WhoisServerRole.RIR -> MaterialTheme.colorScheme.onSecondaryContainer
-    }
+    val roleColor = hopRoleContainerColor(hop.server.role)
+    val roleOnColor = hopRoleOnContainerColor(hop.server.role)
 
     val pulseScale by infiniteTransition.animateFloat(
         initialValue = 0.9f,
@@ -369,14 +382,10 @@ fun HopNode(
         label = "node_bg"
     )
 
-    Column(
-        modifier = modifier,
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(2.dp)
-    ) {
+    Box(modifier = modifier, contentAlignment = Alignment.Center) {
         Box(
             modifier = Modifier
-                .size(40.dp)
+                .size(HopNodeSize)
                 .scale(if (hop.status == HopStatus.QUERYING) pulseScale else 1f)
                 .clip(CircleShape)
                 .background(bgColor),
@@ -384,12 +393,16 @@ fun HopNode(
         ) {
             when (hop.status) {
                 HopStatus.DONE ->
-                    Icon(Icons.Default.Check, contentDescription = null,
-                        modifier = Modifier.size(20.dp), tint = roleOnColor)
+                    Icon(
+                        Icons.Default.Check, contentDescription = null,
+                        modifier = Modifier.size(20.dp), tint = roleOnColor
+                    )
                 HopStatus.FAILED ->
-                    Icon(Icons.Default.Close, contentDescription = null,
+                    Icon(
+                        Icons.Default.Close, contentDescription = null,
                         modifier = Modifier.size(20.dp),
-                        tint = MaterialTheme.colorScheme.onErrorContainer)
+                        tint = MaterialTheme.colorScheme.onErrorContainer
+                    )
                 HopStatus.QUERYING ->
                     CircularProgressIndicator(
                         modifier = Modifier.size(20.dp),
@@ -399,7 +412,16 @@ fun HopNode(
                 else -> {}
             }
         }
+    }
+}
 
+@Composable
+private fun HopNodeLabels(hop: HopUiState, modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(2.dp)
+    ) {
         Text(
             text = hop.server.host,
             style = MaterialTheme.typography.labelSmall,
@@ -417,7 +439,7 @@ fun HopNode(
 
         if (hop.status == HopStatus.DONE && hop.queryTimeMs != null) {
             Text(
-                text = "${hop.queryTimeMs} ms",
+                text = stringResource(R.string.whois_hop_latency_ms, hop.queryTimeMs),
                 style = MaterialTheme.typography.labelSmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 textAlign = TextAlign.Center
@@ -425,6 +447,23 @@ fun HopNode(
         }
     }
 }
+
+@Composable
+private fun hopRoleContainerColor(role: WhoisServerRole): Color = when (role) {
+    WhoisServerRole.IANA -> MaterialTheme.colorScheme.tertiaryContainer
+    WhoisServerRole.REGISTRY -> MaterialTheme.colorScheme.primaryContainer
+    WhoisServerRole.REGISTRAR -> MaterialTheme.colorScheme.secondaryContainer
+    WhoisServerRole.RIR -> MaterialTheme.colorScheme.secondaryContainer
+}
+
+@Composable
+private fun hopRoleOnContainerColor(role: WhoisServerRole): Color = when (role) {
+    WhoisServerRole.IANA -> MaterialTheme.colorScheme.onTertiaryContainer
+    WhoisServerRole.REGISTRY -> MaterialTheme.colorScheme.onPrimaryContainer
+    WhoisServerRole.REGISTRAR -> MaterialTheme.colorScheme.onSecondaryContainer
+    WhoisServerRole.RIR -> MaterialTheme.colorScheme.onSecondaryContainer
+}
+
 
 // ── Idle Card ─────────────────────────────────────────────────────────────────
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -465,6 +465,7 @@
     <string name="whois_error_title">Lookup failed</string>
     <string name="whois_retry">Retry</string>
     <string name="whois_relay_chain">Query Chain</string>
+    <string name="whois_hop_latency_ms">%1$d ms</string>
     <string name="whois_querying_server">Querying %1$s…</string>
     <string name="whois_raw_responses">Raw WHOIS Responses</string>
     <string name="whois_show_raw">Show raw response</string>

--- a/app/src/test/kotlin/net/aieat/netswissknife/app/ui/screens/whois/RelayChainGeometryTest.kt
+++ b/app/src/test/kotlin/net/aieat/netswissknife/app/ui/screens/whois/RelayChainGeometryTest.kt
@@ -1,0 +1,159 @@
+package net.aieat.netswissknife.app.ui.screens.whois
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+@DisplayName("RelayChainGeometry")
+class RelayChainGeometryTest {
+
+    private val tolerance = 0.001f
+
+    @Nested
+    @DisplayName("nodeCenterX")
+    inner class NodeCenterX {
+
+        @Test
+        @DisplayName("centres a single node in the middle of the canvas")
+        fun singleNode() {
+            assertEquals(50f, RelayChainGeometry.nodeCenterX(0, 1, 100f), tolerance)
+        }
+
+        @Test
+        @DisplayName("spaces node centres at cell midpoints")
+        fun evenlySpaced() {
+            assertEquals(25f, RelayChainGeometry.nodeCenterX(0, 4, 200f), tolerance)
+            assertEquals(75f, RelayChainGeometry.nodeCenterX(1, 4, 200f), tolerance)
+            assertEquals(125f, RelayChainGeometry.nodeCenterX(2, 4, 200f), tolerance)
+            assertEquals(175f, RelayChainGeometry.nodeCenterX(3, 4, 200f), tolerance)
+        }
+
+        @Test
+        @DisplayName("keeps the chain symmetric about the canvas centre")
+        fun symmetric() {
+            val width = 330f
+            val n = 5
+            val first = RelayChainGeometry.nodeCenterX(0, n, width)
+            val last = RelayChainGeometry.nodeCenterX(n - 1, n, width)
+            assertEquals(width, first + last, tolerance)
+        }
+
+        @Test
+        @DisplayName("returns zero centres for a zero-width canvas")
+        fun zeroWidth() {
+            assertEquals(0f, RelayChainGeometry.nodeCenterX(2, 3, 0f), tolerance)
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = [0, -1])
+        @DisplayName("rejects a non-positive node count")
+        fun rejectsNonPositiveCount(nodeCount: Int) {
+            assertThrows(IllegalArgumentException::class.java) {
+                RelayChainGeometry.nodeCenterX(0, nodeCount, 100f)
+            }
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = [-1, 3, 4])
+        @DisplayName("rejects an out-of-bounds index")
+        fun rejectsOutOfBoundsIndex(index: Int) {
+            assertThrows(IllegalArgumentException::class.java) {
+                RelayChainGeometry.nodeCenterX(index, 3, 100f)
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("connectorSegments")
+    inner class Segments {
+
+        @Test
+        @DisplayName("produces one fewer segment than nodes")
+        fun segmentCount() {
+            assertEquals(3, RelayChainGeometry.connectorSegments(4, 400f, 10f).size)
+        }
+
+        @Test
+        @DisplayName("joins node edges, not node centres")
+        fun joinsEdges() {
+            val segments = RelayChainGeometry.connectorSegments(2, 200f, 20f)
+            assertEquals(1, segments.size)
+            // Centres at 50 and 150; edges at 70 and 130.
+            assertEquals(70f, segments[0].startX, tolerance)
+            assertEquals(130f, segments[0].endX, tolerance)
+        }
+
+        @Test
+        @DisplayName("chains segments between successive node edges")
+        fun contiguousChain() {
+            // Cells of 100 => centres at 50, 150, 250; radius 10 trims each end.
+            val segments = RelayChainGeometry.connectorSegments(3, 300f, 10f)
+            assertEquals(listOf(60f, 160f), segments.map { it.startX })
+            assertEquals(listOf(140f, 240f), segments.map { it.endX })
+        }
+
+        @Test
+        @DisplayName("draws a full-width connector when the node radius is zero")
+        fun zeroRadius() {
+            val segments = RelayChainGeometry.connectorSegments(2, 200f, 0f)
+            assertEquals(1, segments.size)
+            assertEquals(50f, segments[0].startX, tolerance)
+            assertEquals(150f, segments[0].endX, tolerance)
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = [0, 1])
+        @DisplayName("returns nothing when there is no pair to join")
+        fun tooFewNodes(nodeCount: Int) {
+            assertTrue(RelayChainGeometry.connectorSegments(nodeCount, 200f, 10f).isEmpty())
+        }
+
+        @ParameterizedTest
+        @ValueSource(floats = [0f, -100f])
+        @DisplayName("returns nothing for a non-positive canvas width")
+        fun noWidth(width: Float) {
+            assertTrue(RelayChainGeometry.connectorSegments(3, width, 10f).isEmpty())
+        }
+
+        @Test
+        @DisplayName("returns nothing for a negative node radius")
+        fun negativeRadius() {
+            assertTrue(RelayChainGeometry.connectorSegments(3, 300f, -1f).isEmpty())
+        }
+
+        @Test
+        @DisplayName("omits segments when crowded nodes would render backwards")
+        fun crowdedNodes() {
+            // Cell width 20 => centres 20 apart, but radius 15 => edges overlap.
+            assertTrue(RelayChainGeometry.connectorSegments(5, 100f, 15f).isEmpty())
+        }
+
+        @Test
+        @DisplayName("omits a segment when node edges exactly touch")
+        fun touchingNodes() {
+            // Cell width 40 => centres 40 apart; radius 20 => edges meet at one point.
+            assertTrue(RelayChainGeometry.connectorSegments(5, 200f, 20f).isEmpty())
+        }
+    }
+
+    @Nested
+    @DisplayName("ConnectorSegment")
+    inner class Segment {
+
+        @Test
+        @DisplayName("compares by value")
+        fun valueSemantics() {
+            assertEquals(ConnectorSegment(1f, 2f), ConnectorSegment(1f, 2f))
+            assertEquals(ConnectorSegment(1f, 2f).hashCode(), ConnectorSegment(1f, 2f).hashCode())
+            assertTrue(ConnectorSegment(1f, 2f).toString().contains("1.0"))
+            assertEquals(3f, ConnectorSegment(1f, 2f).copy(startX = 3f).startX, tolerance)
+            assertEquals(1f, ConnectorSegment(1f, 2f).component1(), tolerance)
+            assertEquals(2f, ConnectorSegment(1f, 2f).component2(), tolerance)
+        }
+    }
+}

--- a/core-domain/build.gradle.kts
+++ b/core-domain/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kover)
 }
 
 java {

--- a/core-network/build.gradle.kts
+++ b/core-network/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kover)
 }
 
 java {

--- a/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/HostValidator.kt
+++ b/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/HostValidator.kt
@@ -1,10 +1,12 @@
 package net.aieat.netswissknife.core.network
 
-import java.net.Inet6Address
-import java.net.InetAddress
-
 /**
  * Utility for validating hostnames and IP addresses (IPv4 and IPv6).
+ *
+ * Every check here is a pure string parse. In particular [isValidIpv6] must not
+ * call `InetAddress.getByName`: that resolver falls back to a blocking DNS query
+ * for anything it cannot parse as a literal, and these validators are called
+ * from the UI thread while the user is still typing.
  */
 object HostValidator {
     private val ipv4Regex = Regex(
@@ -13,16 +15,73 @@ object HostValidator {
     private val hostnameRegex = Regex(
         """^[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)*$"""
     )
+    private val hextetRegex = Regex("""^[0-9a-fA-F]{1,4}$""")
+
+    /** Number of 16-bit groups in a full IPv6 address. */
+    private const val IPV6_GROUPS = 8
+
+    /** A trailing dotted-quad occupies the last two 16-bit groups. */
+    private const val IPV4_TAIL_GROUPS = 2
 
     fun isValidIpv4(address: String): Boolean = ipv4Regex.matches(address)
 
+    /**
+     * True for an IPv6 literal, optionally wrapped in brackets and optionally
+     * carrying a `%zone` suffix. Supports `::` zero-compression (at most once)
+     * and an IPv4-mapped tail such as `::ffff:192.168.0.1`.
+     */
     fun isValidIpv6(address: String): Boolean {
-        if (!address.contains(':')) return false
-        return try {
-            InetAddress.getByName(address) is Inet6Address
-        } catch (_: Exception) {
-            false
+        var text = address
+        if (text.startsWith("[") && text.endsWith("]")) {
+            if (text.length < 3) return false
+            text = text.substring(1, text.length - 1)
         }
+
+        val zoneStart = text.indexOf('%')
+        if (zoneStart >= 0) {
+            // A zone id must qualify a non-empty address and must not be empty.
+            if (zoneStart == 0 || zoneStart == text.length - 1) return false
+            text = text.substring(0, zoneStart)
+        }
+
+        if (!text.contains(':')) return false
+
+        val compressionStart = text.indexOf("::")
+        return if (compressionStart >= 0) {
+            // Only one run of "::" is allowed.
+            if (text.indexOf("::", compressionStart + 1) >= 0) return false
+            val head = text.substring(0, compressionStart)
+            val tail = text.substring(compressionStart + 2)
+            val headGroups = countGroups(head, allowIpv4Tail = false) ?: return false
+            val tailGroups = countGroups(tail, allowIpv4Tail = true) ?: return false
+            // "::" must stand in for at least one omitted group.
+            headGroups + tailGroups < IPV6_GROUPS
+        } else {
+            countGroups(text, allowIpv4Tail = true) == IPV6_GROUPS
+        }
+    }
+
+    /**
+     * Counts the 16-bit groups in a colon-separated run, or null if any part is
+     * not a valid hextet. An empty run contributes zero groups. When
+     * [allowIpv4Tail] is set, a trailing dotted-quad counts as two groups.
+     */
+    private fun countGroups(run: String, allowIpv4Tail: Boolean): Int? {
+        if (run.isEmpty()) return 0
+        val parts = run.split(':')
+        var groups = 0
+        parts.forEachIndexed { index, part ->
+            val isLast = index == parts.lastIndex
+            when {
+                isLast && allowIpv4Tail && part.contains('.') -> {
+                    if (!isValidIpv4(part)) return null
+                    groups += IPV4_TAIL_GROUPS
+                }
+                hextetRegex.matches(part) -> groups += 1
+                else -> return null
+            }
+        }
+        return groups
     }
 
     private val looksLikeIpv4 = Regex("""^\d+\.\d+\.\d+\.\d+$""")

--- a/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/wifi/WifiNetwork.kt
+++ b/core-network/src/main/kotlin/net/aieat/netswissknife/core/network/wifi/WifiNetwork.kt
@@ -13,6 +13,20 @@ data class WifiNetwork(
     /** All BSSIDs for this network, sorted strongest-first. */
     val accessPoints: List<WifiAccessPoint>
 ) {
+    /**
+     * Stable identity for list keys and per-row UI state.
+     *
+     * [WifiNetworkGrouper] emits one network per (SSID, security) pair, so that
+     * pair identifies a visible network and stays stable across rescans even as
+     * BSSIDs come and go. Hidden networks all share a blank SSID and are never
+     * grouped, so they are keyed by their single BSSID instead — without this
+     * they would collide, which both merges their expand state and makes them
+     * illegal duplicate keys in a lazy list.
+     */
+    val id: String get() =
+        if (ssid.isBlank()) "|hidden|${accessPoints.firstOrNull()?.bssid.orEmpty()}"
+        else "$ssid|${security.name}"
+
     /** Human-readable name. Hidden networks show last 8 chars of their BSSID. */
     val displaySsid: String get() = ssid.ifBlank {
         "<Hidden: ${accessPoints.first().bssid.takeLast(8)}>"

--- a/core-network/src/test/kotlin/net/aieat/netswissknife/core/network/HostValidatorTest.kt
+++ b/core-network/src/test/kotlin/net/aieat/netswissknife/core/network/HostValidatorTest.kt
@@ -84,5 +84,124 @@ class HostValidatorTest {
         fun `non-IPv6 strings are rejected`(address: String) {
             assertFalse(HostValidator.isValidIpv6(address))
         }
+
+        // ── Pure-parser behaviour ────────────────────────────────────────────
+        // isValidIpv6 used to delegate to InetAddress.getByName, which falls
+        // back to a blocking DNS query for anything it cannot parse. It is now
+        // a pure parse, so these cases pin its exact shape.
+
+        @ParameterizedTest(name = "{0} is a valid IPv6 address")
+        @ValueSource(
+            strings = [
+                "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+                "2001:db8:85a3:0:0:8a2e:370:7334",
+                "1:2:3:4:5:6:7:8",
+                "1::8",
+                "1::",
+                "::8",
+                "fe80::",
+                "0:0:0:0:0:0:0:1"
+            ]
+        )
+        fun `full and compressed forms are accepted`(address: String) {
+            assertTrue(HostValidator.isValidIpv6(address))
+        }
+
+        @ParameterizedTest(name = "{0} is a valid IPv4-mapped IPv6 address")
+        @ValueSource(
+            strings = [
+                "::ffff:192.168.0.1",
+                "::192.168.0.1",
+                "64:ff9b::192.0.2.33",
+                "0:0:0:0:0:ffff:192.168.0.1"
+            ]
+        )
+        fun `IPv4-mapped forms are accepted`(address: String) {
+            assertTrue(HostValidator.isValidIpv6(address))
+        }
+
+        @ParameterizedTest(name = "{0} has an invalid IPv4 tail")
+        @ValueSource(strings = ["::ffff:192.168.0.256", "::ffff:192.168.0", "::ffff:1.2.3.4.5"])
+        fun `malformed IPv4 tails are rejected`(address: String) {
+            assertFalse(HostValidator.isValidIpv6(address))
+        }
+
+        @Test
+        fun `an IPv4 tail is only allowed in the last group`() {
+            assertFalse(HostValidator.isValidIpv6("192.168.0.1::1"))
+        }
+
+        @ParameterizedTest(name = "{0} is bracketed")
+        @ValueSource(strings = ["[::1]", "[2001:db8::1]", "[::ffff:192.168.0.1]"])
+        fun `bracketed literals are accepted`(address: String) {
+            assertTrue(HostValidator.isValidIpv6(address))
+        }
+
+        @ParameterizedTest(name = "{0} has unbalanced or empty brackets")
+        @ValueSource(strings = ["[]", "[::1", "::1]"])
+        fun `malformed brackets are rejected`(address: String) {
+            assertFalse(HostValidator.isValidIpv6(address))
+        }
+
+        @ParameterizedTest(name = "{0} carries a zone id")
+        @ValueSource(strings = ["fe80::1%eth0", "fe80::1%1", "[fe80::1%wlan0]"])
+        fun `zone ids are accepted`(address: String) {
+            assertTrue(HostValidator.isValidIpv6(address))
+        }
+
+        @ParameterizedTest(name = "{0} has a malformed zone id")
+        @ValueSource(strings = ["fe80::1%", "%eth0"])
+        fun `malformed zone ids are rejected`(address: String) {
+            assertFalse(HostValidator.isValidIpv6(address))
+        }
+
+        @ParameterizedTest(name = "{0} has too many or too few groups")
+        @ValueSource(
+            strings = [
+                "1:2:3:4:5:6:7",
+                "1:2:3:4:5:6:7:8:9",
+                "1:2:3:4:5:6:7::8",
+                "1:2:3:4:5:6:7:8::"
+            ]
+        )
+        fun `wrong group counts are rejected`(address: String) {
+            assertFalse(HostValidator.isValidIpv6(address))
+        }
+
+        @ParameterizedTest(name = "{0} has more than one compression run")
+        @ValueSource(strings = ["1::2::3", "::1::", ":::1", "1:::2"])
+        fun `multiple compression runs are rejected`(address: String) {
+            assertFalse(HostValidator.isValidIpv6(address))
+        }
+
+        @ParameterizedTest(name = "{0} has a malformed hextet")
+        @ValueSource(strings = ["12345::1", "2001:db8::xyz", "1:2:3:4:5:6:7:zz", "::-1"])
+        fun `malformed hextets are rejected`(address: String) {
+            assertFalse(HostValidator.isValidIpv6(address))
+        }
+
+        @ParameterizedTest(name = "{0} has a dangling colon")
+        @ValueSource(strings = [":1:2:3:4:5:6:7:8", "1:2:3:4:5:6:7:8:", ":", "1:"])
+        fun `dangling colons are rejected`(address: String) {
+            assertFalse(HostValidator.isValidIpv6(address))
+        }
+
+        @Test
+        fun `the all-zeros address is accepted`() {
+            assertTrue(HostValidator.isValidIpv6("::"))
+        }
+
+        @Test
+        fun `hex digits are accepted in either case`() {
+            assertTrue(HostValidator.isValidIpv6("2001:DB8:ABCD::1"))
+            assertTrue(HostValidator.isValidIpv6("2001:db8:abcd::1"))
+        }
+
+        @Test
+        fun `resolvable hostnames containing a colon are not IPv6`() {
+            // The old getByName-backed check would have issued a DNS query here.
+            assertFalse(HostValidator.isValidIpv6("example.com:80"))
+            assertFalse(HostValidator.isValidIpv6("localhost:8080"))
+        }
     }
 }

--- a/core-network/src/test/kotlin/net/aieat/netswissknife/core/network/httprobe/HttpProbeRepositoryTest.kt
+++ b/core-network/src/test/kotlin/net/aieat/netswissknife/core/network/httprobe/HttpProbeRepositoryTest.kt
@@ -5,9 +5,12 @@ import kotlinx.coroutines.test.runTest
 import net.aieat.netswissknife.core.network.NetworkResult
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 import java.net.InetSocketAddress
 
 @DisplayName("HttpProbeRepositoryImpl – input validation")
@@ -164,6 +167,153 @@ class HttpSecurityAnalyzerTest {
         val checks = HttpSecurityAnalyzer.analyze(emptyMap(), isHttps = true)
         assertTrue(checks.size >= 5)
     }
+
+    // ── Previously uncovered branches ────────────────────────────────────────
+
+    @Test
+    @DisplayName("analyze reports the same seven checks in a stable order")
+    fun `analyze reports the seven checks in order`() {
+        val checks = HttpSecurityAnalyzer.analyze(emptyMap(), isHttps = true)
+        assertEquals(
+            listOf(
+                "Strict-Transport-Security",
+                "Content-Security-Policy",
+                "X-Frame-Options",
+                "X-Content-Type-Options",
+                "Referrer-Policy",
+                "Permissions-Policy",
+                "Server"
+            ),
+            checks.map { it.headerName }
+        )
+    }
+
+    @Test
+    @DisplayName("analyze matches header names case-insensitively")
+    fun `analyze matches header names case-insensitively`() {
+        val headers = mapOf("CONTENT-security-Policy" to listOf("default-src 'self'"))
+        val check = HttpSecurityAnalyzer.analyze(headers, isHttps = true)
+            .first { it.headerName == "Content-Security-Policy" }
+        assertEquals(SecurityRating.PASS, check.rating)
+    }
+
+    @Test
+    @DisplayName("analyze treats a blank header value as absent")
+    fun `analyze treats a blank header value as absent`() {
+        val headers = mapOf("Content-Security-Policy" to listOf("   "))
+        val check = HttpSecurityAnalyzer.analyze(headers, isHttps = true)
+            .first { it.headerName == "Content-Security-Policy" }
+        assertNull(check.value)
+        assertEquals(SecurityRating.WARN, check.rating)
+    }
+
+    @Test
+    @DisplayName("analyze treats an empty value list as absent")
+    fun `analyze treats an empty value list as absent`() {
+        val headers = mapOf("Content-Security-Policy" to emptyList<String>())
+        val check = HttpSecurityAnalyzer.analyze(headers, isHttps = true)
+            .first { it.headerName == "Content-Security-Policy" }
+        assertNull(check.value)
+    }
+
+    @Test
+    @DisplayName("analyze uses the first value when a header repeats")
+    fun `analyze uses the first value when a header repeats`() {
+        val headers = mapOf("Server" to listOf("nginx", "apache"))
+        val check = HttpSecurityAnalyzer.analyze(headers, isHttps = true)
+            .first { it.headerName == "Server" }
+        assertEquals("nginx", check.value)
+    }
+
+    @Test
+    @DisplayName("HSTS present on plain HTTP still gets PASS")
+    fun `HSTS present on plain HTTP still gets PASS`() {
+        val headers = mapOf("Strict-Transport-Security" to listOf("max-age=1"))
+        val check = HttpSecurityAnalyzer.analyze(headers, isHttps = false)
+            .first { it.headerName == "Strict-Transport-Security" }
+        assertEquals(SecurityRating.PASS, check.rating)
+    }
+
+    @Test
+    @DisplayName("HSTS absent on plain HTTP gets INFO, not FAIL")
+    fun `HSTS absent on plain HTTP gets INFO`() {
+        val check = HttpSecurityAnalyzer.analyze(emptyMap(), isHttps = false)
+            .first { it.headerName == "Strict-Transport-Security" }
+        assertEquals(SecurityRating.INFO, check.rating)
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        strings = [
+            "no-referrer",
+            "no-referrer-when-downgrade",
+            "strict-origin",
+            "strict-origin-when-cross-origin",
+            "same-origin",
+            "STRICT-ORIGIN"
+        ]
+    )
+    @DisplayName("privacy-preserving Referrer-Policy gets PASS")
+    fun `privacy preserving referrer policy gets PASS`(value: String) {
+        val headers = mapOf("Referrer-Policy" to listOf(value))
+        val check = HttpSecurityAnalyzer.analyze(headers, isHttps = true)
+            .first { it.headerName == "Referrer-Policy" }
+        assertEquals(SecurityRating.PASS, check.rating)
+    }
+
+    @Test
+    @DisplayName("leaky Referrer-Policy gets WARN and names the value")
+    fun `leaky referrer policy gets WARN`() {
+        val headers = mapOf("Referrer-Policy" to listOf("unsafe-url"))
+        val check = HttpSecurityAnalyzer.analyze(headers, isHttps = true)
+            .first { it.headerName == "Referrer-Policy" }
+        assertEquals(SecurityRating.WARN, check.rating)
+        assertTrue(check.description.contains("unsafe-url"))
+    }
+
+    @Test
+    @DisplayName("absent Referrer-Policy gets WARN")
+    fun `absent referrer policy gets WARN`() {
+        val check = HttpSecurityAnalyzer.analyze(emptyMap(), isHttps = true)
+            .first { it.headerName == "Referrer-Policy" }
+        assertEquals(SecurityRating.WARN, check.rating)
+    }
+
+    @Test
+    @DisplayName("Permissions-Policy present gets PASS")
+    fun `permissions policy present gets PASS`() {
+        val headers = mapOf("Permissions-Policy" to listOf("camera=()"))
+        val check = HttpSecurityAnalyzer.analyze(headers, isHttps = true)
+            .first { it.headerName == "Permissions-Policy" }
+        assertEquals(SecurityRating.PASS, check.rating)
+    }
+
+    @Test
+    @DisplayName("absent Permissions-Policy gets WARN")
+    fun `absent permissions policy gets WARN`() {
+        val check = HttpSecurityAnalyzer.analyze(emptyMap(), isHttps = true)
+            .first { it.headerName == "Permissions-Policy" }
+        assertEquals(SecurityRating.WARN, check.rating)
+    }
+
+    @Test
+    @DisplayName("X-Frame-Options with a non-protective value gets WARN and names it")
+    fun `non protective x frame options gets WARN`() {
+        val headers = mapOf("X-Frame-Options" to listOf("ALLOW-FROM https://example.com"))
+        val check = HttpSecurityAnalyzer.analyze(headers, isHttps = true)
+            .first { it.headerName == "X-Frame-Options" }
+        assertEquals(SecurityRating.WARN, check.rating)
+        assertTrue(check.description.contains("ALLOW-FROM https://example.com"))
+    }
+
+    @Test
+    @DisplayName("every check carries a non-blank description")
+    fun `every check carries a non-blank description`() {
+        HttpSecurityAnalyzer.analyze(emptyMap(), isHttps = false).forEach {
+            assertTrue(it.description.isNotBlank(), "${it.headerName} has a blank description")
+        }
+    }
+
 }
 
 @DisplayName("HttpMethod – body support")

--- a/core-network/src/test/kotlin/net/aieat/netswissknife/core/network/portscan/WellKnownPortsTest.kt
+++ b/core-network/src/test/kotlin/net/aieat/netswissknife/core/network/portscan/WellKnownPortsTest.kt
@@ -1,0 +1,155 @@
+package net.aieat.netswissknife.core.network.portscan
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.ValueSource
+
+@DisplayName("WellKnownPorts")
+class WellKnownPortsTest {
+
+    @Nested
+    @DisplayName("getInfo")
+    inner class GetInfo {
+
+        @ParameterizedTest
+        @CsvSource(
+            "22, SSH",
+            "80, HTTP",
+            "443, HTTPS",
+            "3306, MySQL"
+        )
+        @DisplayName("resolves registered ports to their service name")
+        fun resolvesKnownPorts(port: Int, serviceName: String) {
+            assertEquals(serviceName, WellKnownPorts.getInfo(port)?.serviceName)
+        }
+
+        @Test
+        @DisplayName("defaults the protocol to TCP")
+        fun defaultsToTcp() {
+            assertEquals("TCP", WellKnownPorts.getInfo(22)?.protocol)
+        }
+
+        @Test
+        @DisplayName("marks datagram services as UDP")
+        fun udpServices() {
+            assertEquals("UDP", WellKnownPorts.getInfo(161)?.protocol)
+            assertEquals("UDP", WellKnownPorts.getInfo(123)?.protocol)
+        }
+
+        @Test
+        @DisplayName("gives every registered port a non-blank description")
+        fun descriptionsPresent() {
+            (0..65535).mapNotNull { WellKnownPorts.getInfo(it) }.forEach {
+                assertTrue(it.serviceName.isNotBlank())
+                assertTrue(it.description.isNotBlank())
+                assertTrue(it.protocol.isNotBlank())
+            }
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = [0, 7777, 65535, -1])
+        @DisplayName("returns null for unregistered ports")
+        fun unknownPorts(port: Int) {
+            assertNull(WellKnownPorts.getInfo(port))
+        }
+    }
+
+    @Nested
+    @DisplayName("getServiceName")
+    inner class GetServiceName {
+
+        @Test
+        @DisplayName("prefers the registered name over the range label")
+        fun prefersRegisteredName() {
+            assertEquals("SSH", WellKnownPorts.getServiceName(22))
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = [1, 1023])
+        @DisplayName("labels unregistered system ports as Well-known")
+        fun wellKnownRange(port: Int) {
+            assertEquals("Well-known", WellKnownPorts.getServiceName(port))
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = [1024, 49151])
+        @DisplayName("labels unregistered user ports as Registered")
+        fun registeredRange(port: Int) {
+            assertEquals("Registered", WellKnownPorts.getServiceName(port))
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = [0, 49152, 65535])
+        @DisplayName("labels everything else as Dynamic/Private")
+        fun dynamicRange(port: Int) {
+            assertEquals("Dynamic/Private", WellKnownPorts.getServiceName(port))
+        }
+
+        @Test
+        @DisplayName("never returns a blank label for any valid port")
+        fun neverBlank() {
+            (0..65535).forEach {
+                assertTrue(WellKnownPorts.getServiceName(it).isNotBlank(), "blank label for port $it")
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("presets")
+    inner class Presets {
+
+        private val presets: Map<String, List<Int>> = mapOf(
+            "COMMON_PORTS" to WellKnownPorts.COMMON_PORTS,
+            "WEB_PORTS" to WellKnownPorts.WEB_PORTS,
+            "DATABASE_PORTS" to WellKnownPorts.DATABASE_PORTS,
+            "MAIL_PORTS" to WellKnownPorts.MAIL_PORTS,
+            "REMOTE_ACCESS_PORTS" to WellKnownPorts.REMOTE_ACCESS_PORTS
+        )
+
+        @Test
+        @DisplayName("hold only valid, non-duplicated port numbers")
+        fun validAndUnique() {
+            presets.forEach { (name, ports) ->
+                assertTrue(ports.isNotEmpty(), "$name is empty")
+                assertTrue(ports.all { it in 1..65535 }, "$name has an out-of-range port")
+                assertEquals(ports.size, ports.toSet().size, "$name has duplicates")
+            }
+        }
+
+        @Test
+        @DisplayName("cover the services each preset advertises")
+        fun coverExpectedServices() {
+            assertTrue(WellKnownPorts.COMMON_PORTS.containsAll(listOf(22, 80, 443)))
+            assertTrue(WellKnownPorts.WEB_PORTS.containsAll(listOf(80, 443, 8080)))
+            assertTrue(WellKnownPorts.DATABASE_PORTS.containsAll(listOf(3306, 5432, 27017)))
+            assertTrue(WellKnownPorts.MAIL_PORTS.containsAll(listOf(25, 143, 993)))
+            assertTrue(WellKnownPorts.REMOTE_ACCESS_PORTS.containsAll(listOf(22, 3389, 5900)))
+        }
+    }
+
+    @Nested
+    @DisplayName("PortInfo")
+    inner class PortInfoValue {
+
+        @Test
+        @DisplayName("compares by value")
+        fun valueSemantics() {
+            val a = PortInfo("SSH", "Secure Shell")
+            assertEquals(a, PortInfo("SSH", "Secure Shell", "TCP"))
+            assertEquals(a.hashCode(), PortInfo("SSH", "Secure Shell").hashCode())
+            assertTrue(a.toString().contains("SSH"))
+            assertEquals("UDP", a.copy(protocol = "UDP").protocol)
+            assertEquals("SSH", a.component1())
+            assertEquals("Secure Shell", a.component2())
+            assertEquals("TCP", a.component3())
+            assertNotNull(a)
+        }
+    }
+}

--- a/core-network/src/test/kotlin/net/aieat/netswissknife/core/network/topology/TopologyParamsValidatorTest.kt
+++ b/core-network/src/test/kotlin/net/aieat/netswissknife/core/network/topology/TopologyParamsValidatorTest.kt
@@ -1,0 +1,172 @@
+package net.aieat.netswissknife.core.network.topology
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import org.junit.jupiter.params.provider.ValueSource
+
+@DisplayName("TopologyParamsValidator")
+class TopologyParamsValidatorTest {
+
+    private val invalidIpError = "Target IP must be a valid IPv4 address"
+    private val blankIpError = "Target IP must not be blank"
+    private val communityError = "Community string must not be blank for SNMP v1/v2c"
+    private val usernameError = "Username must not be blank for SNMP v3"
+
+    private fun validate(
+        targetIp: String = "192.168.1.1",
+        version: SnmpVersion = SnmpVersion.V2C,
+        community: String = "public",
+        username: String? = null
+    ) = TopologyParamsValidator.validate(
+        TopologyParams(
+            targetIp = targetIp,
+            snmpVersion = version,
+            communityString = community,
+            v3Username = username
+        )
+    )
+
+    @Nested
+    @DisplayName("target IP")
+    inner class TargetIp {
+
+        @ParameterizedTest
+        @ValueSource(strings = ["192.168.1.1", "0.0.0.0", "255.255.255.255", "8.8.8.8"])
+        @DisplayName("accepts well-formed IPv4 addresses")
+        fun acceptsValid(ip: String) {
+            val result = validate(targetIp = ip)
+            assertTrue(result.isValid, "expected $ip to be accepted: ${result.errors}")
+            assertTrue(result.errors.isEmpty())
+        }
+
+        @Test
+        @DisplayName("trims surrounding whitespace before validating")
+        fun trimsWhitespace() {
+            assertTrue(validate(targetIp = "  10.0.0.1  ").isValid)
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = ["", "   ", "\t"])
+        @DisplayName("rejects a blank target as blank, not malformed")
+        fun rejectsBlank(ip: String) {
+            val result = validate(targetIp = ip)
+            assertFalse(result.isValid)
+            assertEquals(listOf(blankIpError), result.errors)
+        }
+
+        @ParameterizedTest
+        @ValueSource(
+            strings = [
+                "192.168.1",
+                "192.168.1.1.1",
+                "192.168.1.a",
+                "router.local",
+                "1234.1.1.1",
+                "::1",
+                "192.168.1.-1"
+            ]
+        )
+        @DisplayName("rejects malformed addresses")
+        fun rejectsMalformed(ip: String) {
+            val result = validate(targetIp = ip)
+            assertFalse(result.isValid, "expected $ip to be rejected")
+            assertEquals(listOf(invalidIpError), result.errors)
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = ["256.1.1.1", "1.256.1.1", "1.1.256.1", "1.1.1.256", "999.999.999.999"])
+        @DisplayName("rejects octets above 255 even when the shape is right")
+        fun rejectsOutOfRangeOctets(ip: String) {
+            val result = validate(targetIp = ip)
+            assertFalse(result.isValid, "expected $ip to be rejected")
+            assertEquals(listOf(invalidIpError), result.errors)
+        }
+    }
+
+    @Nested
+    @DisplayName("SNMP credentials")
+    inner class Credentials {
+
+        @ParameterizedTest
+        @EnumSource(value = SnmpVersion::class, names = ["V1", "V2C"])
+        @DisplayName("requires a community string for v1 and v2c")
+        fun requiresCommunity(version: SnmpVersion) {
+            val result = validate(version = version, community = " ")
+            assertFalse(result.isValid)
+            assertEquals(listOf(communityError), result.errors)
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = SnmpVersion::class, names = ["V1", "V2C"])
+        @DisplayName("accepts a non-blank community string for v1 and v2c")
+        fun acceptsCommunity(version: SnmpVersion) {
+            assertTrue(validate(version = version, community = "private").isValid)
+        }
+
+        @Test
+        @DisplayName("ignores a blank community string for v3")
+        fun v3IgnoresCommunity() {
+            assertTrue(validate(version = SnmpVersion.V3, community = "", username = "admin").isValid)
+        }
+
+        @Test
+        @DisplayName("requires a username for v3 when it is null")
+        fun v3RequiresUsernameNotNull() {
+            val result = validate(version = SnmpVersion.V3, username = null)
+            assertFalse(result.isValid)
+            assertEquals(listOf(usernameError), result.errors)
+        }
+
+        @Test
+        @DisplayName("requires a username for v3 when it is blank")
+        fun v3RequiresUsernameNotBlank() {
+            val result = validate(version = SnmpVersion.V3, username = "  ")
+            assertFalse(result.isValid)
+            assertEquals(listOf(usernameError), result.errors)
+        }
+    }
+
+    @Nested
+    @DisplayName("error aggregation")
+    inner class Aggregation {
+
+        @Test
+        @DisplayName("reports every problem rather than stopping at the first")
+        fun reportsAllErrors() {
+            val result = validate(targetIp = "", version = SnmpVersion.V2C, community = "")
+            assertFalse(result.isValid)
+            assertEquals(listOf(blankIpError, communityError), result.errors)
+        }
+
+        @Test
+        @DisplayName("combines a malformed IP with a missing v3 username")
+        fun malformedIpAndMissingUsername() {
+            val result = validate(targetIp = "nope", version = SnmpVersion.V3, username = "")
+            assertEquals(listOf(invalidIpError, usernameError), result.errors)
+        }
+    }
+
+    @Nested
+    @DisplayName("ValidationResult")
+    inner class Result {
+
+        @Test
+        @DisplayName("compares by value")
+        fun valueSemantics() {
+            val a = ValidationResult(isValid = true, errors = emptyList())
+            val b = ValidationResult(isValid = true, errors = emptyList())
+            assertEquals(a, b)
+            assertEquals(a.hashCode(), b.hashCode())
+            assertTrue(a.toString().contains("isValid=true"))
+            assertFalse(a.copy(isValid = false).isValid)
+            assertTrue(a.component1())
+            assertTrue(a.component2().isEmpty())
+        }
+    }
+}

--- a/core-network/src/test/kotlin/net/aieat/netswissknife/core/network/wifi/WifiChannelInfoTest.kt
+++ b/core-network/src/test/kotlin/net/aieat/netswissknife/core/network/wifi/WifiChannelInfoTest.kt
@@ -1,0 +1,53 @@
+package net.aieat.netswissknife.core.network.wifi
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+
+@DisplayName("WifiChannelInfo")
+class WifiChannelInfoTest {
+
+    private fun channelInfo(score: Float) = WifiChannelInfo(
+        channel = 6,
+        frequencyMhz = 2437,
+        band = WifiBand.BAND_2_4GHZ,
+        accessPointCount = 3,
+        congestionScore = score,
+        accessPoints = emptyList()
+    )
+
+    @ParameterizedTest
+    @CsvSource(
+        "1.0, Very Busy",
+        "0.75, Very Busy",
+        "0.74, Busy",
+        "0.5, Busy",
+        "0.49, Moderate",
+        "0.25, Moderate",
+        "0.24, Clear",
+        "0.0, Clear"
+    )
+    @DisplayName("labels congestion at each band boundary")
+    fun congestionLabel(score: Float, expected: String) {
+        assertEquals(expected, channelInfo(score).congestionLabel)
+    }
+
+    @Test
+    @DisplayName("compares by value")
+    fun valueSemantics() {
+        val a = channelInfo(0.5f)
+        assertEquals(a, channelInfo(0.5f))
+        assertEquals(a.hashCode(), channelInfo(0.5f).hashCode())
+        assertTrue(a.toString().contains("channel=6"))
+        assertEquals(11, a.copy(channel = 11).channel)
+        assertEquals(6, a.component1())
+        assertEquals(2437, a.component2())
+        assertEquals(WifiBand.BAND_2_4GHZ, a.component3())
+        assertEquals(3, a.component4())
+        assertEquals(0.5f, a.component5())
+        assertTrue(a.component6().isEmpty())
+    }
+}

--- a/core-network/src/test/kotlin/net/aieat/netswissknife/core/network/wifi/WifiNetworkTest.kt
+++ b/core-network/src/test/kotlin/net/aieat/netswissknife/core/network/wifi/WifiNetworkTest.kt
@@ -1,0 +1,278 @@
+package net.aieat.netswissknife.core.network.wifi
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("WifiNetwork")
+class WifiNetworkTest {
+
+    private fun accessPoint(
+        ssid: String = "HomeNet",
+        bssid: String = "AA:BB:CC:DD:EE:FF",
+        rssi: Int = -55,
+        band: WifiBand = WifiBand.BAND_2_4GHZ,
+        isConnected: Boolean = false
+    ) = WifiAccessPoint(
+        ssid = ssid,
+        bssid = bssid,
+        rssi = rssi,
+        frequency = band.minFrequencyMhz + 37,
+        channelWidthMhz = 20,
+        capabilities = "[WPA2-PSK-CCMP][ESS]",
+        channel = 6,
+        band = band,
+        standard = WifiStandard.entries.first(),
+        security = WifiSecurity.entries.first(),
+        isConnected = isConnected,
+        vendor = "Acme",
+        centerFrequency0 = 0,
+        centerFrequency1 = 0,
+        timestampUs = 0L
+    )
+
+    private fun network(
+        ssid: String = "HomeNet",
+        security: WifiSecurity = WifiSecurity.entries.first(),
+        accessPoints: List<WifiAccessPoint> = listOf(accessPoint())
+    ) = WifiNetwork(ssid = ssid, security = security, accessPoints = accessPoints)
+
+    @Nested
+    @DisplayName("displaySsid")
+    inner class DisplaySsid {
+
+        @Test
+        @DisplayName("uses the SSID when it is set")
+        fun namedNetwork() {
+            assertEquals("HomeNet", network().displaySsid)
+        }
+
+        @Test
+        @DisplayName("falls back to the BSSID tail for a hidden network")
+        fun hiddenNetwork() {
+            val hidden = network(
+                ssid = "",
+                accessPoints = listOf(accessPoint(ssid = "", bssid = "AA:BB:CC:DD:EE:FF"))
+            )
+            assertEquals("<Hidden: DD:EE:FF>", hidden.displaySsid)
+        }
+    }
+
+    @Nested
+    @DisplayName("signal aggregation")
+    inner class SignalAggregation {
+
+        private val multiBand = network(
+            accessPoints = listOf(
+                accessPoint(rssi = -75, band = WifiBand.BAND_2_4GHZ),
+                accessPoint(rssi = -45, band = WifiBand.BAND_5GHZ, bssid = "11:22:33:44:55:66"),
+                accessPoint(rssi = -85, band = WifiBand.BAND_5GHZ, bssid = "77:88:99:AA:BB:CC")
+            )
+        )
+
+        @Test
+        @DisplayName("reports the strongest RSSI across BSSIDs")
+        fun bestRssi() {
+            assertEquals(-45, multiBand.bestRssi)
+        }
+
+        @Test
+        @DisplayName("reports the best signal quality across BSSIDs")
+        fun signalQuality() {
+            assertEquals(100, multiBand.signalQualityPercent)
+        }
+
+        @Test
+        @DisplayName("reports the best signal level across BSSIDs")
+        fun signalLevel() {
+            assertEquals(SignalLevel.EXCELLENT, multiBand.signalLevel)
+        }
+
+        @Test
+        @DisplayName("falls back to POOR when there are no access points")
+        fun emptyFallsBackToPoor() {
+            assertEquals(SignalLevel.POOR, network(accessPoints = emptyList()).signalLevel)
+        }
+
+        @Test
+        @DisplayName("counts its BSSIDs")
+        fun bssidCount() {
+            assertEquals(3, multiBand.bssidCount)
+            assertEquals(1, network().bssidCount)
+        }
+    }
+
+    @Nested
+    @DisplayName("bands")
+    inner class Bands {
+
+        @Test
+        @DisplayName("deduplicates the bands its BSSIDs serve")
+        fun deduplicates() {
+            val net = network(
+                accessPoints = listOf(
+                    accessPoint(band = WifiBand.BAND_5GHZ),
+                    accessPoint(band = WifiBand.BAND_5GHZ, bssid = "11:22:33:44:55:66"),
+                    accessPoint(band = WifiBand.BAND_2_4GHZ, bssid = "77:88:99:AA:BB:CC")
+                )
+            )
+            assertEquals(setOf(WifiBand.BAND_5GHZ, WifiBand.BAND_2_4GHZ), net.bands)
+        }
+
+        @Test
+        @DisplayName("sorts from lowest to highest frequency regardless of scan order")
+        fun sortedLowToHigh() {
+            val net = network(
+                accessPoints = listOf(
+                    accessPoint(band = WifiBand.BAND_6GHZ),
+                    accessPoint(band = WifiBand.BAND_2_4GHZ, bssid = "11:22:33:44:55:66"),
+                    accessPoint(band = WifiBand.BAND_5GHZ, bssid = "77:88:99:AA:BB:CC")
+                )
+            )
+            assertEquals(
+                listOf(WifiBand.BAND_2_4GHZ, WifiBand.BAND_5GHZ, WifiBand.BAND_6GHZ),
+                net.sortedBands
+            )
+        }
+
+        @Test
+        @DisplayName("reports no bands when there are no access points")
+        fun emptyNetwork() {
+            val net = network(accessPoints = emptyList())
+            assertTrue(net.bands.isEmpty())
+            assertTrue(net.sortedBands.isEmpty())
+        }
+    }
+
+    @Nested
+    @DisplayName("isConnected")
+    inner class Connected {
+
+        @Test
+        @DisplayName("is true when any BSSID is the associated one")
+        fun anyConnected() {
+            val net = network(
+                accessPoints = listOf(
+                    accessPoint(isConnected = false),
+                    accessPoint(isConnected = true, bssid = "11:22:33:44:55:66")
+                )
+            )
+            assertTrue(net.isConnected)
+        }
+
+        @Test
+        @DisplayName("is false when no BSSID is associated")
+        fun noneConnected() {
+            assertFalse(network().isConnected)
+        }
+    }
+
+    @Nested
+    @DisplayName("colorIndex")
+    inner class ColorIndex {
+
+        @Test
+        @DisplayName("stays inside the palette for a wide range of names")
+        fun withinPalette() {
+            (0..500).forEach { i ->
+                val index = network(ssid = "net-$i").colorIndex
+                assertTrue(
+                    index in 0 until WifiNetwork.PALETTE_SIZE,
+                    "colorIndex $index out of palette range for net-$i"
+                )
+            }
+        }
+
+        @Test
+        @DisplayName("is stable across rescans of the same SSID and security pair")
+        fun stableAcrossScans() {
+            val first = network(accessPoints = listOf(accessPoint(rssi = -40)))
+            val second = network(accessPoints = listOf(accessPoint(rssi = -90, bssid = "00:00:00:00:00:01")))
+            assertEquals(first.colorIndex, second.colorIndex)
+        }
+
+        @Test
+        @DisplayName("stays within the palette for a blank SSID")
+        fun blankSsid() {
+            assertTrue(network(ssid = "").colorIndex in 0 until WifiNetwork.PALETTE_SIZE)
+        }
+    }
+
+    @Nested
+    @DisplayName("id")
+    inner class Id {
+
+        @Test
+        @DisplayName("identifies a visible network by SSID and security")
+        fun visibleNetwork() {
+            assertEquals("HomeNet|${WifiSecurity.entries.first().name}", network().id)
+        }
+
+        @Test
+        @DisplayName("stays stable for a visible network when its BSSIDs change")
+        fun stableAcrossRescans() {
+            val first = network(accessPoints = listOf(accessPoint(bssid = "AA:AA:AA:AA:AA:AA")))
+            val second = network(
+                accessPoints = listOf(
+                    accessPoint(bssid = "BB:BB:BB:BB:BB:BB"),
+                    accessPoint(bssid = "CC:CC:CC:CC:CC:CC")
+                )
+            )
+            assertEquals(first.id, second.id)
+        }
+
+        @Test
+        @DisplayName("distinguishes two hidden networks by BSSID")
+        fun hiddenNetworksAreDistinct() {
+            val first = network(ssid = "", accessPoints = listOf(accessPoint(ssid = "", bssid = "AA:AA:AA:AA:AA:AA")))
+            val second = network(ssid = "", accessPoints = listOf(accessPoint(ssid = "", bssid = "BB:BB:BB:BB:BB:BB")))
+            assertNotEquals(first.id, second.id)
+        }
+
+        @Test
+        @DisplayName("does not collide with a visible network whose SSID looks like the hidden prefix")
+        fun noCollisionWithVisibleNetwork() {
+            val hidden = network(ssid = "", accessPoints = listOf(accessPoint(ssid = "", bssid = "AA:AA:AA:AA:AA:AA")))
+            val visible = network(ssid = "hidden")
+            assertNotEquals(hidden.id, visible.id)
+        }
+
+        @Test
+        @DisplayName("is defined for a hidden network with no access points")
+        fun hiddenWithNoAccessPoints() {
+            assertEquals("|hidden|", network(ssid = "", accessPoints = emptyList()).id)
+        }
+
+        @Test
+        @DisplayName("is unique across a realistic grouped scan")
+        fun uniqueAcrossGroupedScan() {
+            val scanned = listOf(
+                accessPoint(ssid = "HomeNet", bssid = "AA:AA:AA:AA:AA:AA"),
+                accessPoint(ssid = "HomeNet", bssid = "AA:AA:AA:AA:AA:AB", band = WifiBand.BAND_5GHZ),
+                accessPoint(ssid = "Cafe", bssid = "BB:BB:BB:BB:BB:BB"),
+                accessPoint(ssid = "", bssid = "CC:CC:CC:CC:CC:C1"),
+                accessPoint(ssid = "", bssid = "CC:CC:CC:CC:CC:C2"),
+                accessPoint(ssid = "", bssid = "CC:CC:CC:CC:CC:C3")
+            )
+            val ids = WifiNetworkGrouper.group(scanned).map { it.id }
+            assertEquals(ids.size, ids.toSet().size, "duplicate list keys: $ids")
+        }
+    }
+
+    @Test
+    @DisplayName("compares by value")
+    fun valueSemantics() {
+        val a = network()
+        assertEquals(a, network())
+        assertEquals(a.hashCode(), network().hashCode())
+        assertTrue(a.toString().contains("HomeNet"))
+        assertEquals("Other", a.copy(ssid = "Other").ssid)
+        assertEquals("HomeNet", a.component1())
+        assertEquals(WifiSecurity.entries.first(), a.component2())
+        assertEquals(1, a.component3().size)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ snmp4j = "3.12.2"
 icmpenguin = "1.0.0-rc.4"
 kotlin = "2.4.10"
 ksp = "2.3.10"
+kover = "0.9.9"
 composeBom = "2026.06.01"
 navigationCompose = "2.9.8"
 hilt = "2.60.1"
@@ -64,3 +65,4 @@ kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
+kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }


### PR DESCRIPTION
## Summary

Fixes the misaligned connector line between WHOIS query-chain stages, removes a blocking DNS call reachable from the UI thread, and adds coverage tooling with a 100% gate on the new pure logic. Also reviews the app against Google Play's technical quality requirements.

## WHOIS chain alignment — two independent bugs

- **Vertical (the visible symptom):** the connector canvas drew at `size.height / 2`, but each node's circle sits at the *top* of a variable-height `Column`. As per-hop `"N ms"` labels appeared during a scan the columns grew, so the line drifted downwards mid-scan.
- **Horizontal:** the node `Row` carried `padding(horizontal = 4.dp)` that the canvas never accounted for, plus a redundant `SpaceEvenly` + `weight(1f)` combination.

Split the visualiser into a fixed-height circle row with connectors drawn behind it and a separate label row, so `size.height / 2` is exactly correct by construction. Position maths moved into a pure `RelayChainGeometry`. Also replaced a hardcoded `Color.Gray` with `outlineVariant` per the theming rules in CLAUDE.md.

## Main-thread DNS in host validation

`HostValidator.isValidIpv6` delegated to `InetAddress.getByName`, which falls back to a **blocking DNS query** for input it cannot parse as a literal. `DnsScreen.kt:483` calls this from a composable while the user is typing, so a malformed host could stall the main thread — an ANR risk that counts against Play vitals.

Replaced with a pure parser covering `::` compression, IPv4-mapped tails, brackets and zone ids.

> **Behaviour change:** any non-empty `%zone` suffix now validates, where `getByName` checked local interface names. Better for a text-field validator — validation shouldn't depend on which interfaces happen to exist — but it is a change.

## Lazy list keys

Added stable keys to the ping, ports, recent-hosts and Wi-Fi lists.

The Wi-Fi list needed a new `WifiNetwork.id`. Keying on `SSID + security` **would have crashed the list**: hidden networks all carry a blank SSID and are deliberately never grouped, so two of them produce identical keys, which Compose rejects. The new id falls back to BSSID for hidden networks, and also fixes a pre-existing bug where two hidden networks shared expand state.

Uniqueness verified for the others: ping sequences are monotonic in both repository paths, OPEN and non-OPEN port sets are disjoint, and `RecentHostsRepository.addRecent` dedupes.

## Play technical quality review

Reviewed against [the requirements page](https://support.google.com/googleplay/android-developer/answer/17492799). No violations found. Measured against the built release artifact rather than assumed:

| Requirement | Finding |
|---|---|
| 16 KB page size | Compliant — all 64-bit `.so` LOAD segments align to `0x4000`, stored uncompressed |
| 64-bit | Compliant (arm64-v8a, x86_64) |
| Code optimization | Does not bind — DEX is well under the exemption floor; R8 minify + resource shrink already enabled |
| Zero-tap sign-in | N/A — no auth surface, so Restore Credentials does not apply |
| Memory | p90 RSS not measurable locally. Continuous ping already uses a bounded rolling window; no other unbounded accumulation found |
| Crash rate | `CrashHandler` correctly delegates to the default handler, so crashes still reach Play vitals |

Play's numeric thresholds are deliberately **not** committed anywhere — they were retrieved via a summarizing fetch, and a wrong threshold in the repo would be worse than none.

## Coverage

Adds Kover. The `:app` report is deliberately scoped to pure, non-Compose logic: the module's ~17 Compose screens cannot be exercised by JVM unit tests, so a module-wide number would dilute the gate rather than enforce anything. CI now runs `koverVerify`.

New/extended tests: `RelayChainGeometry`, `WifiNetwork`, `WifiChannelInfo`, `WellKnownPorts`, `TopologyParamsValidator`, the IPv6 parser, and previously uncovered `HttpSecurityAnalyzer` branches (Referrer-Policy, Permissions-Policy, blank/empty header handling).

## Verification

All run serially — concurrent Gradle invocations on a memory-constrained host cause test-worker timeouts that masquerade as real failures, now noted in CLAUDE.md.

- `:core-network:test` + `:core-domain:test` — BUILD SUCCESSFUL
- `:app:test` — 213 tests, 0 failures
- `:app:koverVerify` — passes, and confirmed non-vacuous: `RelayChainGeometry` 18/18 branches and 10/10 lines, `ConnectorSegment` 12/12 instructions, both 100%
- `:app:assembleDebug` — BUILD SUCCESSFUL

## Note on scope

The original request mentioned "bounced changes". Nothing measured here is currently failing a Play requirement, so these may be adjacent improvements rather than the specific thing that bounced. Actual Play Console rejection text would confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015wDU64ak1oVS8zeHtdrVVr