### PR TITLE
fix: replace deprecated edge-to-edge APIs and handle IME insets

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,6 +30,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
+            android:windowSoftInputMode="adjustResize"
             android:theme="@style/Theme.NetSwissKnife.Splash">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/MainActivity.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/MainActivity.kt
@@ -5,14 +5,17 @@ import net.aieat.netswissknife.app.BuildConfig
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.consumeWindowInsets
-import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.union
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.MoreHoriz
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarDefaults
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -85,15 +88,14 @@ fun NetSwissKnifeApp(navController: NavHostController) {
             AppBottomNavigationBar(
                 navController  = navController,
                 pinnedRoutes   = pinnedRoutes,
-                onMoreClick    = { showMoreSheet = true },
-                modifier       = Modifier.imePadding()
+                onMoreClick    = { showMoreSheet = true }
             )
         }
     ) { innerPadding ->
         AppNavHost(
             navController = navController,
-            // The bottom bar carries imePadding(), so innerPadding already
-            // accounts for the keyboard — do not add imePadding() again here.
+            // The bottom bar's window insets already include the IME, so
+            // innerPadding accounts for the keyboard — no imePadding() here.
             modifier      = Modifier
                 .padding(innerPadding)
                 .consumeWindowInsets(innerPadding)
@@ -138,8 +140,7 @@ fun NetSwissKnifeApp(navController: NavHostController) {
 private fun AppBottomNavigationBar(
     navController: NavHostController,
     pinnedRoutes: List<String>,
-    onMoreClick: () -> Unit,
-    modifier: Modifier = Modifier
+    onMoreClick: () -> Unit
 ) {
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = navBackStackEntry?.destination?.route
@@ -148,7 +149,11 @@ private fun AppBottomNavigationBar(
         NavRoutes.allTools.find { it.route == route }
     }
 
-    NavigationBar(modifier = modifier) {
+    // union() takes the larger inset per side, so the bar sits above the keyboard
+    // when it is open and above the navigation bar otherwise. Modifier.imePadding()
+    // would instead stack on top of the bar's own navigationBars inset and leave a
+    // navigation-bar-sized gap while the IME is showing.
+    NavigationBar(windowInsets = NavigationBarDefaults.windowInsets.union(WindowInsets.ime)) {
         // Home is always first
         NavigationBarItem(
             selected = currentRoute == NavRoutes.Home.route,

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/MainActivity.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/MainActivity.kt
@@ -4,8 +4,9 @@ import android.os.Bundle
 import net.aieat.netswissknife.app.BuildConfig
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Home
@@ -18,6 +19,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import androidx.core.view.WindowCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -42,7 +44,16 @@ import dagger.hilt.android.AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen()
-        enableEdgeToEdge()
+        // Draw behind the system bars on every supported API level.
+        //
+        // NOTE: do NOT use androidx.activity's enableEdgeToEdge() here. It calls
+        // Window.setStatusBarColor / setNavigationBarColor and sets
+        // LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES, all deprecated in Android 15,
+        // which Play Console flags as "deprecated APIs for edge-to-edge".
+        // setDecorFitsSystemWindows() is the non-deprecated equivalent; the
+        // transparent system bar colours needed below API 35 come from themes.xml,
+        // and the bar icon appearance is set in NetSwissKnifeTheme.
+        WindowCompat.setDecorFitsSystemWindows(window, false)
         super.onCreate(savedInstanceState)
         setContent {
             val settingsViewModel: SettingsViewModel = hiltViewModel()
@@ -74,13 +85,18 @@ fun NetSwissKnifeApp(navController: NavHostController) {
             AppBottomNavigationBar(
                 navController  = navController,
                 pinnedRoutes   = pinnedRoutes,
-                onMoreClick    = { showMoreSheet = true }
+                onMoreClick    = { showMoreSheet = true },
+                modifier       = Modifier.imePadding()
             )
         }
     ) { innerPadding ->
         AppNavHost(
             navController = navController,
-            modifier      = Modifier.padding(innerPadding)
+            // The bottom bar carries imePadding(), so innerPadding already
+            // accounts for the keyboard — do not add imePadding() again here.
+            modifier      = Modifier
+                .padding(innerPadding)
+                .consumeWindowInsets(innerPadding)
         )
     }
 
@@ -122,7 +138,8 @@ fun NetSwissKnifeApp(navController: NavHostController) {
 private fun AppBottomNavigationBar(
     navController: NavHostController,
     pinnedRoutes: List<String>,
-    onMoreClick: () -> Unit
+    onMoreClick: () -> Unit,
+    modifier: Modifier = Modifier
 ) {
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = navBackStackEntry?.destination?.route
@@ -131,7 +148,7 @@ private fun AppBottomNavigationBar(
         NavRoutes.allTools.find { it.route == route }
     }
 
-    NavigationBar {
+    NavigationBar(modifier = modifier) {
         // Home is always first
         NavigationBarItem(
             selected = currentRoute == NavRoutes.Home.route,

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/crash/CrashActivity.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/crash/CrashActivity.kt
@@ -7,7 +7,6 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.activity.enableEdgeToEdge
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.slideInVertically
@@ -53,6 +52,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
+import androidx.core.view.WindowCompat
 import androidx.compose.ui.unit.dp
 import net.aieat.netswissknife.app.MainActivity
 import net.aieat.netswissknife.app.R
@@ -62,7 +62,9 @@ import kotlinx.coroutines.launch
 class CrashActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        enableEdgeToEdge()
+        // See MainActivity: androidx.activity's enableEdgeToEdge() relies on APIs
+        // deprecated in Android 15. setDecorFitsSystemWindows() is the replacement.
+        WindowCompat.setDecorFitsSystemWindows(window, false)
         super.onCreate(savedInstanceState)
 
         val stackTrace = intent.getStringExtra(EXTRA_STACK_TRACE) ?: "No stack trace"

--- a/app/src/main/kotlin/net/aieat/netswissknife/app/ui/theme/Theme.kt
+++ b/app/src/main/kotlin/net/aieat/netswissknife/app/ui/theme/Theme.kt
@@ -60,8 +60,14 @@ fun NetSwissKnifeTheme(
     val view = LocalView.current
     if (!view.isInEditMode) {
         SideEffect {
-            val window = (view.context as Activity).window
-            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = !darkTheme
+            val window = (view.context as? Activity)?.window ?: return@SideEffect
+            // Set explicitly: the activities go edge-to-edge via
+            // WindowCompat.setDecorFitsSystemWindows(), which — unlike
+            // androidx.activity's enableEdgeToEdge() — does not manage bar icon
+            // colours for us. Without this the icons are illegible in one theme.
+            val controller = WindowCompat.getInsetsController(window, view)
+            controller.isAppearanceLightStatusBars = !darkTheme
+            controller.isAppearanceLightNavigationBars = !darkTheme
         }
     }
 

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -19,5 +19,12 @@
         <item name="windowSplashScreenBackground">@color/ic_launcher_background</item>
         <item name="windowSplashScreenAnimatedIcon">@mipmap/ic_launcher_foreground</item>
         <item name="postSplashScreenTheme">@style/Theme.NetSwissKnife</item>
+        <!-- Repeated from Theme.NetSwissKnife: this theme derives from
+             Theme.SplashScreen, not from Theme.NetSwissKnife, and it is the theme
+             MainActivity's window is created with. Relying on the
+             postSplashScreenTheme handover to land before the decor view reads
+             these attributes would leave opaque bars on API 26-34. -->
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
     </style>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,7 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Base app theme. The Compose theme is defined in Theme.kt -->
-    <style name="Theme.NetSwissKnife" parent="android:Theme.Material.NoActionBar" />
+    <!-- Transparent system bars so content drawn edge-to-edge is visible behind
+         them. Android 15 (API 35) makes the bars transparent and ignores these
+         attributes; they only matter on API 26-34, where the activities opt in
+         with WindowCompat.setDecorFitsSystemWindows(window, false).
+         Deliberately set here rather than through androidx.activity's
+         enableEdgeToEdge(), which uses APIs deprecated in Android 15. -->
+    <style name="Theme.NetSwissKnife" parent="android:Theme.Material.NoActionBar">
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+    </style>
 
     <!-- Cold-start splash theme (androidx.core:core-splashscreen).
          MainActivity calls installSplashScreen(); postSplashScreenTheme


### PR DESCRIPTION
Clears the two edge-to-edge actions Google Play raised against release `2026082801` (2026.08.28.1).

## What Play reported

1. **Edge-to-edge may not display for all users** — inset handling.
2. **Deprecated APIs or parameters for edge-to-edge**, naming `Window.setStatusBarColor`, `Window.setNavigationBarColor` and `LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES`, originating at `androidx.activity.EdgeToEdgeApi35.setUp` plus three obfuscated frames (`i90.b`, `k90.b`, `h1.k`).

## Root cause

`enableEdgeToEdge()` itself. Disassembling `activity-1.13.0.aar` (the version we are on) shows:

| Class | Deprecated reference |
|---|---|
| `EdgeToEdgeApi23` / `Api26` / `Api29` / `Api35` | `Window.setStatusBarColor`, `Window.setNavigationBarColor` |
| `EdgeToEdgeApi28` / `Api30` | `WindowManager.LayoutParams.layoutInDisplayCutoutMode` |

Those are exactly the three APIs Play named, and the four frames line up with the four `EdgeToEdgeApi*` variants R8 keeps. No newer release of `androidx.activity` avoids them, so a version bump does not help — the call has to go.

## Changes

**Deprecated APIs**

- `MainActivity` and `CrashActivity` replace `enableEdgeToEdge()` with `WindowCompat.setDecorFitsSystemWindows(window, false)`, which is not deprecated.
- The two things `enableEdgeToEdge()` also did are now explicit:
  - transparent system bar colours move to `themes.xml`, set on **both** `Theme.NetSwissKnife` and `Theme.NetSwissKnife.Splash`. The latter matters: it derives from `Theme.SplashScreen`, not from `Theme.NetSwissKnife`, and it is the theme `MainActivity`'s window is actually created with. Relying on the `postSplashScreenTheme` handover to land before the decor view reads those attributes would risk opaque bars on API 26–34. They only matter there; API 35+ makes the bars transparent and ignores the attributes.
  - `NetSwissKnifeTheme` sets `isAppearanceLightNavigationBars` alongside the existing `isAppearanceLightStatusBars`, so bar icons stay legible in both themes.
- The display-cutout mode is **not** reinstated in any form — `SHORT_EDGES` is named in the report.

**Inset handling**

Previously no screen handled IME insets at all, so the keyboard covered the input on all eleven text-field screens.

- `MainActivity` declares `android:windowSoftInputMode="adjustResize"` (it had none).
- The bottom bar uses `NavigationBarDefaults.windowInsets.union(WindowInsets.ime)`. `union()` takes the larger inset per side, so the bar sits above the keyboard when it is open and above the navigation bar otherwise. `Modifier.imePadding()` would instead stack on top of `NavigationBar`'s own `navigationBars` inset — the two are applied at different points in the modifier chain and neither consumes the other — leaving a navigation-bar-sized gap while the IME is showing.
- `AppNavHost` consumes the `Scaffold`'s `innerPadding`, which therefore already accounts for the IME via the bar's height.

**Incidental**

- `Theme.kt`'s `view.context as Activity` becomes `as? Activity ?: return@SideEffect`. The same theme renders inside `CrashActivity`, where a `ClassCastException` would be unrecoverable.

## Verification

Static scan of the **minified release DEX** — this is what Play analyses, and neither the unit tests nor a debug build exercise it. Run against the final commit:

| Symbol in `classes.dex` | Before | After |
|---|---|---|
| `setStatusBarColor` | present | **absent** |
| `setNavigationBarColor` | present | **absent** |
| `layoutInDisplayCutoutMode` | present | **absent** |
| `setDecorFitsSystemWindows` | — | present |

`./gradlew :app:assembleRelease` and `:app:assembleDebug` both succeed; CI is green on both commits.

**Not verified on-device.** The inset and bar-transparency behaviour on API 26–34 is reasoned from the theme/inset semantics, not observed. The local emulator cannot start — `/dev/kvm` is present but the emulator reports no permission to use it, and it refuses to fall back to TCG for x86_64. Worth a manual look on an API 30-ish device before or shortly after rollout.

## Known limitation

`androidx.core.splashscreen`'s `SplashScreen$Impl31.applyAppSystemUiTheme` also references `setStatusBarColor` / `setNavigationBarColor`. In this build R8 strips it — the after-scan is clean — but that is a shrinker outcome, not a guarantee. Clearing it deterministically would mean dropping `core-splashscreen` and losing the splash screen on API 26–30, a feature regression well outside the scope of this fix, so it is deliberately left alone. If Play still flags a splashscreen frame on the next release, that is the reason.

## Pre-existing test failure

`DnsViewModelTest$PresetSelection` fails locally with `TimeoutException: setUp() timed out after 10 seconds`. It reproduces identically on `main` at `f11213f` with no changes applied, and `main`'s CI at that commit is green — MockK initialisation exceeding the 10s limit on this memory-constrained host. Unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JVgFqwqFXwGczPPeQiwz6y