### PR TITLE
fix: stop release changelog aborting when a section is empty

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -267,6 +267,10 @@ jobs:
               | sed -E 's/ \(#[0-9]+\)$//' \
               | sed 's/^/- /')
             [ -n "$commits" ] && { echo "### $1"; echo "$commits"; echo; }
+            # Never propagate a non-zero status: the step runs under `bash -e`,
+            # so an empty section would abort the script mid-heredoc and leave
+            # CHANGELOG_EOF unwritten ("Matching delimiter not found").
+            return 0
           }
 
           {
@@ -279,7 +283,7 @@ jobs:
               | sed -E 's/^[a-z]+(\([^)]*\))?!?: //' \
               | sed -E 's/ \(#[0-9]+\)$//' \
               | sed 's/^/- /')
-            [ -n "$OTHER" ] && { echo "### Other changes"; echo "$OTHER"; echo; }
+            [ -n "$OTHER" ] && { echo "### Other changes"; echo "$OTHER"; echo; } || true
             echo 'CHANGELOG_EOF'
           } >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Problem

Release run [33150800000](https://github.com/AieatAssam/android-network-tools/actions/runs/33150800000) failed with:

```
Invalid value. Matching delimiter not found 'CHANGELOG_EOF'
```

The build itself was entirely successful — tests passed, signed APK and AAB were produced, native debug symbols were packaged and uploaded. Only the *Create GitHub Release* step was skipped, so no release was published.

## Root cause

The changelog step writes a multi-line value to `$GITHUB_OUTPUT` using a `CHANGELOG_EOF` heredoc. Its `section()` helper ended with:

```bash
[ -n "$commits" ] && { echo "### $1"; echo "$commits"; echo; }
```

When a section matches no commits, the test fails — and being the last command in the function, it makes `section()` return 1. GitHub runs the step under `bash -e`, so the script aborted immediately: *after* `body<<CHANGELOG_EOF` was written, but *before* the closing delimiter.

This is latent and version-dependent. It fires for any release whose commit range has no `feat:` commits (or no `fix:` commits, or nothing outside those buckets). Run 33150800000 hit it because the range contained a single `fix:` commit, leaving the Features section empty. Previous releases happened to include a `feat:` commit and so never tripped it.

## Fix

Give `section()` an explicit `return 0`, and terminate the "Other changes" conditional with `|| true`.

## Verification

Replayed the step's exact script under `bash -e` over the failing commit range (`v2026.07.28.1..HEAD`):

**Before** — aborts after the opening delimiter:
```
body<<CHANGELOG_EOF
rc=1
```

**After** — both delimiters emitted, clean exit:
```
body<<CHANGELOG_EOF
### Fixes
- whois chain alignment, main-thread DNS in host validation, lazy list keys

CHANGELOG_EOF
rc=0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015wDU64ak1oVS8zeHtdrVVr